### PR TITLE
LX Relayouts: preserve the committed physical view through scheduling

### DIFF
--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -2061,73 +2061,22 @@ emitted by `codegen_kernel()`.  When it encounters a `LoopSpec` it
 emits SDSC JSON files for each `OpSpec` in the body (recursively) and
 wraps those executions in an `scf.for` in `bundle.mlir`.
 
-### Changes to `SuperDSCScheduling.codegen_node()`
+### Preparing and emitting counted-loop kernels
 
-`codegen_node` already handles `FusedSchedulerNode | SchedulerNode`.
-`CountedLoopSchedulerNode` is recognized by an `isinstance` check:
-
-```python
-def codegen_node(
-    self,
-    node: Union[FusedSchedulerNode, SchedulerNode, CountedLoopSchedulerNode],
-) -> None:
-    if isinstance(node, CountedLoopSchedulerNode):
-        self._codegen_counted_loop(node)
-        return
-    # existing flat-list path unchanged
-    ...
-
-def _codegen_counted_loop(self, node: CountedLoopSchedulerNode) -> None:
-    inner_nodes = [
-        n for n in node.get_nodes()
-        if n.get_name() not in self.scheduler.removed_ops
-    ]
-    kernel = SpyreKernel()
-    all_schedule_nodes = []
-    with kernel:
-        for inner in inner_nodes:
-            if isinstance(inner, CountedLoopSchedulerNode):
-                self._codegen_loop_body(inner, kernel, all_schedule_nodes)
-            else:
-                sched = self.generate_node_schedule([inner])
-                all_schedule_nodes.extend(sched)
-                for snode in sched:
-                    var_ranges = iteration_space(snode)
-                    vs = list(var_ranges.keys())
-                    index_vars = [vs[:len(snode._body.iter_vars)],
-                                  vs[len(snode._body.iter_vars):]]
-                    snode.codegen(index_vars)
-
-    # Compute tiled symbols for depth 0 from any leaf SchedulerNode.
-    outer_tiled_syms = []
-    for inner in inner_nodes:
-        ref = _find_leaf_sched_node(inner)
-        if ref is not None:
-            outer_tiled_syms = _tiled_syms_for_sched_node_at_depth(ref, 0)
-            break
-
-    # Wrap the collected inner specs in a LoopSpec
-    kernel.wrap_op_specs_in_loop(node.loop_count)
-
-    with V.set_kernel_handler(kernel):
-        src_code = kernel.codegen_kernel()
-    kernel_name = self.define_kernel(src_code, all_schedule_nodes, kernel)
-    ...
-```
-
-`_codegen_loop_body` handles nested `CountedLoopSchedulerNode`s: it
-codegens the body ops into the existing kernel, then wraps only the newly
-added `op_specs` entries in an inner `LoopSpec`.  The outer
-`_codegen_counted_loop` then wraps everything in the outer `LoopSpec` via
-`wrap_op_specs_in_loop`.
+`prepare_kernel` handles both ordinary bundles and `CountedLoopSchedulerNode`s
+before HBM-pool planning. `_codegen_into_kernel` runs leaf operations through the
+existing handlers; `_codegen_loop_body` recursively adds nested loops to the same
+kernel, wrapping only their newly added `op_specs` entries in an inner `LoopSpec`.
+For the outer counted loop, `prepare_kernel` calls `wrap_op_specs_in_loop` once.
 
 `SpyreKernel.wrap_op_specs_in_loop(count)` replaces the flat `self.op_specs`
 list with `[LoopSpec(count=count, body=self.op_specs)]`.
+`generate_node_schedule` flattens any fused nodes inside the loop group into
+leaf `SchedulerNode`s.
 
-`generate_node_schedule` handles `FusedSchedulerNode`s that may appear
-among the inner nodes (e.g. from earlier passes that fused nodes within
-the same loop group) by flattening them into their constituent
-`SchedulerNode`s.
+`codegen_node` consumes this same prepared kernel. It does not rebuild the loop
+body: it binds the final HBM pool size, addresses, and argument list, then emits
+one SuperDSC bundle for the entire `LoopSpec` tree.
 
 ### Serialization in `codegen_kernel()`
 
@@ -2258,7 +2207,7 @@ landed.
 | `torch_spyre/_inductor/wsr/coarse_tile_hints.py` | `reorder_unhinted_interlopers()` reorders interlopers before grouping |
 | `torch_spyre/_inductor/wsr/coarse_tile.py` | Layer 1: `coarse_tile()` stamps `loop_info` and rewrites ranges; `_plan_tiling_propagation` plus the `_insert_all_read_copy_ops`/`_insert_all_reduction_ops`/`_insert_all_write_copy_ops` passes handle the data perimeter |
 | `torch_spyre/_inductor/insert_restickify.py` | `finalize_layouts` commits each op's chosen `FixedTiledLayout` and, for a tiled-reduction op, propagates that layout onto `accum_full` so fill/combine/copy all agree on device coordinates; also stamps a restickify node's `loop_info` from the op it feeds so the node lands in the same loop group |
-| `torch_spyre/_inductor/scheduler.py` | Layer 2: `CountedLoopSchedulerNode`, `build_loop_scheduler_nodes`, `_codegen_counted_loop`, `_regroup_by_outer_loop_key` |
+| `torch_spyre/_inductor/scheduler.py` | Layer 2: `CountedLoopSchedulerNode`, `build_loop_scheduler_nodes`, `prepare_kernel`, `_codegen_loop_body`, `_regroup_by_outer_loop_key` |
 | `torch_spyre/_inductor/op_spec.py` | Layer 3: `LoopSpec` and `OpSpec` dataclasses |
 | `torch_spyre/_inductor/spyre_kernel.py` | Layer 3: serializes `LoopSpec` tree in `codegen_kernel()`; `wrap_op_specs_in_loop()` |
 | `torch_spyre/_inductor/codegen/bundle.py` | Layer 3: emits `scf.for` wrapping `affine.apply`/`sdsc_execute` in `bundle.mlir` |

--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -99,9 +99,10 @@ CustomPreSchedulingPasses:
 ... Inductor scheduler construction ...
 
 CustomPostFusionPasses:
-  demote_incoherent_lx_buffers         # LX fixups (phase 2)
   spyre_fuse_nodes                     # Determine bundle boundaries
+  prepare_spyre_kernels                # Prepare each bundle's kernel once; demote LX on failure
   hbm_pool_planning                    # Per-bundle HBM pool allocation (this pass)
+  verify_carried_reduction_ownership   # Check required carried-reduction stages
 ```
 
 By the time this pass runs, `nodes` is the final, post-fusion top-level list.

--- a/docs/source/compiler/inductor_frontend.md
+++ b/docs/source/compiler/inductor_frontend.md
@@ -44,8 +44,8 @@ points, all registered in
 | `CustomPreGradPasses` | Pre-grad FX graph | Reserved for graph rewrites before autograd partitioning. The pipeline is empty today. |
 | `CustomPrePasses` | Post-grad FX graph (early) | `collect_spyre_hints` snapshots `spyre_hint` annotations so they survive AOT re-tracing. |
 | `CustomPostPasses` | Post-grad FX graph (late) | Late post-grad rewrites: `decompose_addmm`, `mm_to_bmm_pass`, `bmm_unflatten_pass`. (`recover_spyre_hints` runs separately, via a `GraphLowering` monkey-patch in `patches.py`.) |
-| `CustomPreFusionPasses` | LoopLevelIR (pre-fusion) | Pre-fusion scheduler passes: `propagate_mutation_layouts`, `align_lx_producer_loop_order`, `build_loop_scheduler_nodes`. |
-| `CustomPostFusionPasses` | LoopLevelIR (post-fusion) | Post-fusion scheduler passes: `demote_incoherent_lx_buffers`, `spyre_fuse_nodes`, `hbm_pool_planning`, `verify_carried_reduction_ownership`. |
+| `CustomPreFusionPasses` | LoopLevelIR (pre-fusion) | Pre-fusion scheduler passes: `propagate_mutation_layouts`, `build_loop_scheduler_nodes`. |
+| `CustomPostFusionPasses` | LoopLevelIR (post-fusion) | Post-fusion scheduler passes: `spyre_fuse_nodes`, `prepare_spyre_kernels`, `hbm_pool_planning`, `verify_carried_reduction_ownership`. Each bundle's kernel is prepared once, with the real finalization, while HBM fallback is still available; emission binds only what pooling decided. The final pass checks the carried-reduction stages after placement is complete. |
 | `CustomPreSchedulingPasses` | LoopLevelIR (pre-scheduler) | The pre-scheduling pipeline that runs immediately before the Scheduler is constructed (wired in via a `GraphLowering._update_scheduler` monkey-patch in [`patches.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/patches.py)). The full step list is in [LoopLevelIR Passes](#looplevelir-passes) below. |
 
 ### FX Graph Passes

--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -337,6 +337,7 @@ The checks, in evaluation order (the first failure is the reason reported):
 |---|---|
 | `op not allowed` | not a `ComputedBuffer`, a mutation layout, or an op name inside `OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE` (the debug flag `config.allow_all_ops_in_lx_planning` bypasses the op-name gate) |
 | `unsized (no device layout)` | no computable footprint (e.g. a `MultiOutputLayout` tuple op) |
+| `empty tensor` | A zero-sized tensor needs no LX reservation |
 | `mutation target` | filled by offset writes, so one LX base mis-addresses it |
 | `tiled (advancing)` | LX addresses cannot be `affine.apply` symbols; the advancing-tile check reads `loop_info` (the sole source of truth for per-tile geometry) |
 | `read by restickify (cross-frame barrier)` | the read and write frames are transposes, so a per-core LX slice is not self-sufficient (the buffer a restickify reads; its own output is safe and is not barred) |

--- a/tests/configs/torch_spyre_tests/inductor/test_kernel_preparation_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_kernel_preparation_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_kernel_preparation.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -8124,17 +8124,19 @@ class TestTileHelpers(unittest.TestCase):
 
 class TestCustomPostFusionPassesOrder(unittest.TestCase):
     def test_hbm_pool_planning_runs_after_fusion(self):
-        """hbm_pool_planning must see post-fusion bundles, not pre-fusion nodes."""
+        """Kernels are prepared before HBM placement and stage validation."""
         from torch_spyre._inductor.passes import CustomPostFusionPasses
-        from torch_spyre._inductor.fusion import spyre_fuse_nodes
-        from torch_spyre._inductor.hbm_pool_planning import hbm_pool_planning
 
         pipeline = CustomPostFusionPasses()
         names = [p.__name__ for p in pipeline.passes]
-        self.assertLess(
-            names.index(spyre_fuse_nodes.__name__),
-            names.index(hbm_pool_planning.__name__),
-            "spyre_fuse_nodes must run before hbm_pool_planning",
+        self.assertEqual(
+            names,
+            [
+                "spyre_fuse_nodes",
+                "prepare_spyre_kernels",
+                "hbm_pool_planning",
+                "verify_carried_reduction_ownership",
+            ],
         )
 
 

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -795,6 +795,14 @@ def _prepare_compound_axis_view(iter_space, index, repeat_info=None):
     return prep, graph
 
 
+def test_direct_axis_proof_budget_boundary():
+    prove = core_mapping_module.direct_axis_ownership_failure
+    point = core_mapping_module._LOOP_POINT
+    assert prove(65536, 1, point, 65536, 1) is None
+    assert prove(65537, 1, point, 65537, 1).startswith("proof limit:")
+    assert prove(8, 2, sympy.Mod(point, 4), 8, 2).startswith("ownership mismatch:")
+
+
 def test_prepare_per_core_view_does_not_record_repeat_info():
     head, flat = sympy.symbols("head flat", integer=True, nonnegative=True)
     prior = sympy.Symbol("prior")

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -621,7 +621,9 @@ def test_planner_and_sdsc_use_the_same_mapping(
         ownership, num_cores=None
     ).physical_core_count == math.prod(dim_splits)
     prep = _view_prep(
-        iter_space={dim: extent for dim, (extent, _) in op_spec.iteration_space.items()},
+        iter_space={
+            dim: extent for dim, (extent, _) in op_spec.iteration_space.items()
+        },
         write_index=dims[0],
         dep_coeff={dims[0]: 1, dims[1]: 2, dims[2]: 0},
         dep_device_coordinates=(dims[0], dims[1]),

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import dataclasses
+from functools import partial
 import math
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 import sympy
@@ -23,6 +24,7 @@ import sympy
 import torch_spyre._inductor.codegen.superdsc as superdsc_module
 import torch_spyre._inductor.core_mapping as core_mapping_module
 import torch_spyre._inductor.pass_utils as pass_utils_module
+import torch_spyre._inductor.spyre_kernel as spyre_kernel_module
 from torch_spyre._C import DataFormats, ElementArrangement
 from torch_spyre._inductor.codegen.superdsc import parse_op_spec
 from torch_spyre._inductor.constants import (
@@ -33,65 +35,48 @@ from torch_spyre._inductor.core_mapping import (
     core_mappings_equal,
     core_to_slice_mapping,
     derive_core_mapping,
-    derive_operation_mapping,
     derive_partition_mapping,
+    derive_operation_mapping,
     finalize_tensor_work_divisions,
-    remap_work_division,
+    select_unique_partition_division,
 )
 from torch_spyre._inductor.op_spec import (
     OpSpec,
     TensorArg,
     TensorWorkDivision,
-    is_lx_relayout_identity,
+    LX_RELAYOUT_INFO_KEY,
 )
 from torch_spyre._inductor.pass_utils import PerCoreView, per_core_views_equal
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 from torch_spyre._inductor.views import (
     align_tensors,
-    align_tensors_pure,
+)
+
+
+_CORE_ID = sympy.Symbol("core_id")
+_FUSED = sympy.Symbol("fused")
+
+# Literal defaults only: each case supplies its coordinates, strides and owners.
+_view_prep = partial(
+    pass_utils_module._ViewPrep,
+    elems_per_stick=64,
+    stick_host_stride=None,
+    num_stick_dim=None,
+    num_stick=0,
+    num_stick_stride=0,
+    is_matmul=False,
 )
 
 
 def _coordinates(splits, num_cores, **kwargs):
     dims = sympy.symbols(f"dim_0:{len(splits)}")
     mapping = core_to_slice_mapping(dims, splits, num_cores, **kwargs)
-    core_id = sympy.Symbol("core_id")
-    return [
-        tuple(int(mapping[dim].subs(core_id, core)) for dim in dims)
-        for core in range(num_cores)
-    ]
+    return _mapping_coordinates(mapping, dims, num_cores)
 
 
-_CORE_ID = sympy.Symbol("core_id")
-
-
-def test_owner_maps_compare_physical_owners_not_sympy_spelling():
-    """Equivalent spellings compare equal; unsplit dimensions describe nothing."""
-
-    head, local = sympy.symbols("head local")
-    same = _CORE_ID - 4 * sympy.floor(_CORE_ID / 4)
-    reordered = sympy.floor(_CORE_ID / 2)
-    left = TensorWorkDivision(
-        {head: 4, local: 1}, {head: sympy.Mod(_CORE_ID, 4), local: sympy.S.Zero}
-    )
-    equivalent = TensorWorkDivision({head: 4}, {head: same}, num_cores=4)
-
-    assert left.physical_core_count == 4
-    assert left != equivalent and left.same_ownership(equivalent)
-    assert not left.same_ownership(
-        TensorWorkDivision({head: 4}, {head: reordered}, num_cores=4)
-    )
-
-    view = PerCoreView(((0, 4),), ((0, sympy.Mod(_CORE_ID, 4)),), num_cores=8)
-    equivalent_view = PerCoreView(
-        ((0, 4), (1, 1)), ((0, same), (1, sympy.S.Zero)), num_cores=8
-    )
-    assert view != equivalent_view and view.same_partition(equivalent_view)
-    assert per_core_views_equal(view, equivalent_view)
-    assert per_core_views_equal(None, None)
-    assert not view.same_partition(
-        PerCoreView(((0, 4),), ((0, reordered),), num_cores=8)
-    )
+def test_default_mapping_preserves_existing_core_order():
+    one_grid = [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (1, 2)]
+    assert _coordinates((2, 3), 12) == one_grid * 2
 
 
 @pytest.mark.parametrize("slot", [sympy.Rational(1, 2), sympy.Symbol("unresolved")])
@@ -147,9 +132,17 @@ def test_owner_evaluation_keeps_short_circuit_order():
     )
 
 
-def test_default_mapping_preserves_existing_core_order():
-    one_grid = [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (1, 2)]
-    assert _coordinates((2, 3), 12) == one_grid * 2
+def test_kernel_rejects_lx_allocation_without_physical_ownership():
+    """The fault is a placement rejection: preparation demotes and retries."""
+
+    kernel = spyre_kernel_module.SpyreKernel.__new__(spyre_kernel_module.SpyreKernel)
+    kernel.current_node = SimpleNamespace(node=object())
+    tensor = SimpleNamespace(layout=SimpleNamespace(allocation={"lx": 0}, lx_view=None))
+    with (
+        mock.patch.object(spyre_kernel_module, "iteration_space", return_value={}),
+        pytest.raises(ValueError, match="missing_view has no physical ownership"),
+    ):
+        kernel.create_tensor_arg(False, "missing_view", tensor)
 
 
 @pytest.mark.parametrize("contiguous_dim", [0, 1, 2])
@@ -217,12 +210,65 @@ def test_late_mapping_derives_contiguous_broadcast_groups():
     assert coordinates == [(core % 16, core // 16) for core in range(32)]
 
 
+def test_ambiguous_canonical_owner_orders_are_rejected():
+    first, second = sympy.symbols("first second")
+    reasons = []
+    assert (
+        select_unique_partition_division(
+            (first, second),
+            {first: 2, second: 2},
+            4,
+            lambda _: True,
+            rejection_reasons=reasons,
+        )
+        is None
+    )
+    assert reasons == ["ambiguous ownership: multiple canonical maps matched"]
+
+
 def test_late_partition_mapping_repeats_contiguous_owners():
     head = sympy.Symbol("head")
     mapping = derive_partition_mapping((head,), (4,), 32)
     assert _mapping_coordinates(mapping, (head,), 32) == [
         (core // 8,) for core in range(32)
     ]
+
+
+@pytest.mark.parametrize(
+    ("coords", "extent", "split", "sizes"),
+    [
+        ((_FUSED, _FUSED), 4, 2, (4, 4)),
+        ((3 - _FUSED,), 4, 2, (4,)),
+        ((sympy.floor((_FUSED + 1) / 4),), 6, 2, (2,)),
+        ((2 * _FUSED,), 4, 2, (8,)),
+        ((sympy.Mod(_FUSED + 6, 8),), 4, 2, (8,)),
+        ((sympy.floor(_FUSED / 98), sympy.Mod(_FUSED, 98)), 196, 2, (2, 98)),
+    ],
+)
+def test_index_regions_match_exact_points(coords, extent, split, sizes):
+    coordinates = tuple(
+        c.xreplace({_FUSED: core_mapping_module._LOOP_POINT}) for c in coords
+    )
+    bounds, full = [], True
+    width = extent // split
+    for part in range(split):
+        points = {
+            tuple(c.subs(_FUSED, p) for c in coords)
+            for p in range(part * width, (part + 1) * width)
+        }
+        region = tuple(zip(map(min, zip(*points)), map(max, zip(*points))))
+        bounds.append(region)
+        full &= len(points) == width == math.prod(hi - lo + 1 for lo, hi in region)
+    for rectangles in (False, True):
+        if rectangles and not full:
+            with pytest.raises(ValueError):
+                core_mapping_module._loop_regions(
+                    extent, coordinates, sizes, split, True
+                )
+        else:
+            assert core_mapping_module._loop_regions(
+                extent, coordinates, sizes, split, rectangles
+            ) == tuple(bounds)
 
 
 def test_late_mapping_keeps_shared_destination_after_one_consumer_factors():
@@ -262,78 +308,33 @@ def test_group_topology_does_not_follow_final_loop_reordering():
     )
 
 
-def test_remap_work_division_accepts_equivalent_merged_owner_slots():
-    first, second, merged = sympy.symbols("first second merged")
-    core_id = sympy.Symbol("core_id")
-    division = TensorWorkDivision(
-        {first: 4, second: 4},
-        {
-            first: sympy.Mod(core_id, 4),
-            second: core_id - 4 * sympy.floor(core_id / 4),
-        },
-        num_cores=8,
+def test_owner_maps_compare_physical_owners_not_sympy_spelling():
+    """Equivalent spellings compare equal; unsplit dimensions describe nothing."""
+
+    head, local = sympy.symbols("head local")
+    same = _CORE_ID - 4 * sympy.floor(_CORE_ID / 4)
+    reordered = sympy.floor(_CORE_ID / 2)
+    left = TensorWorkDivision(
+        {head: 4, local: 1}, {head: sympy.Mod(_CORE_ID, 4), local: sympy.S.Zero}
+    )
+    equivalent = TensorWorkDivision({head: 4}, {head: same}, num_cores=4)
+
+    assert left.physical_core_count == 4
+    assert left != equivalent and left.same_ownership(equivalent)
+    assert not left.same_ownership(
+        TensorWorkDivision({head: 4}, {head: reordered}, num_cores=4)
     )
 
-    remapped = remap_work_division(
-        division,
-        {first: ((merged, 4),), second: ((merged, 4),)},
+    view = PerCoreView(((0, 4),), ((0, sympy.Mod(_CORE_ID, 4)),), num_cores=8)
+    equivalent_view = PerCoreView(
+        ((0, 4), (1, 1)), ((0, same), (1, sympy.S.Zero)), num_cores=8
     )
-
-    assert remapped.physical_core_count == 8
-    assert remapped.work_slices == {merged: 4}
-    assert core_mappings_equal(
-        {merged: remapped.core_id_to_work_slice[merged]},
-        {merged: sympy.Mod(core_id, 4)},
-        8,
+    assert view != equivalent_view and view.same_partition(equivalent_view)
+    assert per_core_views_equal(view, equivalent_view)
+    assert per_core_views_equal(None, None)
+    assert not view.same_partition(
+        PerCoreView(((0, 4),), ((0, reordered),), num_cores=8)
     )
-
-
-def test_remap_work_division_rejects_conflicting_merged_owner_slots():
-    first, second, merged = sympy.symbols("first second merged")
-    core_id = sympy.Symbol("core_id")
-    division = TensorWorkDivision(
-        {first: 4, second: 4},
-        {
-            first: sympy.Mod(core_id, 4),
-            second: sympy.floor(core_id / 2),
-        },
-        num_cores=8,
-    )
-
-    with pytest.raises(ValueError, match="conflicting normalized ownership"):
-        remap_work_division(
-            division,
-            {first: ((merged, 4),), second: ((merged, 4),)},
-        )
-
-
-def test_identity_with_equivalent_owner_spelling_is_not_a_relayout():
-    head = sympy.Symbol("head")
-    core_id = sympy.Symbol("core_id")
-    base = TensorArg(
-        True,
-        0,
-        DataFormats.SEN169_FP16,
-        [4, 64],
-        [head, head],
-        {"lx": 0},
-        work_division=TensorWorkDivision(
-            {head: 4},
-            {head: sympy.Mod(core_id, 4)},
-            num_cores=4,
-        ),
-    )
-    destination = dataclasses.replace(
-        base,
-        is_input=False,
-        work_division=TensorWorkDivision(
-            {head: 4},
-            {head: core_id - 4 * sympy.floor(core_id / 4)},
-            num_cores=4,
-        ),
-    )
-
-    assert not is_lx_relayout_identity("identity", (base, destination))
 
 
 def test_late_mapping_rejects_geometry_that_does_not_fill_groups():
@@ -347,33 +348,14 @@ def test_late_mapping_rejects_geometry_that_does_not_fill_groups():
         )
 
 
-def test_final_tensor_ownership_is_derived_from_aligned_buffer_geometry():
-    extra, shared = sympy.symbols("extra shared")
-    core_id = sympy.Symbol("core_id")
-    division = TensorWorkDivision(
-        {shared: 2},
-        # Planning-time placement is working data, not the final assignment.
-        {shared: sympy.Mod(core_id, 2)},
-        num_cores=4,
-    )
-
-    (finalized,) = finalize_tensor_work_divisions(
-        {extra: (8, 2), shared: (8, 2)},
-        [division],
-    )
-
-    assert finalized == TensorWorkDivision(
-        {shared: 2},
-        {shared: sympy.Mod(sympy.floor(core_id / 2), 2)},
-        num_cores=4,
-    )
-
-
 def test_shared_lx_buffer_keeps_owners_across_different_operation_dims():
     producer_extra, producer_shared = sympy.symbols("producer_extra producer_shared")
     consumer_shared, consumer_extra = sympy.symbols("consumer_shared consumer_extra")
     core_id = sympy.Symbol("core_id")
-    owners = sympy.Mod(core_id, 2)
+    # The shared tensor owns contiguous two-core groups. That one physical
+    # order remains valid when producer and consumer spell their loops in a
+    # different order.
+    owners = sympy.floor(core_id / 2)
     producer_division = finalize_tensor_work_divisions(
         {producer_extra: (8, 2), producer_shared: (8, 2)},
         [
@@ -413,20 +395,18 @@ def test_shared_lx_buffer_keeps_owners_across_different_operation_dims():
     )
 
 
-def test_final_tensor_ownership_requires_a_buffer_core_domain():
-    shared = sympy.Symbol("shared")
+def test_operation_mapping_preserves_a_satisfying_default_map():
+    batch, head = sympy.symbols("batch head")
     core_id = sympy.Symbol("core_id")
+    iteration_space = {batch: (8, 2), head: (16, 4)}
+    default = derive_core_mapping((batch, head), (2, 4), 8)
+    division = TensorWorkDivision(
+        {head: 4},
+        {head: sympy.Mod(sympy.floor(core_id / 2), 4)},
+        num_cores=8,
+    )
 
-    with pytest.raises(ValueError, match="physical core domain"):
-        finalize_tensor_work_divisions(
-            {shared: (8, 2)},
-            [
-                TensorWorkDivision(
-                    {shared: 2},
-                    {shared: sympy.Mod(core_id, 2)},
-                )
-            ],
-        )
+    assert derive_operation_mapping(iteration_space, [division]) == default
 
 
 def test_operation_mapping_rejects_conflicting_lx_tensor_owners():
@@ -449,28 +429,6 @@ def test_operation_mapping_rejects_conflicting_lx_tensor_owners():
         derive_operation_mapping(
             {shared: (8, 2), extra: (8, 2)},
             divisions,
-        )
-
-
-def test_operation_mapping_bounds_aligned_owner_dimension_permutations():
-    dims = sympy.symbols("d0:6")
-    core_id = sympy.Symbol("core_id")
-    division = TensorWorkDivision(
-        {dim: 2 for dim in dims},
-        {
-            dim: sympy.Mod(sympy.floor(core_id / (2**index)), 2)
-            for index, dim in enumerate(dims)
-        },
-        num_cores=64,
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="too many aligned tensor-owned dimensions.*6 > 5",
-    ):
-        derive_operation_mapping(
-            {dim: (sympy.Integer(2), 2) for dim in dims},
-            [division],
         )
 
 
@@ -502,44 +460,71 @@ def test_alignment_preview_is_repeatable_and_does_not_consume_repeat_info():
     assert preview == codegen
 
 
-def test_captured_alignment_inputs_leave_codegen_unchanged(monkeypatch):
-    dim = sympy.Symbol("dim")
-    op_spec = OpSpec(
-        "identity",
-        False,
-        {dim: (sympy.Integer(4), 2)},
-        [
-            TensorArg(
-                True,
-                0,
-                DataFormats.SEN169_FP16,
-                [2, 64],
-                [sympy.floor(dim / 2), dim],
-                {"hbm": 0},
-            )
-        ],
-        {},
-    )
-    monkeypatch.setattr(
-        pass_utils_module,
-        "alignment_coordinates",
-        lambda *args, **kwargs: [sympy.floor(dim / 2), dim],
-    )
-    captured = pass_utils_module.build_operation_alignment_inputs(
-        {dim: sympy.Integer(4)},
-        [pass_utils_module.AlignmentAccess(SimpleNamespace(device_size=[2, 64]), dim)],
-        aligned_iteration_space=op_spec.iteration_space,
-    )
-    # A preceding validation preview must neither consume nor change the input
-    # subsequently used by codegen.
-    align_tensors_pure(captured)
+def _lx_op_spec(op, iteration_space, tensors, divisions, *, certified=False):
+    """An operation on LX-resident operands, before alignment.
 
-    captured_path = copy.deepcopy(op_spec)
-    ordinary_path = copy.deepcopy(op_spec)
-    simplify_op_spec(captured_path, alignment_inputs=captured)
-    simplify_op_spec(ordinary_path)
+    ``certified`` marks it as a planner-certified relayout identity.
+    """
 
-    assert captured_path == ordinary_path
+    args = [
+        TensorArg(
+            index + 1 < len(tensors),
+            index,
+            DataFormats.SEN169_FP16,
+            list(tensor["size"]),
+            list(tensor["coordinates"]),
+            {"lx": 0},
+            work_division=division,
+        )
+        for index, (tensor, division) in enumerate(zip(tensors, divisions))
+    ]
+    op_info = {LX_RELAYOUT_INFO_KEY: True} if certified else {}
+    return OpSpec(op, False, dict(iteration_space), args, op_info)
+
+
+def test_relayouts_are_finished_on_the_operation_split_space():
+    """Ownership is settled on the operation's committed split space.
+
+    An ordinary operation keeps its owners; a certified relayout keeps the
+    destination's owners, also across core domains; coinciding divisions,
+    domains that do not divide the execution domain and splits beyond the
+    aligned extent are rejected.
+    """
+
+    head = sympy.Symbol("head")
+    space = {head: (sympy.Integer(2), 2)}
+    tensor = {"size": [2, 64], "coordinates": [head, sympy.S.Zero]}
+
+    def division(split, slot, num_cores):
+        return TensorWorkDivision({head: split}, {head: slot}, num_cores=num_cores)
+
+    source = division(2, sympy.Mod(_CORE_ID, 2), 2)
+    wide = division(2, sympy.floor(_CORE_ID / 16), 32)
+
+    ordinary = _lx_op_spec("add", space, [tensor, tensor], (source, source))
+    simplify_op_spec(ordinary)
+    assert core_mappings_equal(
+        {head: ordinary.core_id_to_work_slice[head]}, source.core_id_to_work_slice, 2
+    )
+
+    def finish(source, destination):
+        op_spec = _lx_op_spec(
+            "identity", space, [tensor, tensor], (source, destination), certified=True
+        )
+        simplify_op_spec(op_spec)
+        return op_spec
+
+    relayout = finish(source, wide)
+    assert set(relayout.core_id_to_work_slice) == set(relayout.iteration_space)
+    assert core_mappings_equal(
+        relayout.core_id_to_work_slice, wide.core_id_to_work_slice, 32
+    )
+    with pytest.raises(ValueError, match="ownership collapsed"):
+        finish(source, division(2, _CORE_ID - 2 * sympy.floor(_CORE_ID / 2), 2))
+    with pytest.raises(ValueError, match="core domains must divide"):
+        finish(division(3, sympy.Mod(_CORE_ID, 3), 3), wide)
+    with pytest.raises(ValueError, match="split exceeds its aligned extent"):
+        finish(source, division(4, sympy.Mod(_CORE_ID, 4), 32))
 
 
 def _bmm_op_spec(op: str) -> OpSpec:
@@ -635,24 +620,18 @@ def test_planner_and_sdsc_use_the_same_mapping(
     assert dataclasses.replace(
         ownership, num_cores=None
     ).physical_core_count == math.prod(dim_splits)
-    prep = pass_utils_module._ViewPrep(
-        iter_space=op_spec.iteration_space,
+    prep = _view_prep(
+        iter_space={dim: extent for dim, (extent, _) in op_spec.iteration_space.items()},
         write_index=dims[0],
-        read_index=dims[-1],
         dep_coeff={dims[0]: 1, dims[1]: 2, dims[2]: 0},
         dep_device_coordinates=(dims[0], dims[1]),
         device_size=[2, 4],
         stride_map=[1, 2],
-        elems_per_stick=64,
         device_stride_to_dim={1: 0, 2: 1},
-        stick_host_stride=None,
-        num_stick_dim=None,
-        num_stick=0,
-        num_stick_stride=0,
         is_matmul=pass_utils_module._is_matmul_op(FakeComputedBuffer(op)),
     )
     planner_view, partial, representable = pass_utils_module._per_core_view_from_prep(
-        prep, ownership.work_slices, {dims[2]: dim_splits[2]}
+        prep, ownership.work_slices, {dims[2]: dim_splits[2]}, ownership=ownership
     )
 
     op_spec.core_id_to_work_slice = derive_operation_mapping(
@@ -676,10 +655,9 @@ def test_planner_and_sdsc_use_the_same_mapping(
 
 def test_flattened_iteration_span_is_not_a_single_axis_view():
     heads, flat = sympy.symbols("heads flat")
-    prep = pass_utils_module._ViewPrep(
+    prep = _view_prep(
         iter_space={heads: 16, flat: 512},
         write_index=512 * heads + flat,
-        read_index=512 * heads + flat,
         dep_coeff={heads: 512, flat: 1},
         dep_device_coordinates=(
             sympy.floor(flat / 256),
@@ -692,22 +670,86 @@ def test_flattened_iteration_span_is_not_a_single_axis_view():
         ),
         device_size=[2, 1, 1, 1, 4, 16, 64],
         stride_map=[256, -1, -1, -1, 64, 512, 1],
-        elems_per_stick=64,
         device_stride_to_dim={256: 0, 64: 4, 512: 5, 1: 6},
         stick_host_stride=1,
         num_stick_dim=4,
         num_stick=4,
         num_stick_stride=64,
-        is_matmul=False,
     )
 
     view, partial, representable = pass_utils_module._per_core_view_from_prep(
-        prep, ({512: 16, 1: 2}, {})
+        prep, {heads: 16, flat: 2}
     )
 
     assert not representable
     assert not partial
     assert not view.work_slice_dims
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("captured_k", [False, True])
+def test_stride_selected_compound_view_matches_actual_owned_values(reverse, captured_k):
+    """A successful stride lookup must not hide a fused batch/head split."""
+    flat = sympy.Symbol("flat", integer=True, nonnegative=True)
+    core = sympy.Symbol("core_id")
+    if captured_k:
+        # The saved K access fuses four batches of eight heads. Its stride
+        # selects the head axis, but each of eight partitions owns four heads
+        # of one batch, not one head across all four batches.
+        extent, split = 32, 8
+        coordinates = (sympy.Mod(flat, 8), sympy.floor(flat / 8))
+        device_size, stride_map = [8, 4], [1, 8]
+        stick_host_stride, num_stick_dim, num_stick = None, None, 0
+    else:
+        extent, split = 128, 2
+        coordinates = (sympy.floor(flat / 64), sympy.Mod(flat, 64))
+        device_size, stride_map = [2, 64], [64, 1]
+        stick_host_stride, num_stick_dim, num_stick = 1, 0, 2
+    owner = split - 1 - core if reverse else core
+    prep = _view_prep(
+        iter_space={flat: extent},
+        write_index=flat,
+        dep_coeff={flat: 1},
+        dep_device_coordinates=coordinates,
+        device_size=device_size,
+        stride_map=stride_map,
+        device_stride_to_dim={stride: axis for axis, stride in enumerate(stride_map)},
+        stick_host_stride=stick_host_stride,
+        num_stick_dim=num_stick_dim,
+        num_stick=num_stick,
+        num_stick_stride=64 if num_stick else 0,
+    )
+    view, partial, representable = pass_utils_module._per_core_view_from_prep(
+        prep,
+        {flat: split},
+        ownership=TensorWorkDivision({flat: split}, {flat: owner}, num_cores=split),
+    )
+    assert not partial
+    if not representable:
+        # The ownership foundation rejects K; the later exact-decomposition
+        # extension may accept it, but must satisfy the same element proof.
+        assert captured_k
+        return
+    physical_splits = dict(view.work_slice_dims)
+    physical_slots = dict(view.core_to_slot)
+    for c in range(split):
+        logical_slot = int(owner.subs(core, c))
+        expected = set(
+            range(
+                logical_slot * (extent // split), (logical_slot + 1) * (extent // split)
+            )
+        )
+        actual = {
+            point
+            for point in range(extent)
+            if all(
+                int(coordinates[axis].subs(flat, point))
+                // (device_size[axis] // factor)
+                == int(physical_slots[axis].subs(core, c))
+                for axis, factor in physical_splits.items()
+            )
+        }
+        assert actual == expected, (c, actual, expected)
 
 
 def _prepare_compound_axis_view(iter_space, index, repeat_info=None):
@@ -734,12 +776,20 @@ def _prepare_compound_axis_view(iter_space, index, repeat_info=None):
         _repeat_info={} if repeat_info is None else repeat_info,
         get_buffer=lambda name: SimpleNamespace(layout=layout),
     )
-    with pass_utils_module.V.set_graph_handler(graph):
+    rw = SimpleNamespace(writes={dep}, reads={dep})
+    with (
+        pass_utils_module.V.set_graph_handler(graph),
+        mock.patch.object(pass_utils_module, "op_read_writes", return_value=rw),
+        mock.patch.object(
+            pass_utils_module,
+            "iteration_space_from_op",
+            return_value=iter_space,
+        ),
+    ):
         prep = pass_utils_module._prepare_per_core_view(
             object(),
             dep,
             "buf",
-            parts=(iter_space, index, index),
         )
     assert prep is not None
     return prep, graph
@@ -761,7 +811,10 @@ def test_prepare_per_core_view_does_not_record_repeat_info():
     assert graph._repeat_info == before
 
 
-def test_reshape_changes_per_core_ownership_within_one_device_axis():
+@pytest.mark.parametrize("relayout_enabled", [False, True])
+def test_reshape_changes_per_core_ownership_within_one_device_axis(
+    monkeypatch, relayout_enabled
+):
     """A split of an inner term is not a contiguous split of the containing axis.
 
     This is the Gemma 4 decode geometry: the producer splits a flattened
@@ -769,6 +822,10 @@ def test_reshape_changes_per_core_ownership_within_one_device_axis():
     consumer views that dimension as ``[2, 256]`` and splits the inner 256.
     The latter owns alternating pairs of sticks, not contiguous groups of four.
     """
+    # Turning off movement must not turn off the physical-ownership guard.
+    monkeypatch.setattr(
+        pass_utils_module.config, "lx_planner_relayout", relayout_enabled
+    )
     producer_head, producer_flat = sympy.symbols(
         "producer_head producer_flat", integer=True, nonnegative=True
     )

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -690,8 +690,10 @@ class TestHbmPoolPlanningE2E(InductorTestCase):
 
     @config.patch({"lx_planning": False})
     def test_bundle_pool_size_threaded_from_hbm_pool_sizes(self):
-        """codegen_node must look up this bundle's own pool_size from
-        V.graph.hbm_pool_sizes, not a stale graph-global scalar.
+        """codegen_node must bind this bundle's own pool_size from
+        V.graph.hbm_pool_sizes before printing its kernel, not a stale
+        graph-global scalar. Pooling runs after the kernel is prepared, so
+        the value is observed at the binding point.
 
         lx_planning is disabled here so the `a = x + y` intermediate isn't
         claimed by LX scratchpad planning first -- with LX planning on,
@@ -704,11 +706,11 @@ class TestHbmPoolPlanningE2E(InductorTestCase):
         from torch_spyre._inductor.spyre_kernel import SpyreKernel
 
         seen_pool_sizes = []
-        orig_init = SpyreKernel.__init__
+        orig_codegen_kernel = SpyreKernel.codegen_kernel
 
-        def _recording_init(self, pool_size=0, **kwargs):
-            seen_pool_sizes.append(pool_size)
-            orig_init(self, pool_size=pool_size, **kwargs)
+        def _recording_codegen_kernel(self):
+            seen_pool_sizes.append(self.pool_size)
+            return orig_codegen_kernel(self)
 
         def fn(x, y):
             a = x + y
@@ -719,7 +721,7 @@ class TestHbmPoolPlanningE2E(InductorTestCase):
         y = torch.randn(64, 64, dtype=torch.float16, device="spyre")
 
         with (
-            mock_patch.object(SpyreKernel, "__init__", _recording_init),
+            mock_patch.object(SpyreKernel, "codegen_kernel", _recording_codegen_kernel),
             mock_patch(_LAUNCH_JOBPLAN),
             mock_patch(_PREPARE_KERNEL),
             mock_patch("subprocess.run"),

--- a/tests/inductor/test_indirect_access_scatter.py
+++ b/tests/inductor/test_indirect_access_scatter.py
@@ -908,6 +908,10 @@ class _ScatterScenarios:
     # -- Known crashes (separate from the indirect-store path) -------------
     def test_index_fill_crashes(self):
         """out.index_fill_(0, idx, 0.0) -- scalar fill -> rank-0 Constant codegen."""
+        # Main 6e92c9ec and lift 89c7c210 both reject the scalar Constant
+        # before producing an OpSpec. The lift also rejects this unsupported
+        # scatter's missing index bound during preflight; this is not a
+        # successful-finalization case and must not hide any other fallback.
         out = torch.rand(128, 256, dtype=torch.float16).to("spyre")
         idx = torch.randint(0, 128, (3,), dtype=torch.int32).to("spyre")
         self.name_dims(out, {"M": 128, "N": 256})
@@ -916,7 +920,9 @@ class _ScatterScenarios:
         def kernel(out, idx):
             return out.index_fill_(0, idx, 0.0)
 
-        self.check(kernel, out, idx, expect=CRASHED)
+        result = self.check(kernel, out, idx, expect=CRASHED)
+        self.assertIn("store value of unexpected type", str(result.exc))
+        self.assertIn("Constant", str(result.exc))
 
     def test_masked_scatter_element_mask_unsupported(self):
         """Element-level mask (stride(-1) != 0): the decomposition rejects it.

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -266,12 +266,10 @@ _LX_ALLOCATION_MARKER = "allocation={'lx'"
 def _assert_keeps_lx_residency(fn, x, case):
     """Assert the compiled graph still pins at least one buffer into LX.
 
-    Comparing values cannot detect a regression in
-    ``align_lx_producer_loop_order``: if an LX buffer's producer and consumers
-    stop agreeing on core->slice, ``demote_incoherent_lx_buffers`` clears the LX
+    Comparing values cannot detect a residency regression: if the clone cannot
+    commit the consumers' agreed physical ownership, preflight clears its LX
     allocation and the results come out correct anyway -- just served from HBM.
-    Residency is therefore the only observable that separates "aligned" from
-    "demoted", so assert it directly.
+    Assert residency directly as well as values.
 
     Measured on the shapes in SHARED_INPUT_TWO_REDUCTION_PARAM_SETS: with the
     aligner in place every case keeps 3 LX allocations (4 for the three-consumer
@@ -286,8 +284,8 @@ def _assert_keeps_lx_residency(fn, x, case):
     assert source_codes[0].count(_LX_ALLOCATION_MARKER) > 0, (
         f"{case}: no buffer left in LX. The values may still be correct, but an "
         f"LX buffer whose users disagree on core->slice gets demoted to HBM -- so "
-        f"this is the signature of the producer/consumer loop-order alignment "
-        f"regressing (see align_lx_producer_loop_order, #3374/#3387)."
+        f"this is the signature of clone ownership or finalization preflight "
+        f"regressing (see #3374/#3387)."
     )
 
 
@@ -1511,16 +1509,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             },
             "param_sets": INDEX_REDUCTION_KEEPDIM_PARAM_SETS,
         },
-        # Regression guard for the LX producer/consumer core->slice agreement
-        # (#3374, #3387). Two device reductions over one LX-pinned input reducing
-        # a non-trailing dim get a positional core->slice mapping from
-        # core_to_slice_mapping; if the clone that pins the input into LX walks it
-        # in a different dim order than the reductions read it, each core reads a
-        # slice another core wrote and the result is silently wrong. Through 2.12
-        # Inductor's loop_ordering_after_fusion happened to rewrite the clone into
-        # the consumers' order; 2.13 computes that reorder and discards it, which
-        # is what exposed it. aminmax was merely the first op to show it, so these
-        # cases assert the general shape.
+        # Regression guard for LX producer/consumer physical ownership
+        # (#3374, #3387). Two reductions over one pinned input may read it in a
+        # different loop order from the boundary clone. The clone must commit
+        # the consumers' accepted physical view before scheduling; otherwise a
+        # core can read a slice another core wrote. aminmax was merely the first
+        # op to expose the general shape.
         (
             "test_shared_input_two_reductions",
             "test_shared_input_two_reductions_base",

--- a/tests/inductor/test_kernel_preparation.py
+++ b/tests/inductor/test_kernel_preparation.py
@@ -172,6 +172,7 @@ def test_a_pooled_mutation_destination_leaves_the_external_argument_list():
     pooled = _layout(False)
     pooled.allocation = {"hbm_pool": 4096}  # filled in after preparation
     layouts = {"destination": pooled, "result": _layout(False), "alias": Mock()}
+    emitted = []
     graph = SimpleNamespace(
         get_buffer={
             name: SimpleNamespace(get_layout=lambda layout=layout: layout)
@@ -179,7 +180,7 @@ def test_a_pooled_mutation_destination_leaves_the_external_argument_list():
         }.get,
         removed_buffers=OrderedSet(),
         scheduler=SimpleNamespace(mutation_real_name={"alias": "destination"}),
-        wrapper_code=None,
+        wrapper_code=SimpleNamespace(writeline=emitted.append),
         get_dtype=lambda name: None,
     )
 
@@ -188,8 +189,21 @@ def test_a_pooled_mutation_destination_leaves_the_external_argument_list():
         kernel.store_buffer_names.add("alias")
         kernel.args.output("alias")  # registered as "destination"
         kernel.args.output("result")
-        kernel.remove_kernel_local_buffers()
-        assert kernel.args.python_argdefs()[1] == ["result"]
+        kernel.args.input("dead_index")  # simplified away after registration
+        destination_arg = Mock(allocation=pooled.allocation)
+        result_arg = Mock(allocation={"hbm": 0})
+        # The destination was registered before pooling and remains in this
+        # prepared list; only emission knows it no longer needs an external arg.
+        kernel.spyre_kernel_args = [
+            ("destination", destination_arg),
+            ("result", result_arg),
+        ]
+        kernel.codegen_kernel()
+        assert "destination" not in kernel.args.python_argdefs()[1]
+        assert kernel._live_call_arg_names == ["result"]
+        assert result_arg.arg_index == 0
+        kernel.call_kernel("prepared")
+        assert emitted == ["prepared.run(result)"]
 
 
 # --- the real compile -------------------------------------------------------
@@ -219,8 +233,9 @@ def test_emission_consumes_the_kernels_prepared_before_pooling():
     def codegen_kernel(kernel):
         emitted.append((kernel, operation_ids(kernel)))
         result = real_codegen(kernel)
-        # python_argdefs needs the active graph's dtype lookup.
-        emitted_arguments[id(kernel)] = kernel.args.python_argdefs()[1]
+        # This is the same filtered ordering used by arg_index and .run().
+        assert kernel._live_call_arg_names is not None
+        emitted_arguments[id(kernel)] = kernel._live_call_arg_names.copy()
         return result
 
     def fn(x, y):

--- a/tests/inductor/test_kernel_preparation.py
+++ b/tests/inductor/test_kernel_preparation.py
@@ -157,6 +157,41 @@ def test_a_rejected_attempt_demotes_restarts_and_keeps_the_final_kernels():
         assert node.prepared_kernel is kernels[node.name]
 
 
+def test_a_pooled_mutation_destination_leaves_the_external_argument_list():
+    """Emission prunes a pooled destination registered through a mutation alias.
+
+    Preparation runs before HBM pooling, so an operation that writes a padded
+    intermediate registers it as an external argument. ``KernelArgs.output``
+    resolves ``mutation_real_name``, so the alias lands in
+    ``store_buffer_names`` while the real destination lands in
+    ``output_buffers``. Emission skips a pooled tensor's descriptor argument,
+    so the same tensor must leave the call argument list, or the wrapper passes
+    one argument more than the bundle declares.
+    """
+
+    pooled = _layout(False)
+    pooled.allocation = {"hbm_pool": 4096}  # filled in after preparation
+    layouts = {"destination": pooled, "result": _layout(False), "alias": Mock()}
+    graph = SimpleNamespace(
+        get_buffer={
+            name: SimpleNamespace(get_layout=lambda layout=layout: layout)
+            for name, layout in layouts.items()
+        }.get,
+        removed_buffers=OrderedSet(),
+        scheduler=SimpleNamespace(mutation_real_name={"alias": "destination"}),
+        wrapper_code=None,
+        get_dtype=lambda name: None,
+    )
+
+    with V.set_graph_handler(graph):
+        kernel = SpyreKernel()
+        kernel.store_buffer_names.add("alias")
+        kernel.args.output("alias")  # registered as "destination"
+        kernel.args.output("result")
+        kernel.remove_kernel_local_buffers()
+        assert kernel.args.python_argdefs()[1] == ["result"]
+
+
 # --- the real compile -------------------------------------------------------
 
 

--- a/tests/inductor/test_kernel_preparation.py
+++ b/tests/inductor/test_kernel_preparation.py
@@ -1,0 +1,228 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Each bundle's kernel is prepared once, before HBM pooling; emission consumes it.
+
+The stub scenario drives the preparation pass with hand-built nodes; the
+real compile checks one preparation per bundle, the identical operations at
+emission, and the late binding of pooled intermediates.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch as mock_patch
+
+import sympy
+import torch
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.utils import run_and_get_code
+from torch._inductor.virtualized import V
+from torch.utils._ordered_set import OrderedSet
+
+import torch_spyre._inductor.scheduler as scheduler_module
+import torch_spyre._inductor.scratchpad.lx_relayout as lx_relayout_module
+from torch_spyre._inductor import config
+from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.pass_utils import PerCoreView
+from torch_spyre._inductor.spyre_kernel import SpyreKernel, _iter_op_specs
+
+_LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
+_PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
+_CORE_ID = sympy.Symbol("core_id")
+_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),), num_cores=8)
+_OTHER_VIEW = PerCoreView(
+    ((0, 4), (1, 2)),
+    ((0, sympy.floor(_CORE_ID / 2)), (1, sympy.Mod(_CORE_ID, 2))),
+    num_cores=8,
+)
+
+
+class _Node:
+    """A scheduler-node stand-in: one operation that is also its own bundle."""
+
+    def __init__(self, name, reads=(), writes=()):
+        self.name = name
+        self.read_writes = SimpleNamespace(
+            reads=[MemoryDep(read, sympy.S.Zero, (), ()) for read in reads],
+            writes=[MemoryDep(write, sympy.S.Zero, (), ()) for write in writes],
+        )
+
+    def get_nodes(self):
+        return [self]
+
+    def get_name(self):
+        return self.name
+
+    def get_device(self):
+        return None
+
+    is_template = is_extern = is_foreach = staticmethod(lambda: False)
+
+
+def _layout(lx, view=_VIEW):
+    # Real MemoryDeps above and a spec'd layout here let the pass's own
+    # isinstance checks do the filtering, with no patched module types.
+    layout = Mock(spec=FixedTiledLayout)
+    layout.allocation = {"lx": 0} if lx else {"hbm": 0}
+    layout.lx_view = view if lx else None
+    layout.device_layout = SimpleNamespace(device_size=(8, 64))
+    return layout
+
+
+def _graph(layouts, scheduler=None):
+    buffers = {
+        name: SimpleNamespace(
+            layout=SimpleNamespace(), get_layout=lambda layout=layout: layout
+        )
+        for name, layout in layouts.items()
+    }
+    backend = scheduler_module.SuperDSCScheduling(scheduler)
+    graph = SimpleNamespace(
+        try_get_buffer=buffers.get,
+        get_buffer=buffers.__getitem__,
+        removed_buffers=OrderedSet(),
+        scheduler=SimpleNamespace(get_backend=lambda _device: backend, name_to_buf={}),
+    )
+    return graph, backend
+
+
+# --- the preparation pass ---------------------------------------------------
+
+
+def test_a_rejected_attempt_demotes_restarts_and_keeps_the_final_kernels():
+    """One failing relayout copy: its group falls back, nothing else moves.
+
+    The copy touches both ends of the relayout, so source and destination are
+    demoted together (the first name closes the connected group through the
+    registry; the second finds no plan and clears its own layout again). The
+    attempt's graph removals are dropped and the next attempt starts over in
+    order; an unrelated LX placement survives; every bundle keeps the kernel
+    of the last, complete attempt.
+    """
+
+    plan = lx_relayout_module.LXRelayoutPlan(
+        "source", ("consumer",), _VIEW, _OTHER_VIEW, 8
+    )
+    layouts = {
+        "target": _layout(False),
+        "source": _layout(True),
+        "destination": _layout(True, _OTHER_VIEW),
+        "z": _layout(True),
+    }
+    writer = _Node("writer", writes=("target",))
+    copy = _Node("copy", reads=("source",), writes=("destination",))
+    unrelated = _Node("unrelated", writes=("z",))
+    graph, backend = _graph(layouts)
+    graph._spyre_lx_relayout_copies = {("source", "consumer"): ("destination", plan)}
+    order, kernels = [], {}
+
+    def prepare(node, kernel):
+        order.append(node.name)
+        kernels[node.name] = kernel
+        if node.name == "writer":
+            # Handlers add mutation aliases to the graph's removed set. A
+            # restarted attempt must start from the entry state again.
+            assert "alias" not in graph.removed_buffers
+            graph.removed_buffers.add("alias")
+        elif node.name == "copy" and "lx" in layouts["source"].allocation:
+            kernel.failed_node = node
+            raise ValueError("ownership mismatch: forced")
+        return kernel
+
+    with (
+        mock_patch.object(scheduler_module, "SchedulerNode", _Node),
+        mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
+        mock_patch.object(backend, "prepare_kernel", side_effect=prepare),
+    ):
+        scheduler_module.prepare_spyre_kernels([writer, copy, unrelated])
+
+    assert order == ["writer", "copy", "writer", "copy", "unrelated"]
+    assert list(graph.removed_buffers) == ["alias"]
+    assert graph._spyre_lx_relayout_copies == {}
+    for name in ("source", "destination"):
+        assert "lx" not in layouts[name].allocation and layouts[name].lx_view is None
+    assert layouts["z"].allocation == {"lx": 0} and layouts["z"].lx_view is _VIEW
+    for node in (writer, copy, unrelated):
+        assert node.prepared_kernel is kernels[node.name]
+
+
+# --- the real compile -------------------------------------------------------
+
+
+@config.patch({"lx_planning": False})
+def test_emission_consumes_the_kernels_prepared_before_pooling():
+    """One preparation per bundle inside the pass; emission consumes the same
+    operations and binds only what HBM pooling decided afterwards."""
+
+    prepared, emitted = {}, []
+    real_prepare = scheduler_module.SuperDSCScheduling.prepare_kernel
+    real_codegen = SpyreKernel.codegen_kernel
+
+    def operation_ids(kernel):
+        return [id(spec) for spec in _iter_op_specs(kernel.op_specs)]
+
+    def prepare(backend, node, kernel):
+        result = real_prepare(backend, node, kernel)
+        # The scheduler gains ``removed_ops`` only after the post-fusion hook,
+        # so its absence marks a preparation made by the pass.
+        if not hasattr(V.graph.scheduler, "removed_ops"):
+            prepared[id(kernel)] = operation_ids(kernel)
+        return result
+
+    def codegen_kernel(kernel):
+        emitted.append((kernel, operation_ids(kernel)))
+        return real_codegen(kernel)
+
+    def fn(x, y):
+        a = x + y
+        b = a * 2
+        return b - x
+
+    x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+    y = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+    with (
+        mock_patch.object(
+            scheduler_module.SuperDSCScheduling,
+            "prepare_kernel",
+            side_effect=prepare,
+            autospec=True,
+        ),
+        mock_patch.object(
+            SpyreKernel, "codegen_kernel", side_effect=codegen_kernel, autospec=True
+        ),
+        mock_patch(_LAUNCH_JOBPLAN),
+        mock_patch(_PREPARE_KERNEL),
+        mock_patch("subprocess.run"),
+    ):
+        _, code = run_and_get_code(torch.compile(fn, dynamic=False), x, y)
+    generated = "\n".join(code)
+
+    assert emitted
+    assert all(prepared.get(id(kernel)) == ids for kernel, ids in emitted)
+    assert len({id(kernel) for kernel, _ in emitted}) == len(emitted)
+    assert "'hbm_pool'" in generated  # intermediates were pooled after preparation
+    assert any(kernel.pool_size > 0 for kernel, _ in emitted)  # bound at emission
+    # Pooling ran after preparation: pooled intermediates are pruned from the
+    # external call arguments at emission, and the survivors keep the indices
+    # of the actual argument list.
+    pooled = set()
+    for kernel, _ in emitted:
+        call_args = kernel.args.python_argdefs()[1]
+        for name, arg in kernel.spyre_kernel_args:
+            if "hbm_pool" in arg.allocation:
+                pooled.add(name)
+                assert name not in call_args
+            elif "lx" not in arg.allocation:
+                assert arg.arg_index == call_args.index(name)
+    assert pooled

--- a/tests/inductor/test_kernel_preparation.py
+++ b/tests/inductor/test_kernel_preparation.py
@@ -201,6 +201,7 @@ def test_emission_consumes_the_kernels_prepared_before_pooling():
     operations and binds only what HBM pooling decided afterwards."""
 
     prepared, emitted = {}, []
+    emitted_arguments = {}
     real_prepare = scheduler_module.SuperDSCScheduling.prepare_kernel
     real_codegen = SpyreKernel.codegen_kernel
 
@@ -217,7 +218,10 @@ def test_emission_consumes_the_kernels_prepared_before_pooling():
 
     def codegen_kernel(kernel):
         emitted.append((kernel, operation_ids(kernel)))
-        return real_codegen(kernel)
+        result = real_codegen(kernel)
+        # python_argdefs needs the active graph's dtype lookup.
+        emitted_arguments[id(kernel)] = kernel.args.python_argdefs()[1]
+        return result
 
     def fn(x, y):
         a = x + y
@@ -253,7 +257,7 @@ def test_emission_consumes_the_kernels_prepared_before_pooling():
     # of the actual argument list.
     pooled = set()
     for kernel, _ in emitted:
-        call_args = kernel.args.python_argdefs()[1]
+        call_args = emitted_arguments[id(kernel)]
         for name, arg in kernel.spyre_kernel_args:
             if "hbm_pool" in arg.allocation:
                 pooled.add(name)

--- a/tests/inductor/test_log_op_specs.py
+++ b/tests/inductor/test_log_op_specs.py
@@ -206,17 +206,19 @@ def _make_test_kernel():
     kernel.args.python_argdefs.return_value = (None, [])
     kernel.spyre_kernel_args = []
     kernel._alignment_repeat_info = {}
-    kernel._alignment_repeat_info_by_spec = {}
-    kernel._alignment_access_by_tensor_arg = {}
-    kernel._alignment_inputs_by_spec = {}
+    kernel.failed_node = None
     kernel.pool_size = 0
     return kernel
 
 
 class TestSpyreKernelLogging:
-    """Tests for logger.info calls in SpyreKernel.codegen_kernel."""
+    """Tests for logger.info calls in SpyreKernel.check_op_specs.
 
-    def test_logs_at_both_stages(self):
+    Operations are finished as they are created, so the sequence is logged
+    once, in its finished form, after loop wrapping.
+    """
+
+    def test_logs_the_finished_sequence_once(self):
         logger = logging.getLogger("spyre.inductor.spyre_kernel")
         with patch.object(logger, "isEnabledFor", return_value=True):
             with patch.object(logger, "info") as mock_info:
@@ -225,15 +227,12 @@ class TestSpyreKernelLogging:
                     return_value="<formatted>",
                 ) as mock_fmt:
                     kernel = _make_test_kernel()
-
-                    with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
-                        kernel.codegen_kernel()
+                    kernel.check_op_specs()
 
                     info_calls = mock_info.call_args_list
                     labels = [c.args[0] for c in info_calls if "OP SPECS" in c.args[0]]
-                    assert any("CREATION/LOOP-WRAPPING" in lbl for lbl in labels)
-                    assert any("SIMPLIFICATION" in lbl for lbl in labels)
-                    assert mock_fmt.call_count >= 2
+                    assert labels == ["OP SPECS AFTER SIMPLIFICATION\n%s"]
+                    assert mock_fmt.call_count == 1
 
     def test_no_formatting_when_logging_disabled(self):
         logger = logging.getLogger("spyre.inductor.spyre_kernel")
@@ -242,9 +241,7 @@ class TestSpyreKernelLogging:
                 "torch_spyre._inductor.spyre_kernel.format_op_spec_list"
             ) as mock_fmt:
                 kernel = _make_test_kernel()
-
-                with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
-                    kernel.codegen_kernel()
+                kernel.check_op_specs()
 
                 mock_fmt.assert_not_called()
 

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -34,6 +34,7 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
 )
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
+from torch_spyre._inductor.scratchpad.exhaustive_search import ExhaustiveSearchSolver
 
 try:
     from ortools.sat.python import cp_model  # noqa: F401
@@ -81,6 +82,46 @@ class TestCoreDivision(TestCase):
             CoreDivision(output_splits={y: 2, x: 4}).signature_key(),
             ((x, 4), (y, 2)),
         )
+
+
+class TestExhaustiveSearchResidency(TestCase):
+    def test_mismatched_consumer_spills_the_producer(self):
+        """A consumer mismatch makes its input unsafe in LX, not its output."""
+
+        producer = CoreDivisionBuffer(
+            "producer", 128, [0, 1], core_divisions=[CoreDivision()]
+        )
+        consumer = CoreDivisionBuffer(
+            "consumer",
+            128,
+            [1, 2],
+            core_divisions=[CoreDivision()],
+            parents=["producer"],
+            cd_parent_matches={"producer": []},
+        )
+        sink = CoreDivisionBuffer(
+            "sink",
+            128,
+            [2, 3],
+            core_divisions=[CoreDivision()],
+            parents=["consumer"],
+            cd_parent_matches={"consumer": [(0, 0)]},
+            residency_reason="no consumer reads it from LX",
+        )
+
+        solver = ExhaustiveSearchSolver(
+            [producer, consumer, sink],
+            size=512,
+            inner_factory=GreedyLayoutSolver,
+            alignment=1,
+        )
+        result = {
+            buffer.name: buffer for buffer in solver.plan_layout_and_core_divisions()
+        }
+
+        self.assertIsNone(result["producer"].address)
+        self.assertIsNotNone(result["consumer"].address)
+        self.assertEqual(solver.spill_reasons["producer"], "core div mismatch")
 
 
 class TestLxPlanningContract(TestCase):

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -26,6 +26,7 @@ import torch
 
 from torch._inductor import config as t_inductor_config
 from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import MutationLayoutSHOULDREMOVE
 
 from torch_spyre._inductor.passes import CustomPreSchedulingPasses
 from torch_spyre._inductor import passes
@@ -69,6 +70,30 @@ def test_nested_spyre_context_runs_pre_scheduling_once():
         GraphLowering._update_scheduler(graph)
 
     assert calls == [graph]
+
+
+def test_cooptimizing_allocator_rejects_relayout_results_without_asserts():
+    """Unsupported paired plans remain fail-closed under ``python -O``."""
+
+    import torch_spyre._inductor.cost_model as cost_model_module
+    import torch_spyre._inductor.scratchpad.allocator as allocator_module
+
+    solver = SimpleNamespace(
+        buffers=[],
+        plan_layout_and_core_divisions=lambda _cost: [
+            SimpleNamespace(lx_relayout_plans=[object()])
+        ],
+    )
+    graph = SimpleNamespace(operations=[])
+    with (
+        patch.object(allocator_module, "CoreDivisionLayoutSolver", object),
+        patch.object(allocator_module, "mem_usage_by_buf", return_value={}),
+        patch.object(cost_model_module, "predict_by_bundle", return_value=0),
+        unittest.TestCase().assertRaisesRegex(
+            AssertionError, "CoOptimizingAllocator does not support LX relayout"
+        ),
+    ):
+        allocator_module.CoOptimizingAllocator._solve(SimpleNamespace(), solver, graph)
 
 
 class CustomPreSchedulingPassesWithOurPasses(CustomPreSchedulingPasses):
@@ -159,6 +184,8 @@ class BaseTestScratchpadUsage(unittest.TestCase):
                 buf_name = op.name
                 buffer = graph.get_buffer(buf_name)
                 layout = buffer.get_layout()
+                if isinstance(layout, MutationLayoutSHOULDREMOVE):
+                    layout = layout.real_layout()
                 device_layout = layout.device_layout
                 allocation = getattr(layout, "allocation", {})
                 mem_usages[buf_name] = {
@@ -622,10 +649,10 @@ class TestCloneAtGraphBoundaries(
         """A graph input read by a reduction is LX-cloned, with the clone's
         per-core split re-keyed correctly.
 
-        push_allocation_with_clone re-keys the consumer's op_it_space_splits
-        through the buffer's strides before assigning them to the clone. A reduction consumer's split is keyed to its
-        reduced-shape output; copied verbatim it would split the wrong axis of
-        the full-shape clone (wrong values / SDSC abort at multi-core). The
+        push_allocation_with_clone projects the accepted physical view through
+        the clone's own coordinates and commits that complete division. Copying
+        a reduction consumer's logical split verbatim could split the wrong axis
+        of the full-shape clone (wrong values / SDSC abort at multi-core). The
         numerical failure only manifests when work is split across cores; here
         (sencores=1) we assert the clone is inserted and the result is correct.
         Multi-core numerical coverage lives in

--- a/tests/inductor/test_scratchpad_utils.py
+++ b/tests/inductor/test_scratchpad_utils.py
@@ -39,8 +39,13 @@ from unittest import TestCase, mock
 
 import sympy
 from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import ExternKernel, FallbackKernel
 
-from torch_spyre._inductor.scratchpad.utils import _would_produce_lx_back_gap
+from torch_spyre._inductor import config
+from torch_spyre._inductor.scratchpad.utils import (
+    _would_produce_lx_back_gap,
+    get_ncores_for_buffers,
+)
 
 _COORDS = "torch_spyre._inductor.scratchpad.utils.device_coordinates"
 
@@ -139,6 +144,31 @@ class BackGapTest(TestCase):
         gap. This is why the check needs real range analysis and not ``subs``.
         """
         self.assertFalse(_back_gap(sympy.Mod(d0, 5), 4, {d0: 8}))
+
+
+class ExternalOperandTest(TestCase):
+    def test_external_operands_never_publish_physical_ownership(self):
+        graph = SimpleNamespace(try_get_buffer=lambda name: None)
+        for op_type in (ExternKernel, FallbackKernel):
+            for cores in (1, 32):
+                with self.subTest(op=op_type.__name__, cores=cores):
+                    op = mock.Mock(spec=op_type)
+                    op.get_name.return_value = "opaque"
+                    with (
+                        config.patch({"sencores": cores}),
+                        mock.patch(
+                            "torch_spyre._inductor.scratchpad.utils._get_buffer_user_deps",
+                            return_value={_BUF: [(op, None)]},
+                        ),
+                        mock.patch(
+                            "torch_spyre._inductor.scratchpad.utils._per_core_view_on_buf"
+                        ) as project,
+                    ):
+                        counts, reasons, views = get_ncores_for_buffers(graph)
+                    self.assertEqual(counts, {_BUF: -1})
+                    self.assertIn("FallbackKernel/ExternKernel", reasons[_BUF])
+                    self.assertEqual(views, {})
+                    project.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -14,7 +14,6 @@
 
 import math
 import unittest
-from collections import namedtuple
 from contextlib import ExitStack
 from typing import NamedTuple
 from unittest.mock import MagicMock, patch
@@ -39,13 +38,15 @@ from torch_spyre._inductor.constants import (
     CONV2D_FWD_OP,
     DEPTHWISE_CONV2D_OP,
 )
-from torch_spyre._inductor.pass_utils import SchedNodeArg
+from torch_spyre._inductor.pass_utils import PerCoreView, SchedNodeArg
 from torch_spyre._inductor.scratchpad import allocator as allocator_module
 from torch_spyre._inductor.scratchpad.allocator import (
     CoOptimizingAllocator,
     CoreDivision,
 )
-from torch_spyre._inductor.scratchpad.plan_solver import CoreDivisionBuffer
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    CoreDivisionBuffer,
+)
 from torch_spyre._inductor.work_division import (
     TensorDep,
     _cost_model_matmul_planner,
@@ -1379,7 +1380,18 @@ class TestSpanReductionConstraints(unittest.TestCase):
         self.assertEqual(must_split.call_args.args[-1], {r0, r1})
 
 
-_FakeView = namedtuple("_FakeView", "work_slice_dims")
+def _physical_view(*splits):
+    """A real :class:`PerCoreView` whose cores own contiguous slices in
+    row-major order of ``splits`` (device-dim index, split factor)."""
+
+    core_id = sympy.Symbol("core_id")
+    num_cores = math.prod(split for _, split in splits)
+    slots = []
+    stride = num_cores
+    for dim, split in splits:
+        stride //= split
+        slots.append((dim, sympy.Mod(sympy.floor(core_id / stride), split)))
+    return PerCoreView(tuple(splits), tuple(slots), num_cores=num_cores)
 
 
 class TestResidencyEdgeMatching(unittest.TestCase):
@@ -1389,9 +1401,9 @@ class TestResidencyEdgeMatching(unittest.TestCase):
 
     def setUp(self):
         x, y = _isym("x"), _isym("y")
-        self.view_a = _FakeView(((0, 4),))
-        self.view_b = _FakeView(((0, 2),))
-        self.view_wide = _FakeView(((0, 2), (1, 2)))
+        self.view_a = _physical_view((0, 4))
+        self.view_b = _physical_view((0, 2))
+        self.view_wide = _physical_view((0, 2), (1, 2))
 
         def _div(splits, reduction=None):
             return CoreDivision(

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 from collections.abc import Sequence
+from contextlib import contextmanager
 from dataclasses import replace
+import json
 import logging
 import logging.handlers
+import os
+from pathlib import Path
 import regex as re
+import subprocess
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch as mock_patch
@@ -33,6 +38,7 @@ from torch._dynamo.test_case import (
 from torch._functorch.aot_autograd import aot_module_simplified
 from torch._functorch._aot_autograd.utils import make_boxed_func
 from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.ir import NoneLayout
 from torch._inductor.utils import run_and_get_code, InputType
 
 from torch_spyre._inductor import config, spyre_hint
@@ -42,20 +48,30 @@ import torch_spyre._inductor.work_division as _wd
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spec
-from torch_spyre._inductor.constants import IDENTITY_OP
+from torch_spyre._inductor.constants import (
+    BATCH_MATMUL_OP,
+    IDENTITY_OP,
+)
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.loop_info import CarriedReductionRecord
 from torch_spyre._inductor.scratchpad.lx_relayout import (
     LXRelayoutPlan,
     work_division_from_view,
 )
-from torch_spyre._inductor.op_spec import OpSpec, TensorArg, TensorWorkDivision
+from torch_spyre._inductor.op_spec import (
+    LX_RELAYOUT_INFO_KEY,
+    OpSpec,
+    TensorArg,
+    TensorWorkDivision,
+)
 from torch_spyre._inductor.pass_utils import PerCoreView
 from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
+from torch_spyre._inductor.spyre_kernel import SpyreKernel, _iter_op_specs
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
 from torch_spyre._inductor.core_mapping import remap_work_division
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
+import torch_spyre.execution.async_compile as async_compile_module
 
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
 _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
@@ -63,6 +79,77 @@ _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 
 _declare_tensor_dim = _pnd.declare_tensor_dim
 _name_tensor_dims = _pnd.name_tensor_dims
+
+
+@contextmanager
+def _emitted_kernels():
+    """Collect every kernel the backend emits during one compile."""
+
+    kernels = []
+    real_codegen = SpyreKernel.codegen_kernel
+
+    def codegen_kernel(kernel):
+        kernels.append(kernel)
+        return real_codegen(kernel)
+
+    with mock_patch.object(
+        SpyreKernel, "codegen_kernel", side_effect=codegen_kernel, autospec=True
+    ):
+        yield kernels
+
+
+@contextmanager
+def _capture_backend_output_dirs():
+    output_dirs = []
+    get_output_dir = async_compile_module.get_output_dir
+
+    def capture(kernel_name):
+        output_dir = get_output_dir(kernel_name)
+        output_dirs.append(Path(output_dir))
+        return output_dir
+
+    with mock_patch.object(async_compile_module, "get_output_dir", side_effect=capture):
+        yield output_dirs
+
+
+def _assert_lx_only_relayout_payload(output_dirs):
+    # Inspect the backend payload for the same bundle whose values were checked.
+    # This debug lowering is not a second device execution or a timing sample.
+    for output_dir in output_dirs:
+        subprocess.run(
+            ["dxp_standalone", "-d", output_dir, "--use-dxp"],
+            check=True,
+            env={**os.environ, "DXP_DEBUG": "1"},
+        )
+    payloads = [
+        json.loads(path.read_text())
+        for output_dir in output_dirs
+        for path in output_dir.glob("debug/sdsc_*/*.out.out.out.json")
+    ]
+    assert payloads, "DeepTools emitted no debug SDSC payloads"
+    nodes = []
+    pending = list(payloads)
+    while pending:
+        value = pending.pop()
+        if isinstance(value, dict):
+            nodes.append(value)
+            pending.extend(value.values())
+        elif isinstance(value, list):
+            pending.extend(value)
+    lx_ops = [
+        node
+        for node in nodes
+        if isinstance(node.get("op"), dict) and node["op"].get("name") == "STCDPOpLx"
+    ]
+    assert len(lx_ops) == 1
+    op_names = [node["name"] for node in nodes if isinstance(node.get("name"), str)]
+    assert not any(
+        token in name.lower()
+        for name in op_names
+        for token in ("dma", "restickify", "stcdpophbm")
+    )
+    labeled_ds = lx_ops[0]["labeledDs_"]
+    assert labeled_ds and all(ds["hbmSize_"] == 0 for ds in labeled_ds)
 
 
 class TestNamedWorkDivisionHint(InductorTestCase):
@@ -557,6 +644,15 @@ class TestNamedWorkDivisionHint(InductorTestCase):
 
 
 _CORE_ID = Symbol("core_id")
+_FUSED, _LOOP = Symbol("fused"), Symbol("loop")
+
+
+def _view(splits, slots, num_cores):
+    """A per-core view from ``{device dim: split}`` and ``{device dim: owner}``."""
+
+    return PerCoreView(tuple(splits.items()), tuple(slots.items()), num_cores=num_cores)
+
+
 _SOURCE_VIEW = PerCoreView(
     ((0, 4), (1, 2)),
     ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2))),
@@ -565,45 +661,121 @@ _SOURCE_VIEW = PerCoreView(
 _DESTINATION_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),), num_cores=8)
 
 
-def _relayout_plan(source="source", consumers="consumer"):
+def _relayout_plan(
+    source="source", consumers="consumer", *, destination_view=_DESTINATION_VIEW
+):
     if isinstance(consumers, str):
         consumers = (consumers,)
-    return LXRelayoutPlan(source, consumers, _SOURCE_VIEW, _DESTINATION_VIEW, 8)
+    return LXRelayoutPlan(source, consumers, _SOURCE_VIEW, destination_view, 8)
+
+
+def _allocation_graph(*operation_names):
+    return SimpleNamespace(
+        operations=[
+            SimpleNamespace(get_name=lambda name=name: name) for name in operation_names
+        ]
+    )
 
 
 @pytest.mark.parametrize(
-    ("view", "message"),
+    ("view", "device_size", "coordinates", "extents", "expected"),
     [
+        # A fused loop over two physical axes projects to one 32-way division
+        # whose owners are the canonical order the generator spells.
         (
-            PerCoreView(((0, 2),), (), num_cores=2),
-            "split and owner-slot dimensions differ",
+            _view({0: 4, 1: 8}, {0: floor(_CORE_ID / 8), 1: Mod(_CORE_ID, 8)}, 32),
+            (4, 8),
+            (floor(_FUSED / 8), Mod(_FUSED, 8)),
+            {_FUSED: 32},
+            {_FUSED: 32},
+        ),
+        # A 32K-point direct axis is within the exact proof budget.
+        (
+            _view({0: 32}, {0: Mod(_CORE_ID, 32)}, 32),
+            (32768,),
+            (_LOOP,),
+            {_LOOP: 32768},
+            {_LOOP: 32},
+        ),
+        # 129 fp16 values are three sticks: three cores own one stick each
+        # whatever the logical tail; two cores cannot own three sticks.
+        (
+            _view({0: 3}, {0: Mod(_CORE_ID, 3)}, 3),
+            (3, 64),
+            (floor(_LOOP / 64), Mod(_LOOP, 64)),
+            {_LOOP: 129},
+            {_LOOP: 3},
         ),
         (
-            PerCoreView(
-                ((0, 2),),
-                ((0, Symbol("unknown_owner")),),
-                num_cores=2,
-            ),
-            "non-integral owner slot",
+            _view({0: 2}, {0: Mod(_CORE_ID, 2)}, 2),
+            (3, 64),
+            (floor(_LOOP / 64), Mod(_LOOP, 64)),
+            {_LOOP: 129},
+            "not divisible",
         ),
+        # Fused states beyond the budget are a limit, never wrong owners.
         (
-            PerCoreView(((0, 2),), ((0, Integer(2)),), num_cores=2),
-            "owner slot 2 outside split 2",
+            _view({0: 32, 1: 2}, {0: floor(_CORE_ID / 2), 1: Mod(_CORE_ID, 2)}, 64),
+            (32, 32),
+            (floor(_FUSED / 32), Mod(_FUSED, 32)),
+            {_FUSED: 1024},
+            "proof limit.*1088.*1024",
+        ),
+        # A 4-way fused split over (4, 8) cut 2x2: each quarter is two
+        # disjoint 2x2 regions, not one contiguous slice.
+        (
+            _view({0: 2, 1: 2}, {0: floor(_CORE_ID / 2), 1: Mod(_CORE_ID, 2)}, 4),
+            (4, 8),
+            (floor(_FUSED / 8), Mod(_FUSED, 8)),
+            {_FUSED: 32},
+            "ownership mismatch",
+        ),
+        # Every loop value is checked: a permuted feature axis is not owned
+        # contiguously even though its first values line up.
+        (
+            _view({0: 4, 1: 2}, {0: Mod(_CORE_ID, 4), 1: floor(_CORE_ID / 4)}, 8),
+            (4, 8),
+            (_FUSED, Mod(_LOOP + 4 * Mod(_LOOP, 4), 8)),
+            {_FUSED: 4, _LOOP: 8},
+            "ownership mismatch",
+        ),
+        # Partitions that interleave physical slices have no contiguous owners.
+        (
+            _view({0: 2}, {0: floor(_CORE_ID / 4)}, 8),
+            (8,),
+            (Mod(_LOOP + 4 * Mod(_LOOP, 4), 8),),
+            {_LOOP: 8},
+            "ownership mismatch",
+        ),
+        # A direct axis beyond the exact proof cap is a limit.
+        (
+            _view({0: 2}, {0: floor(_CORE_ID / 4)}, 8),
+            (65538,),
+            (_LOOP,),
+            {_LOOP: 65538},
+            "proof limit.*65538.*65536",
         ),
     ],
 )
-def test_lx_relayout_partition_validation_fails_closed(view, message):
-    with pytest.raises(ValueError, match=message):
-        lx_relayout_module._compatible_partitions(view, _DESTINATION_VIEW, 2)
+def test_work_division_from_view_examples(
+    view, device_size, coordinates, extents, expected
+):
+    if isinstance(expected, str):
+        with pytest.raises(ValueError, match=expected):
+            work_division_from_view(view, device_size, coordinates, extents)
+        return
+    division = work_division_from_view(view, device_size, coordinates, extents)
+    assert division is not None
+    assert division.work_slices == expected
+    assert division.physical_core_count == view.num_cores
 
 
 def test_lx_relayout_activation_policy_is_source_wide():
     dep = SimpleNamespace(name="input")
+    graph = SimpleNamespace()
     producer = SimpleNamespace()
     with (
-        mock_patch.object(
-            lx_relayout_module, "op_short_name", return_value="restickify"
-        ),
+        mock_patch.object(lx_relayout_module, "is_restickify_op", return_value=True),
         mock_patch.object(
             lx_relayout_module,
             "op_read_writes",
@@ -612,8 +784,8 @@ def test_lx_relayout_activation_policy_is_source_wide():
         mock_patch.object(lx_relayout_module, "MemoryDep", SimpleNamespace),
         mock_patch.object(lx_relayout_module, "ComputedBuffer", SimpleNamespace),
     ):
-        assert not lx_relayout_module._is_activation_source({}, producer)
-        assert lx_relayout_module._is_activation_source({"input": dep}, producer)
+        assert not lx_relayout_module._is_activation_source(graph, {}, producer)
+        assert lx_relayout_module._is_activation_source(graph, {"input": dep}, producer)
 
 
 def test_lx_relayout_planner_rejects_equal_projected_ownership():
@@ -629,16 +801,18 @@ def test_lx_relayout_planner_rejects_equal_projected_ownership():
         num_cores=32,
     )
     coordinates = [m, m]
-    source_work_division = work_division_from_view(source_view, coordinates, (m,))
+    source_work_division = work_division_from_view(
+        source_view, [32, 32], coordinates, {m: 32}
+    )
     destination_work_division = work_division_from_view(
-        destination_view, coordinates, (m,)
+        destination_view, [32, 32], coordinates, {m: 32}
     )
     assert source_view != destination_view
     assert source_work_division == destination_work_division
 
     source_dep = SimpleNamespace(name="source", is_indirect=lambda: False)
     producer = SimpleNamespace(
-        layout=SimpleNamespace(device_layout=SimpleNamespace()),
+        layout=SimpleNamespace(device_layout=SimpleNamespace(device_size=[32, 32])),
         data=SimpleNamespace(),
         get_name=lambda: "source",
     )
@@ -675,11 +849,9 @@ def test_lx_relayout_planner_rejects_equal_projected_ownership():
             lx_relayout_module, "try_device_coordinates", return_value=coordinates
         ),
         mock_patch.object(
-            lx_relayout_module, "iteration_space_from_op", return_value=(m,)
+            lx_relayout_module, "iteration_space_from_op", return_value={m: 32}
         ),
-        mock_patch.object(
-            lx_relayout_module, "op_short_name", return_value="pointwise"
-        ),
+        mock_patch.object(lx_relayout_module, "is_restickify_op", return_value=False),
     ):
         assert lx_relayout_module.collect_lx_relayout_plans(graph) == []
 
@@ -714,18 +886,29 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
     args = [
         replace(
             base,
-            work_division=work_division_from_view(source_view, coordinates, (m, n)),
+            work_division=work_division_from_view(
+                source_view, base.device_size, coordinates, {m: 64, n: 256}
+            ),
         ),
         replace(
             base,
             is_input=False,
             allocation={"lx": 256},
             work_division=work_division_from_view(
-                destination_view, coordinates, (m, n)
+                destination_view,
+                base.device_size,
+                coordinates,
+                {m: 64, n: 256},
             ),
         ),
     ]
-    spec = OpSpec(IDENTITY_OP, False, {n: (256, 8), m: (64, 1)}, args, {})
+    spec = OpSpec(
+        IDENTITY_OP,
+        False,
+        {n: (256, 8), m: (64, 1)},
+        args,
+        {LX_RELAYOUT_INFO_KEY: True},
+    )
     root, allocations = _compile_spec(spec)
     assert spec.op == IDENTITY_OP
     assert set(root["dscs_"][0]) == {"shuffle"}
@@ -736,18 +919,24 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
     ]
     assert root["numWkSlicesPerDim_"] == {"mb": 1, "x": 8, "out": 1}
     maps = [node["coordinates_"]["coreIdToWkSlice_"] for node in allocations]
-    assert [maps[0][str(i)]["x"] for i in range(8)] == [i % 4 for i in range(8)]
-    assert [maps[0][str(i)]["out"] for i in range(8)] == [i // 4 for i in range(8)]
+    assert [maps[0][str(i)]["x"] for i in range(8)] == [i // 2 for i in range(8)]
+    assert [maps[0][str(i)]["out"] for i in range(8)] == [i % 2 for i in range(8)]
     assert [maps[1][str(i)]["x"] for i in range(8)] == [i % 2 for i in range(8)]
     assert [maps[1][str(i)]["out"] for i in range(8)] == [i // 2 for i in range(8)]
     coord_info = [node["coordinates_"]["coordInfo"] for node in allocations]
     assert coord_info[0]["x"]["folds"]["dim_prop_func"][0]["Affine"]["alpha_"] == 2
     assert coord_info[1]["x"]["folds"]["dim_prop_func"][0]["Affine"]["alpha_"] == 4
     with pytest.raises(ValueError, match="cannot map device dimension"):
-        work_division_from_view(source_view, [Integer(0), m + n, Integer(0)], (m, n))
+        work_division_from_view(
+            source_view,
+            base.device_size,
+            [Integer(0), m + n, Integer(0)],
+            {m: 64, n: 256},
+        )
 
     for arg in spec.args:
         arg.work_division = None
+    spec.op_info = {}
     ordinary_root, ordinary_allocations = _compile_spec(spec, normalize=False)
     ordinary_sdsc, _ = parse_op_spec(spec)
     assert set(ordinary_root["dscs_"][0]) == {IDENTITY_OP}
@@ -784,8 +973,23 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
         "layout_solver": "greedy",
     }
 )
-@pytest.mark.parametrize("second_consumer", ["pointwise", "matmul_lhs", "matmul_rhs"])
+@pytest.mark.parametrize(
+    "second_consumer",
+    [
+        "pointwise",
+        "duplicate_pointwise",
+        "matmul_lhs",
+        "matmul_rhs",
+    ],
+)
 def test_lx_relayout_consumers_share_destination_view(second_consumer):
+    """Compile every foundation operation class through one relayout source.
+
+    This compact corpus covers ordinary pointwise (distinct and repeated
+    reads), BMM on either operand, and the relayout identity that connects
+    their differing LX views.
+    """
+
     torch.manual_seed(0)
     m_size = 64 if second_consumer == "matmul_rhs" else 32
     x = torch.randn(8, m_size, 64, dtype=torch.float16)
@@ -799,7 +1003,7 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
     ):
         _declare_tensor_dim(name, size)
 
-    shares_destination = second_consumer in ("pointwise", "matmul_lhs")
+    shares_destination = second_consumer != "matmul_rhs"
 
     def fn(x, weight):
         with spyre_hint(work_div={"B": 4, "M": 2}):
@@ -812,6 +1016,8 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
                 second = torch.bmm(hidden, weight)
             elif second_consumer == "matmul_rhs":
                 second = torch.bmm(weight, hidden)
+            elif second_consumer == "duplicate_pointwise":
+                second = hidden + hidden
             else:
                 second = torch.abs(hidden)
         return pointwise, second
@@ -858,30 +1064,91 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
     assert {pair[1] for pair in divisions} == expected_destinations
 
 
+@config.patch(
+    {
+        "sencores": 32,
+        "lx_planning": True,
+        "allow_all_ops_in_lx_planning": True,
+        "layout_solver": "greedy",
+    }
+)
+def test_unhinted_moe_down_route_uses_the_production_hbm_fallback():
+    """Record the production choice for an unhinted E=2 down->route edge.
+
+    The only hint creates the two-expert loop; there is deliberately no work
+    division hint. At this shape the cost model splits T=4, H=4, and the F
+    reduction=2. Since the output cannot own the reduction split, the existing
+    fail-closed path keeps down->route in HBM. The full 8x4 LX acceptance gate
+    belongs to the composed MoE stack, where its ownership proposer exists.
+    """
+
+    torch.manual_seed(0)
+    experts, tokens, intermediate, hidden = 2, 64, 128, 256
+    activations = torch.randn(experts, tokens, intermediate, dtype=torch.float16) * 0.01
+    weights = torch.randn(experts, intermediate, hidden, dtype=torch.float16) * 0.01
+    routes = torch.randn(experts, tokens, 1, dtype=torch.float16) * 0.01
+    for name, size in (
+        ("E", experts),
+        ("T", tokens),
+        ("F", intermediate),
+        ("H", hidden),
+        ("R", 1),
+    ):
+        _declare_tensor_dim(name, size)
+
+    def fn(activations, weights, routes):
+        with spyre_hint(num_tiles_per_dim={"E": experts}):
+            down = torch.bmm(activations, weights)
+            return down * routes
+
+    device_args = (
+        _name_tensor_dims(activations.to("spyre"), ["E", "T", "F"]),
+        _name_tensor_dims(weights.to("spyre"), ["E", "F", "H"]),
+        _name_tensor_dims(routes.to("spyre"), ["E", "T", "R"]),
+    )
+    torch._inductor.codecache.FxGraphCache.clear()
+    with _emitted_kernels() as kernels:
+        actual, _ = run_and_get_code(
+            torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+            *device_args,
+        )
+    torch.testing.assert_close(
+        actual.cpu(), fn(activations, weights, routes), rtol=0.05, atol=0.05
+    )
+    specs = [spec for kernel in kernels for spec in _iter_op_specs(kernel.op_specs)]
+    bmm_specs = [spec for spec in specs if spec.op == BATCH_MATMUL_OP]
+    assert len(bmm_specs) == 1
+    assert [split for _, split in bmm_specs[0].iteration_space.values()] == [4, 4, 2]
+    down_arg = next(arg for arg in bmm_specs[0].args if not arg.is_input)
+    assert set(down_arg.allocation) == {"hbm_pool"}
+    assert down_arg.work_division is None
+    down_address = down_arg.allocation["hbm_pool"]
+
+    route_reads = [
+        arg
+        for spec in specs
+        if spec.op != BATCH_MATMUL_OP
+        for arg in spec.args
+        if arg.is_input and arg.allocation.get("hbm_pool") == down_address
+    ]
+    assert len(route_reads) == 1
+    assert route_reads[0].work_division is None
+    assert not any(
+        spec.op == IDENTITY_OP
+        and any(arg.allocation.get("hbm_pool") == down_address for arg in spec.args)
+        for spec in specs
+    )
+
+
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):
     alternate_view = PerCoreView(((1, 8),), ((1, _CORE_ID),))
     plans = [
         _relayout_plan("source", ("consumer_a", "consumer_b")),
-        LXRelayoutPlan(
-            "source",
-            ("consumer_c",),
-            _SOURCE_VIEW,
-            alternate_view,
-            8,
-        ),
+        _relayout_plan("source", "consumer_c", destination_view=alternate_view),
     ]
     allocator = ScratchpadAllocator(GreedyLayoutSolver, 256)
-    graph = SimpleNamespace(
-        operations=[
-            SimpleNamespace(get_name=lambda name=name: name)
-            for name in (
-                "producer",
-                "consumer_a",
-                "consumer_b",
-                "consumer_c",
-                "ordinary_consumer",
-            )
-        ]
+    graph = _allocation_graph(
+        "producer", "consumer_a", "consumer_b", "consumer_c", "ordinary_consumer"
     )
     source = LifetimeBoundBuffer("source", 128, [0, 1, 2, 3])
     source.lx_relayout_plans = list(plans)
@@ -924,20 +1191,13 @@ def _assert_live_buffers_do_not_share_addresses(graph, buffers, limit):
 def test_lx_relayout_copies_loop_lifetime_to_every_destination():
     plans = [
         _relayout_plan("source", ("consumer_a", "consumer_b")),
-        LXRelayoutPlan(
+        _relayout_plan(
             "source",
-            ("consumer_c",),
-            _SOURCE_VIEW,
-            PerCoreView(((1, 8),), ((1, _CORE_ID),)),
-            8,
+            "consumer_c",
+            destination_view=PerCoreView(((1, 8),), ((1, _CORE_ID),)),
         ),
     ]
-    graph = SimpleNamespace(
-        operations=[
-            SimpleNamespace(get_name=lambda name=name: name)
-            for name in ("producer", "consumer_a", "consumer_b", "consumer_c")
-        ]
-    )
+    graph = _allocation_graph("producer", "consumer_a", "consumer_b", "consumer_c")
     source = LifetimeBoundBuffer("source", 64, [0, 1, 2, 3], lifetime_end_override=6)
     source.lx_relayout_plans = list(plans)
     buffers = [source]
@@ -953,12 +1213,7 @@ def test_lx_relayout_copies_loop_lifetime_to_every_destination():
 
 
 def test_lx_relayout_keeps_source_lifetime_for_later_original_reader():
-    graph = SimpleNamespace(
-        operations=[
-            SimpleNamespace(get_name=lambda name=name: name)
-            for name in ("producer", "relayout_consumer", "ordinary_consumer")
-        ]
-    )
+    graph = _allocation_graph("producer", "relayout_consumer", "ordinary_consumer")
     source = LifetimeBoundBuffer("source", 64, [0, 1, 2], lifetime_end_override=4)
     source.lx_relayout_plans = [_relayout_plan("source", "relayout_consumer")]
     buffers = [source]
@@ -985,134 +1240,44 @@ class _RelayoutNode:
     def get_name(self):
         return self.name
 
+    def get_device(self):
+        return None
+
+    is_template = is_extern = is_foreach = staticmethod(lambda: False)
+
+
+def test_lx_layout_ignores_none_layout_without_hiding_other_layout_errors():
+    class NoneLayoutBuffer:
+        layout = NoneLayout(device=None)
+
+        def get_layout(self):
+            raise AssertionError("NoneLayout must be rejected before get_layout")
+
+    class BrokenBuffer:
+        layout = object()
+
+        def get_layout(self):
+            raise NotImplementedError("unexpected concrete-layout failure")
+
+    buffers = {"none": NoneLayoutBuffer(), "broken": BrokenBuffer()}
+    graph = SimpleNamespace(try_get_buffer=buffers.get)
+    with mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)):
+        assert scheduler_module._lx_layout("none") is None
+        with pytest.raises(
+            NotImplementedError, match="unexpected concrete-layout failure"
+        ):
+            scheduler_module._lx_layout("broken")
+
 
 def _relayout_layout(address, view):
     # FixedTiledLayout always carries the final physical device layout.  Keep
     # that field in the test double so ownership verification exercises the
     # same contract as the real post-allocation pipeline.
     return SimpleNamespace(
-        allocation={"lx": address}, lx_view=view, device_layout=object()
+        allocation={"lx": address},
+        lx_view=view,
+        device_layout=SimpleNamespace(device_size=(8, 8)),
     )
-
-
-def test_lx_relayout_scheduler_checks_final_ownership_projection():
-    m, n = Symbol("m"), Symbol("n")
-    layout = SimpleNamespace(device_layout=object())
-    graph = SimpleNamespace(
-        try_get_buffer=lambda name: (
-            SimpleNamespace(get_layout=lambda: layout) if name == "source" else None
-        )
-    )
-    node, dep = SimpleNamespace(), SimpleNamespace()
-
-    def projectable(coordinates):
-        with (
-            mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
-            mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
-            mock_patch.object(
-                scheduler_module,
-                "try_device_coordinates",
-                return_value=coordinates,
-            ),
-            mock_patch.object(
-                scheduler_module, "iteration_space", return_value={m: 32, n: 64}
-            ),
-        ):
-            return scheduler_module._ownership_projectable(
-                node, dep, "source", _SOURCE_VIEW
-            )
-
-    assert projectable([m, n])
-    assert not projectable([m + n, n])
-
-
-def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
-    def run_registered(drift):
-        plan = _relayout_plan()
-        src, dst = SimpleNamespace(name="source"), SimpleNamespace(name="destination")
-        unary_src = SimpleNamespace(name="ordinary_source")
-        unary_dst = SimpleNamespace(name="ordinary_unary")
-        layouts = {
-            "source": _relayout_layout(0, _SOURCE_VIEW),
-            "destination": _relayout_layout(256, _DESTINATION_VIEW),
-            "ordinary_source": _relayout_layout(512, _SOURCE_VIEW),
-            "ordinary_unary": _relayout_layout(768, _DESTINATION_VIEW),
-        }
-        node = _RelayoutNode
-        nodes = [
-            node("source", writes=(src,), layout=layouts["source"]),
-            node("destination", (src,), (dst,), layouts["destination"]),
-            node("consumer", reads=(dst,)),
-            node(
-                "ordinary_source",
-                writes=(unary_src,),
-                layout=layouts["ordinary_source"],
-            ),
-            node(
-                "ordinary_unary", (unary_src,), (unary_dst,), layouts["ordinary_unary"]
-            ),
-            node("ordinary_consumer", reads=(unary_dst,)),
-        ]
-        if drift == "missing":
-            nodes = [node for node in nodes if node.name != "destination"]
-        buffers = {
-            name: SimpleNamespace(
-                layout=SimpleNamespace(),
-                get_layout=lambda layout=layout: layout,
-            )
-            for name, layout in layouts.items()
-        }
-        if drift == "missing_buffer":
-            del buffers["destination"]
-        graph = SimpleNamespace(
-            _spyre_lx_relayout_copies={plan.edge: ("destination", plan)},
-            try_get_buffer=buffers.get,
-            get_buffer=buffers.__getitem__,
-        )
-
-        def view(node, _dep, name):
-            if name == "ordinary_source":
-                expected = (
-                    _DESTINATION_VIEW if node.name == "ordinary_unary" else _SOURCE_VIEW
-                )
-            else:
-                expected = _SOURCE_VIEW if name == "source" else _DESTINATION_VIEW
-            return (
-                PerCoreView((), ()) if node.name == drift else expected,
-                False,
-                True,
-            )
-
-        with (
-            mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
-            mock_patch.object(scheduler_module, "MemoryDep", SimpleNamespace),
-            mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
-            mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace),
-            mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
-            mock_patch.object(scheduler_module, "per_core_view_scheduled", view),
-            mock_patch.object(
-                scheduler_module,
-                "_ownership_projectable",
-                side_effect=lambda node, _dep, _name, _view: (
-                    not (drift == "projection" and node.name == "consumer")
-                ),
-            ),
-            config.patch({"lx_planning": True}),
-        ):
-            scheduler_module.demote_incoherent_lx_buffers(nodes)
-        assert graph._spyre_lx_relayout_copies == {}
-        assert "lx" not in layouts["source"].allocation
-        if drift != "missing_buffer":
-            assert "lx" not in layouts["destination"].allocation
-            assert layouts["destination"].lx_view is None
-        assert "lx" not in layouts["ordinary_source"].allocation
-        assert "lx" in layouts["ordinary_unary"].allocation
-
-    run_registered("source")
-    run_registered("consumer")
-    run_registered("projection")
-    run_registered("missing")
-    run_registered("missing_buffer")
 
 
 class _CarriedReductionDep:
@@ -1120,14 +1285,8 @@ class _CarriedReductionDep:
         self.name = name
 
 
-def _verify_carried_reduction(
-    drift=None, wrong_logical_dim=False, scheduled_rank_mismatch=False
-):
+def _verify_carried_reduction(missing_view=False):
     accumulator = "fill"
-    operation_row = Symbol("d0")
-    operation_other = Symbol("d1")
-    scheduled_row = Symbol("c0")
-    scheduled_other = Symbol("c1")
     record = CarriedReductionRecord(
         accumulator_name=accumulator,
         row_dim_name="T",
@@ -1144,52 +1303,19 @@ def _verify_carried_reduction(
     ]
     for node in nodes:
         node.node._carried_reduction_record = record
-        node.node.work_div_loop_info = {
-            operation_row: ["T"],
-            operation_other: ["H"],
-        }
 
-    layout = _relayout_layout(0, _SOURCE_VIEW)
+    layout = _relayout_layout(0, None if missing_view else _SOURCE_VIEW)
     graph = SimpleNamespace(
         try_get_buffer=lambda name: (
             SimpleNamespace(get_layout=lambda: layout) if name == accumulator else None
         )
     )
 
-    def view(node, _dep, _name):
-        realized = _DESTINATION_VIEW if node.name == drift else _SOURCE_VIEW
-        return realized, False, True
-
-    def work_division(_view, _coordinates, _symbols):
-        symbol = scheduled_other if wrong_logical_dim else scheduled_row
-        return SimpleNamespace(work_slices={symbol: 8})
-
     with (
         mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
         mock_patch.object(scheduler_module, "MemoryDep", _CarriedReductionDep),
         mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
         mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
-        mock_patch.object(scheduler_module, "per_core_view_scheduled", view),
-        mock_patch.object(
-            scheduler_module, "try_device_coordinates", return_value=[scheduled_row]
-        ),
-        mock_patch.object(
-            scheduler_module,
-            "iteration_space_from_op",
-            return_value={operation_row: 64, operation_other: 64},
-        ),
-        mock_patch.object(
-            scheduler_module,
-            "iteration_space",
-            return_value=(
-                {scheduled_row: 64}
-                if scheduled_rank_mismatch
-                else {scheduled_row: 64, scheduled_other: 64}
-            ),
-        ),
-        mock_patch.object(
-            scheduler_module, "work_division_from_view", side_effect=work_division
-        ),
     ):
         return scheduler_module.verify_carried_reduction_ownership(nodes)
 
@@ -1202,19 +1328,45 @@ def test_carried_reduction_verifier_accepts_matching_final_ownership():
     ]
 
 
-def test_carried_reduction_verifier_rejects_final_ownership_drift():
-    with pytest.raises(Unsupported, match="does not match accumulator ownership"):
-        _verify_carried_reduction(drift="drain")
+def test_carried_reduction_verifier_requires_physical_ownership():
+    with pytest.raises(Unsupported, match="LX address but no physical ownership"):
+        _verify_carried_reduction(missing_view=True)
 
 
-def test_carried_reduction_verifier_rejects_same_count_on_wrong_dimension():
-    with pytest.raises(Unsupported, match="expected only T split=8"):
-        _verify_carried_reduction(wrong_logical_dim=True)
+@config.patch(
+    {
+        "sencores": 32,
+        "lx_planning": True,
+        "allow_all_ops_in_lx_planning": True,
+        "layout_solver": "greedy",
+    }
+)
+def test_carried_reduction_stages_compile_to_a_drain():
+    """Compile the real fill/combine/drain nodes, not hand-built descriptors."""
 
+    torch.manual_seed(0)
+    experts, tokens, hidden = 2, 64, 64
+    values = torch.randn(experts, tokens, hidden, dtype=torch.float16) * 0.1
+    for name, size in (("E", experts), ("T", tokens), ("H", hidden)):
+        _declare_tensor_dim(name, size)
 
-def test_carried_reduction_verifier_rejects_scheduler_rank_change():
-    with pytest.raises(Unsupported, match="changed iteration rank"):
-        _verify_carried_reduction(scheduled_rank_mismatch=True)
+    def fn(values):
+        _name_tensor_dims(values, ["E", "T", "H"])
+        with spyre_hint(
+            num_tiles_per_dim={"E": experts},
+            work_div={"T": 32},
+        ):
+            return values.sum(dim=0)
+
+    device_values = _name_tensor_dims(values.to("spyre"), ["E", "T", "H"])
+    torch._inductor.codecache.FxGraphCache.clear()
+    actual, code = run_and_get_code(
+        torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+        device_values,
+    )
+
+    torch.testing.assert_close(actual.cpu(), fn(values), atol=0.05, rtol=0.05)
+    assert "coarse_tile_reduction_drain" in "\n".join(code)
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -18,6 +18,7 @@ from dataclasses import replace
 import json
 import logging
 import logging.handlers
+import math
 import os
 from pathlib import Path
 import regex as re
@@ -1118,7 +1119,11 @@ def test_unhinted_moe_down_route_uses_the_production_hbm_fallback():
     specs = [spec for kernel in kernels for spec in _iter_op_specs(kernel.op_specs)]
     bmm_specs = [spec for spec in specs if spec.op == BATCH_MATMUL_OP]
     assert len(bmm_specs) == 1
-    assert [split for _, split in bmm_specs[0].iteration_space.values()] == [4, 4, 2]
+    # Alignment can append range-1 loops for elided device dimensions. Check
+    # the requested T4/H4/K2 division, not the number of aligned loop symbols.
+    splits = [split for _, split in bmm_specs[0].iteration_space.values()]
+    assert [split for split in splits if split > 1] == [4, 4, 2]
+    assert math.prod(splits) == config.sencores
     down_arg = next(arg for arg in bmm_specs[0].args if not arg.is_input)
     assert set(down_arg.allocation) == {"hbm_pool"}
     assert down_arg.work_division is None

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -1320,7 +1320,7 @@ def _verify_carried_reduction(missing_view=False):
         return scheduler_module.verify_carried_reduction_ownership(nodes)
 
 
-def test_carried_reduction_verifier_accepts_matching_final_ownership():
+def test_carried_reduction_verifier_accepts_preserved_stages_and_view():
     assert [node.name for node in _verify_carried_reduction()] == [
         "fill",
         "combine",

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -195,7 +195,7 @@ def core_idx_to_slice_offset(
 def num_bytes(df: DataFormats) -> int:
     """Try to avoid using this method; it is a bad API due to sub-byte datatypes"""
     num_elems = df.elems_per_stick()
-    if num_elems > 128:
+    if num_elems > BYTES_PER_STICK:
         raise RuntimeError(f"sub-byte dataformat {df}")
     return 128 // num_elems
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -195,7 +195,7 @@ def core_idx_to_slice_offset(
 def num_bytes(df: DataFormats) -> int:
     """Try to avoid using this method; it is a bad API due to sub-byte datatypes"""
     num_elems = df.elems_per_stick()
-    if num_elems > BYTES_PER_STICK:
+    if num_elems > 128:
         raise RuntimeError(f"sub-byte dataformat {df}")
     return 128 // num_elems
 

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -1837,7 +1837,7 @@ def _finalize_tensor_work_divisions(
 def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     is_matmul = _is_matmul(op_spec.op)
     is_conv2d = _is_conv(op_spec.op)
-    is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
+    is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args, op_spec.op_info)
     is_restickify = op_spec.op == RESTICKIFY_OP
     is_pool = _is_pool(op_spec.op)
     is_conv = _is_conv(op_spec.op)

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -83,8 +83,9 @@ ktir_emitter: bool = os.environ.get("TORCH_SPYRE_KTIR", "0") == "1"
 # A .mlir declaring the target device, passed to the backend compiler.
 ktir_device_mlir: str = os.environ.get("KTIR_DEVICE_MLIR", "")
 
-# Materialize compatible producer/consumer LX ownership changes as identity copies.
-# Set SPYRE_LX_PLANNER_RELAYOUT=0 to disable this optimization.
+# Enable certified LX ownership changes.
+# Set SPYRE_LX_PLANNER_RELAYOUT=0 to disable these optional optimizations, not
+# ownership validation. This does not change the allocator or LX memory budget.
 lx_planner_relayout: bool = os.getenv("SPYRE_LX_PLANNER_RELAYOUT", "1").lower() in (
     "1",
     "true",

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -20,7 +20,7 @@ import math
 from collections.abc import Mapping, Sequence
 from functools import lru_cache
 from itertools import permutations
-from typing import Any
+from typing import Any, Callable
 
 from sympy import Expr, Integer, Mod, Symbol, floor, sympify
 
@@ -30,6 +30,27 @@ from .op_spec import TensorWorkDivision
 # pass_utils imports this module; keep its PerCoreView type out of this layer.
 # TensorWorkDivision imports the comparator only when its method is called.
 _MAX_OWNER_PERMUTATION_DIMS = 5
+
+
+_MAX_EXACT_OWNERSHIP_POINTS = 1024
+
+
+_MAX_EXACT_DIRECT_AXIS_POINTS = 1 << 16
+_LOOP_POINT = Symbol("direct_axis_loop", integer=True, nonnegative=True)
+# Evaluating symbolic coordinates can fail in many ways; each is a rejected
+# proof, never a compiler crash.
+_EVALUATION_ERRORS = (
+    AttributeError,
+    ImportError,
+    KeyError,
+    NameError,
+    NotImplementedError,
+    OverflowError,
+    SyntaxError,
+    TypeError,
+    ValueError,
+    ZeroDivisionError,
+)
 
 
 # Room for 128 distinct formulas on a 32-core device; eviction only repeats work.
@@ -102,6 +123,197 @@ def same_owner_maps(
         )
     except KeyError:
         return False
+
+
+@lru_cache(maxsize=256)
+def _loop_regions(
+    extent: int,
+    coordinates: tuple[Expr, ...],
+    device_extents: tuple[int, ...],
+    split: int,
+    rectangles: bool = False,
+) -> tuple[tuple[tuple[int, int], ...], ...]:
+    """Bounds on each original axis for each contiguous loop partition.
+
+    The ordinary index parser supplies quotient/remainder factors. Bounds use
+    integer arithmetic at partition endpoints, including modulo wrap. Creating
+    a view additionally requires an injective, hole-free rectangle; reading a
+    view only requires containment, so diagonal and gapped reads remain legal.
+    """
+    from sympy import simplify
+    from torch.utils._sympy.functions import FloorDiv
+
+    from .errors import Unsupported
+    from .views import Term
+
+    terms = []
+    try:
+        for coordinate, size in zip(coordinates, device_extents):
+            expr = coordinate.replace(floor, lambda x: x)
+            offset = expr.subs(_LOOP_POINT, 0)
+            term = Term.from_coordinate(
+                expr - offset, _LOOP_POINT, Integer(extent), size
+            )
+            term.offset = offset
+            num, den, mod, offset = map(
+                int, (term.num, term.den, term.mod, term.offset)
+            )
+            if (
+                (num, den, mod, offset) != (term.num, term.den, term.mod, term.offset)
+                or num == 0
+                or den <= 0
+                or mod <= 0
+            ):
+                raise ValueError("not an integer term")
+            # The aligner's historical floor/offset assumptions are not an
+            # ownership proof. Check the unmodified expression before reuse.
+            rebuilt = num * floor(Mod(_LOOP_POINT, mod) / den) + offset
+            original = coordinate.replace(FloorDiv, lambda a, b: floor(a / b))
+            delta = (original - rebuilt).xreplace(
+                {Mod(_LOOP_POINT, extent): _LOOP_POINT}
+            )
+            if simplify(delta) != 0:
+                raise ValueError("normalization changes this coordinate")
+            terms.append((num, den, mod, offset))
+    except (Unsupported, AssertionError, TypeError, ValueError):
+        terms = []
+
+    # A chain of quotient/remainder digits determines the original loop value.
+    # Otherwise the bounded exact fallback checks uniqueness, not just bounds.
+    known_modulus = 1
+    for _, den, mod, _ in sorted(terms, key=lambda t: t[1]):
+        if known_modulus % den == 0 and mod % known_modulus == 0:
+            known_modulus = mod
+    analytic = bool(terms) and (not rectangles or known_modulus >= extent)
+    result = []
+    width = extent // split
+    for slot in range(split):
+        first, last = slot * width, (slot + 1) * width - 1
+        if analytic:
+            bounds = []
+            for num, den, mod, offset in terms:
+                low, high = first % mod // den, last % mod // den
+                if first // mod != last // mod:
+                    low, high = 0, (mod - 1) // den
+                bounds.append(tuple(sorted((num * low + offset, num * high + offset))))
+        else:
+            points = [
+                tuple(sympify(c).subs(_LOOP_POINT, p) for c in coordinates)
+                for p in range(first, last + 1)
+            ]
+            if any(value.is_integer is not True for row in points for value in row):
+                raise ValueError("coordinates must be integral")
+            bounds = list(zip(map(min, zip(*points)), map(max, zip(*points))))
+            if rectangles and len(set(points)) != width:
+                raise ValueError("fused partition repeats an element")
+        if any(
+            low < 0 or high >= size for (low, high), size in zip(bounds, device_extents)
+        ):
+            raise ValueError("loop partition is off-axis")
+        if rectangles and math.prod(high - low + 1 for low, high in bounds) != width:
+            raise ValueError("fused partitions are not one rectangle shape")
+        result.append(tuple((int(low), int(high)) for low, high in bounds))
+    return tuple(result)
+
+
+def direct_axis_ownership_failure(
+    extent: int, split: int, coordinate: Expr, device_extent: int, physical_split: int
+) -> str | None:
+    """Check the stride proposal: loop partition p must stay in physical slice p."""
+    if extent > _MAX_EXACT_DIRECT_AXIS_POINTS:
+        return f"proof limit: direct axis needs {extent} points; limit is {_MAX_EXACT_DIRECT_AXIS_POINTS}"
+    if split <= 0 or extent % split or device_extent <= 0 or device_extent % split:
+        return "unsupported ownership input: incompatible extents, splits or cores"
+    if split != physical_split:
+        return "ownership mismatch: logical and physical split counts differ"
+    try:
+        regions = _loop_regions(extent, (coordinate,), (device_extent,), split)
+        width = device_extent // split
+        signatures = []
+        for ((low, high),) in regions:
+            if low // width != high // width:
+                return "ownership mismatch: one loop partition crosses physical slices"
+            signatures.append(low // width)
+        if len(set(signatures)) != split:
+            return "ownership mismatch: loop partitions do not cover distinct physical slices"
+        if signatures != list(range(split)):
+            return "ownership mismatch: loop and physical slices have different core owners"
+        return None
+    except _EVALUATION_ERRORS as exc:
+        return f"unsupported ownership evaluation: {type(exc).__name__}: {exc}"
+
+
+def select_unique_partition_division(
+    dimensions: Sequence[Symbol],
+    work_slices: Mapping[Symbol, int],
+    num_cores: int,
+    matches: Callable[[TensorWorkDivision], bool],
+    *,
+    rejection_reasons: list[str] | None = None,
+) -> TensorWorkDivision | None:
+    """Return the sole standard dimension order accepted by ``matches``.
+
+    This bounded search only tries mappings produced by the existing canonical
+    partition generator. The caller supplies the exact ownership proof; two
+    distinct accepted owner maps are ambiguity and fail closed.
+    Optional reasons belong to this call only and never steer the search.
+    """
+
+    def reject(reason: str) -> None:
+        if rejection_reasons is not None:
+            rejection_reasons.append(reason)
+
+    split_by_dim = {
+        dim: int(work_slices[dim])
+        for dim in dimensions
+        if int(work_slices.get(dim, 1)) > 1
+    }
+    if set(split_by_dim) != {
+        dim for dim, split in work_slices.items() if int(split) > 1
+    }:
+        reject("unsupported ownership input: candidate dimension keys differ")
+        return None
+    split_dims = tuple(split_by_dim)
+    if not split_dims:
+        reject("no canonical candidate: there are no split dimensions")
+        return None
+    if len(split_dims) > _MAX_OWNER_PERMUTATION_DIMS:
+        reject(
+            f"proof limit: canonical search has {len(split_dims)} split dimensions; "
+            f"limit is {_MAX_OWNER_PERMUTATION_DIMS}"
+        )
+        return None
+
+    # Mapping order and field order are separate. Keep the caller's field order
+    # stable while trying the bounded set of canonical owner formulas.
+    candidate_splits = {dim: int(split) for dim, split in work_slices.items()}
+    accepted: list[TensorWorkDivision] = []
+    for order in permutations(split_dims):
+        try:
+            mapping = derive_partition_mapping(
+                order,
+                tuple(split_by_dim[dim] for dim in order),
+                num_cores,
+            )
+            candidate = TensorWorkDivision(
+                candidate_splits,
+                {dim: mapping.get(dim, Integer(0)) for dim in candidate_splits},
+                num_cores=num_cores,
+            )
+        except ValueError as exc:
+            reject(f"unsupported ownership candidate: {exc}")
+            continue
+        if matches(candidate) and not any(
+            previous.same_ownership(candidate) for previous in accepted
+        ):
+            accepted.append(candidate)
+            if len(accepted) > 1:
+                reject("ambiguous ownership: multiple canonical maps matched")
+                return None
+    if accepted:
+        return accepted[0]
+    reject("no canonical candidate matched")
+    return None
 
 
 def core_to_slice_mapping(
@@ -179,7 +391,10 @@ def derive_core_mapping(
     grouped_splits = dict(grouped_splits or {})
     unknown_dims = grouped_splits.keys() - split_by_dim.keys()
     if unknown_dims:
-        raise ValueError(f"grouped dimensions are not in the operation: {unknown_dims}")
+        raise ValueError(
+            "grouped dimensions are not in the operation: "
+            f"{sorted(map(str, unknown_dims))}"
+        )
     for dim, split in grouped_splits.items():
         if int(split) != split_by_dim[dim]:
             raise ValueError(
@@ -250,7 +465,7 @@ def derive_partition_mapping(
     dims = tuple(dims)
     splits = tuple(int(split) for split in dim_splits)
     owner_count = math.prod(splits)
-    if owner_count <= 0 or num_cores % owner_count:
+    if owner_count <= 0 or num_cores <= 0 or num_cores % owner_count:
         raise ValueError(
             f"partition owner count must divide num_cores: {owner_count}, {num_cores}"
         )
@@ -277,7 +492,9 @@ def remap_work_division(
     new_splits: dict[Symbol, int] = {}
     new_core_map: dict[Symbol, Expr] = {}
     for old_dim, split in division.work_slices.items():
-        new_dims = dimension_remap[old_dim]
+        new_dims = dimension_remap.get(old_dim)
+        if new_dims is None:
+            raise ValueError(f"tensor ownership dimension {old_dim} has no alignment")
         remaining_split = int(split)
         split_factors: list[tuple[Symbol, int]] = []
         if len(new_dims) == 1:
@@ -324,7 +541,7 @@ def finalize_tensor_work_divisions(
     iteration_space: Mapping[Symbol, tuple[Expr, int]],
     divisions: Sequence[TensorWorkDivision | None],
 ) -> tuple[TensorWorkDivision | None, ...]:
-    """Derive each tensor's owners from its final aligned partition."""
+    """Verify committed tensor owners in the final aligned iteration space."""
 
     result: list[TensorWorkDivision | None] = []
     for division in divisions:
@@ -339,24 +556,23 @@ def finalize_tensor_work_divisions(
         unknown_dims = work_slices.keys() - iteration_space.keys()
         if unknown_dims:
             raise ValueError(
-                f"tensor ownership dimensions are not aligned: {unknown_dims}"
+                "tensor ownership dimensions are not aligned: "
+                f"{sorted(map(str, unknown_dims))}"
             )
 
-        if division.num_cores is None:
+        try:
+            core_map = {dim: division.core_id_to_work_slice[dim] for dim in work_slices}
+        except KeyError as exc:
             raise ValueError(
-                "tensor ownership must carry its physical core domain before alignment"
-            )
-        result.append(
-            TensorWorkDivision(
-                work_slices,
-                derive_partition_mapping(
-                    tuple(work_slices),
-                    tuple(work_slices.values()),
-                    division.num_cores,
-                ),
-                num_cores=division.num_cores,
-            )
+                f"tensor ownership has no owner for {exc.args[0]}"
+            ) from exc
+        verified = TensorWorkDivision(
+            work_slices,
+            core_map,
+            num_cores=division.physical_core_count,
         )
+        verified.to_core_slices(verified.physical_core_count)
+        result.append(verified)
     return tuple(result)
 
 
@@ -376,7 +592,7 @@ def derive_operation_mapping(
     for division in tensor_divisions:
         if division is None:
             continue
-        if division.work_slices and division.physical_core_count != num_cores:
+        if division.physical_core_count != num_cores:
             raise ValueError(
                 "LX tensor ownership and operation use different core domains: "
                 f"{division.physical_core_count} != {num_cores}"
@@ -404,6 +620,20 @@ def derive_operation_mapping(
             contiguous_dim=contiguous_dim,
         )
 
+    # Preserve main's operation map whenever it already satisfies the physical
+    # tensor owners. The grouped search below is only needed when it does not.
+    default = derive_core_mapping(
+        dims,
+        splits,
+        num_cores,
+        contiguous_dim=contiguous_dim,
+    )
+    if all(
+        core_mappings_equal({dim: default[dim]}, {dim: expression}, num_cores)
+        for dim, expression in constrained.items()
+    ):
+        return default
+
     # Tensor-owned dimensions occupy the outer, contiguous groups. At most five
     # dimensions can be split on 32 cores, so trying their radix orders is small.
     if len(constrained) > _MAX_OWNER_PERMUTATION_DIMS:
@@ -411,7 +641,7 @@ def derive_operation_mapping(
             "too many aligned tensor-owned dimensions for bounded core-order "
             f"search: {len(constrained)} > {_MAX_OWNER_PERMUTATION_DIMS}"
         )
-    for order in permutations(constrained):
+    for order in permutations(sorted(constrained, key=str)):
         candidate = derive_core_mapping(
             dims,
             splits,

--- a/torch_spyre/_inductor/enforce_indirect_access_layout.py
+++ b/torch_spyre/_inductor/enforce_indirect_access_layout.py
@@ -60,6 +60,7 @@ from .pass_utils import (
     device_coordinates,
     indirect_info_from_op,
     iteration_space_from_op,
+    iteration_space_with_splits,
     padded_entry_output_stl,
 )
 from .views import AlignmentInputs, UnalignedStickSplit, align_tensors_pure
@@ -354,12 +355,12 @@ def _scatter_alignment_inputs(
             AlignmentAccess(overrides.get(dep.name, layout.device_layout), dep.index)
         )
     accesses.append(AlignmentAccess(output_layout.device_layout, write_dep.index))
+    space = iteration_space_from_op(op)
     return build_operation_alignment_inputs(
-        iteration_space_from_op(op),
+        space,
         accesses,
+        iteration_space_with_splits(op, read_writes, space),
         indirect_sizes=indirect_sizes,
-        op=op,
-        read_writes=read_writes,
     )
 
 

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -29,6 +29,9 @@ from torch_spyre import _C
 from .constants import IDENTITY_OP
 
 
+LX_RELAYOUT_INFO_KEY = "lx_relayout_certified"
+
+
 class IndirectAccess(Function):
     """Sympy function: IndirectAccess(tensor_name) — runtime index read from that tensor at the current iteration point.
 
@@ -277,19 +280,25 @@ class TensorArg:
     work_division: TensorWorkDivision | None = None
 
 
-def is_lx_relayout_identity(op: str, args: Sequence[TensorArg]) -> bool:
-    """An LX identity whose input and output have different owners."""
+def is_lx_relayout_identity(
+    op: str,
+    args: Sequence[TensorArg],
+    op_info: dict[str, Any] | None = None,
+) -> bool:
+    """A planner-certified LX identity moving between different owners."""
 
-    if op != IDENTITY_OP or len(args) != 2:
+    if not op_info or not op_info.get(LX_RELAYOUT_INFO_KEY):
         return False
+    if op != IDENTITY_OP or len(args) != 2:
+        raise ValueError("certified LX relayout must be a two-argument identity")
     source, destination = args
-    return (
-        "lx" in source.allocation
-        and "lx" in destination.allocation
-        and source.work_division is not None
-        and destination.work_division is not None
-        and not source.work_division.same_ownership(destination.work_division)
-    )
+    if "lx" not in source.allocation or "lx" not in destination.allocation:
+        raise ValueError("certified LX relayout lost an LX allocation")
+    if source.work_division is None or destination.work_division is None:
+        raise ValueError("certified LX relayout lost a tensor work division")
+    if source.work_division.same_ownership(destination.work_division):
+        raise ValueError("certified LX relayout ownership collapsed")
+    return True
 
 
 @dataclasses.dataclass

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -88,6 +88,14 @@ class AlignmentAccess:
     index: sympy.Expr
 
 
+def input_layout_for_operation(op: Operation, name: str, default: Any) -> Any:
+    """Return the input descriptor every compiler phase must use for ``name``."""
+
+    overrides = getattr(op, "_input_layout_overrides", {})
+    override = overrides.get(name)
+    return default if override is None else override
+
+
 def _fixed_read_layout(buf) -> "FixedTiledLayout":
     layout = buf.get_layout()
     if isinstance(layout, MutationLayoutSHOULDREMOVE):
@@ -179,11 +187,10 @@ def op_read_writes(op: Operation) -> ReadWrites:
     """``op.get_read_writes()`` memoized on the op instance.
 
     ``ComputedBuffer.get_read_writes`` re-runs sympy dependency extraction on
-    every call and is not cached upstream, yet its result does not depend on the
-    only thing the LX planner mutates (``op_it_space_splits``). The scratchpad
-    pass calls it hundreds of times, so we cache it under a private key only this
-    helper reads -- a non-planner caller (e.g. later-pass codegen) still goes
-    through the real method.
+    every call and is not cached upstream, yet its result does not depend on
+    work-division metadata. The scratchpad pass calls it hundreds of times, so
+    we cache it under a private key only this helper reads -- a non-planner
+    caller (e.g. later-pass codegen) still goes through the real method.
     """
     rw = op.__dict__.get("_ts_cached_read_writes")
     if rw is None:
@@ -210,8 +217,8 @@ def invalidate_op_read_writes(op: Operation) -> None:
     swapping a load name in its ``inner_fn`` -- so the next
     :func:`op_read_writes` re-traces instead of returning stale reads/writes.
     The memo is keyed on the op instance and is otherwise never invalidated: its
-    result is independent of ``op_it_space_splits`` (the only thing the LX
-    planner normally mutates), so a plain split change needs no invalidation.
+    result is independent of work-division metadata, so a plain ownership or
+    split change needs no invalidation.
     """
     op.__dict__.pop("_ts_cached_read_writes", None)
 
@@ -1200,9 +1207,8 @@ def alignment_coordinates(
 ) -> list[sympy.Expr]:
     """Build the coordinates consumed by tensor alignment.
 
-    Scheduler validation and codegen must prepare identical inputs for
-    ``align_tensors``.  Keep index concretization and coordinate construction in
-    this one helper so the validation preview cannot drift from real codegen.
+    Placement checks and kernel preparation share index concretization and
+    coordinate construction. Emission consumes the prepared kernel.
     """
 
     # device_size and stride_map come from the C++ SpyreTensorLayout and are
@@ -1222,43 +1228,36 @@ def alignment_coordinates(
 def build_operation_alignment_inputs(
     raw_iteration_space: dict[sympy.Symbol, sympy.Expr],
     accesses: Sequence[AlignmentAccess],
+    aligned_iteration_space: dict[sympy.Symbol, tuple[sympy.Expr, int]],
     *,
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
     repeat_info: "dict[sympy.Symbol, dict] | None" = None,
-    op: ComputedBuffer | None = None,
-    read_writes: ReadWrites | None = None,
-    aligned_iteration_space: (dict[sympy.Symbol, tuple[sympy.Expr, int]] | None) = None,
 ) -> AlignmentInputs:
     """Build the complete, immutable input to tensor alignment.
 
-    Codegen may supply its already-finalized iteration space when an operation
-    has an op-specific extension.  Scheduler preview supplies ``op`` and
-    ``read_writes`` and gets the standard split-aware space.  Coordinate and
-    indirect-symbol preparation are shared in both cases.
+    The caller supplies the operation's split-aware iteration space, either
+    the standard one from ``iteration_space_with_splits`` or its op-specific
+    extension.  Coordinate and indirect-symbol preparation happen here.
     """
 
-    if aligned_iteration_space is None:
-        if op is None or read_writes is None:
-            raise ValueError(
-                "alignment input construction requires either a finalized "
-                "iteration space or an operation and its dependencies"
-            )
-        aligned_iteration_space = iteration_space_with_splits(
-            op, read_writes, raw_iteration_space
-        )
-
-    if indirect_sizes is None and op is not None:
-        indirect_sizes = indirect_sizes_from_op(op)
     resolved_indirect_sizes = dict(indirect_sizes or {})
     if resolved_indirect_sizes:
         # Dependency extraction can recreate an equivalent Symbol with
         # different assumptions.  Bind the Symbol present in the real index to
-        # the recovered range so preview and codegen normalize the same input.
+        # the recovered range so placement and preparation normalize it alike.
         size_by_name = {str(dim): size for dim, size in resolved_indirect_sizes.items()}
         for access in accesses:
             for dim in access.index.free_symbols - raw_iteration_space.keys():
                 if dim not in resolved_indirect_sizes and str(dim) in size_by_name:
                     resolved_indirect_sizes[dim] = size_by_name[str(dim)]
+        used_symbols = set().union(*(access.index.free_symbols for access in accesses))
+        # Earlier operations' unused index bindings are not inputs to this
+        # operation's alignment or ownership proof.
+        resolved_indirect_sizes = {
+            dim: size
+            for dim, size in resolved_indirect_sizes.items()
+            if dim in used_symbols
+        }
 
     repeat_snapshot = {
         symbol: dict(info) for symbol, info in (repeat_info or {}).items()
@@ -1733,9 +1732,9 @@ def make_iteration_space_ownership(
         )
         else None
     )
-    # Keep the selected mapping with the splits for the planned codegen handoff.
-    # Scheduler still reconstructs it from coefficient transport today; meanwhile
-    # retaining it lets the boundary diagnose aliases with different ownership.
+    # Keep the selected mapping with its splits through LX planning. Physical
+    # views preserve this core order after the legacy scheduler transport keeps
+    # only the operation's split counts.
     return TensorWorkDivision(
         work_slices,
         core_to_slice_mapping(
@@ -1753,6 +1752,35 @@ def commit_iteration_space_ownership(
 ) -> None:
     """Commit pre-scheduler symbol-keyed split and core ownership."""
     op.iteration_space_ownership = make_iteration_space_ownership(op, splits)
+
+
+def commit_tensor_work_division(op: Operation, ownership: TensorWorkDivision) -> None:
+    """Commit physical owners, completing omitted unsplit operation loops."""
+
+    symbols = tuple(iteration_space_from_op(op))
+    split_symbols = set(ownership.work_slices)
+    owner_symbols = set(ownership.core_id_to_work_slice)
+    if split_symbols != owner_symbols:
+        raise ValueError("committed ownership split and owner symbols differ")
+    unknown = split_symbols - set(symbols)
+    if unknown:
+        raise ValueError(
+            "committed ownership has unknown operation loops: "
+            f"{sorted(map(str, unknown))}"
+        )
+
+    # A physical view records only dimensions that divide the tensor. Missing
+    # operation loops are therefore unambiguously local: one slice, slot zero.
+    committed = TensorWorkDivision(
+        {symbol: int(ownership.work_slices.get(symbol, 1)) for symbol in symbols},
+        {
+            symbol: ownership.core_id_to_work_slice.get(symbol, sympy.S.Zero)
+            for symbol in symbols
+        },
+        num_cores=ownership.physical_core_count,
+    )
+    committed.to_core_slices(committed.physical_core_count)
+    op.iteration_space_ownership = committed
 
 
 def select_work_division_transport_indexes(
@@ -2850,21 +2878,18 @@ def read_with_max_reduction_overlap(
     return best_read
 
 
-# TODO: Select and store the core mapping before LX planning, then pass the
-# winning mapping to codegen.
 class _ViewPrep(NamedTuple):
     """Candidate-invariant precompute shared across every core-division
     candidate of one ``(op, dep, buf_name)``.
 
-    Everything here depends only on the op, its dep, and the target buffer (not
-    on ``op.op_it_space_splits``), so ``_prepare_per_core_view`` computes it once
-    and ``_per_core_view_from_prep`` reuses it per candidate -- hoisting the
+    Everything here depends only on the op, its dep, and the target buffer, not
+    on a candidate's splits or owners. ``_prepare_per_core_view`` computes it
+    once and ``_per_core_view_from_prep`` reuses it per candidate, hoisting the
     sympy-heavy op-level work out of the per-candidate loop.
     """
 
     iter_space: dict
     write_index: "sympy.Expr"
-    read_index: "sympy.Expr"
     # concretize_expr(dep.index.coeff(sym)) over the *full* iteration space, so
     # the per-candidate path does a dict lookup instead of a sympy .coeff() call.
     dep_coeff: dict
@@ -2888,8 +2913,6 @@ def _prepare_per_core_view(
     op: Operation,
     dep: MemoryDep,
     buf_name: str,
-    *,
-    parts: "Optional[tuple[dict, sympy.Expr, sympy.Expr]]" = None,
 ) -> Optional[_ViewPrep]:
     """Compute the candidate-invariant pieces of a per-core view once.
 
@@ -2898,21 +2921,15 @@ def _prepare_per_core_view(
     ``None`` to the unrepresentable result without entering the per-candidate
     path.
 
-    ``parts`` supplies ``(iter_space, write_index, read_index)`` explicitly.
-    Default (None) reads them off ``op`` -- the *pre*-scheduler ranges, which is
-    what LX planning sees. Post-fusion callers pass the ``SchedulerNode``'s
-    ranges instead, so they model the order codegen will actually emit.
+    The inputs come from the pre-scheduler operation. Post-scheduler ownership
+    is validated by projecting the committed physical view through the final
+    access; this builder no longer has a second scheduler-derived mode.
     """
-    if parts is not None:
-        iter_space, write_index, read_index = parts
-    else:
-        # The op-level write_index / read_index (for *any* buffer the op writes /
-        # reads, not necessarily buf_name) bridge stride-keyed coeff_splits back
-        # to scheduler symbols.
-        rw = op_read_writes(op)
-        write_index = next(iter(rw.writes)).index
-        read_index = next((d.index for d in rw.reads), write_index)
-        iter_space = iteration_space_from_op(op)
+    # The op-level write index bridges stride-keyed split counts back to
+    # operation symbols, independently of the target buffer's access.
+    rw = op_read_writes(op)
+    write_index = next(iter(rw.writes)).index
+    iter_space = iteration_space_from_op(op)
 
     buf_op = V.graph.get_buffer(buf_name)
     buf_layout = buf_op.layout
@@ -2957,7 +2974,6 @@ def _prepare_per_core_view(
     return _ViewPrep(
         iter_space=iter_space,
         write_index=write_index,
-        read_index=read_index,
         dep_coeff=dep_coeff,
         dep_device_coordinates=dep_device_coordinates,
         device_size=device_size,
@@ -2974,14 +2990,16 @@ def _prepare_per_core_view(
 
 def _per_core_view_from_prep(
     prep: Optional[_ViewPrep],
-    splits: dict[sympy.Symbol, int] | tuple[dict, dict],
+    splits: dict[sympy.Symbol, int],
     reduction_splits: Optional[dict[sympy.Symbol, int]] = None,
+    *,
+    ownership: TensorWorkDivision | None = None,
 ) -> tuple[PerCoreView, bool, bool]:
-    """Evaluate a precomputed view for symbol splits or scheduler transport."""
-    num_cores = math.prod(
-        value
-        for group in (splits if isinstance(splits, tuple) else (splits,))
-        for value in group.values()
+    """Evaluate a view from complete symbol-keyed ownership or candidate splits."""
+    num_cores = (
+        ownership.physical_core_count
+        if ownership is not None
+        else math.prod(splits.values())
     )
     # 3-tuple: (view, has_partial_reduction, representable). ``representable`` is
     # False only on the give-up returns below (a split that slices this buffer
@@ -2995,30 +3013,16 @@ def _per_core_view_from_prep(
 
     # No real split -> whole-buffer view, representable regardless of layout. Must
     # precede the ``prep is None`` guard to match the original ordering.
-    if isinstance(splits, tuple):
-        if not any(n > 1 for d in splits for n in d.values()):
-            return (
-                PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
-                False,
-                True,
-            )
-        if prep is None:
-            return unrepresentable
-        per_sym = apply_splits_from_index_coeff(
-            splits, prep.write_index, prep.read_index, prep.iter_space
+    if not any(n > 1 for n in splits.values()):
+        return (
+            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+            False,
+            True,
         )
-        has_partial_reduction = any(n > 1 for n in splits[1].values())
-    else:
-        if not any(n > 1 for n in splits.values()):
-            return (
-                PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
-                False,
-                True,
-            )
-        if prep is None:
-            return unrepresentable
-        per_sym = {sym: int(splits.get(sym, 1)) for sym in prep.iter_space}
-        has_partial_reduction = any(n > 1 for n in (reduction_splits or {}).values())
+    if prep is None:
+        return unrepresentable
+    per_sym = {sym: int(splits.get(sym, 1)) for sym in prep.iter_space}
+    has_partial_reduction = any(n > 1 for n in (reduction_splits or {}).values())
 
     # Step 2: keep splits that actually slice this buffer, keyed by their host
     # stride on buf (precomputed in ``dep_coeff``). host_stride == 0 means the
@@ -3027,14 +3031,15 @@ def _per_core_view_from_prep(
     # has_partial_reduction flag is op-level -- set whenever the op has any
     # reduction-axis split -- and is independent of which dep we're inspecting.
     splits_by_stride: dict[int, tuple[int, "sympy.Symbol"]] = {}
+    tensor_owned_split_symbols: set[sympy.Symbol] = set()
     for sym, split in per_sym.items():
         host_stride = prep.dep_coeff.get(sym, 0)
         if split <= 1 or host_stride == 0:
             continue
+        tensor_owned_split_symbols.add(sym)
         splits_by_stride[host_stride] = (int(split), sym)
 
     device_size = prep.device_size
-    stride_map = prep.stride_map
     elems_per_stick = prep.elems_per_stick
     device_stride_to_dim = prep.device_stride_to_dim
     stick_host_stride = prep.stick_host_stride
@@ -3042,6 +3047,34 @@ def _per_core_view_from_prep(
     num_stick = prep.num_stick
     num_stick_stride = prep.num_stick_stride
     iter_space = prep.iter_space
+
+    core_to_slot: Optional[dict[sympy.Symbol, Expr]] = None
+
+    def iteration_core_to_slot() -> Optional[dict[sympy.Symbol, Expr]]:
+        nonlocal core_to_slot
+        if core_to_slot is not None:
+            return core_to_slot
+        iter_symbols = tuple(iter_space)
+        dim_splits = tuple(int(per_sym[sym]) for sym in iter_symbols)
+        contiguous_dim = (
+            len(dim_splits) - 1
+            if prep.is_matmul and config.core_id_k_fast_emission
+            else None
+        )
+        if ownership is not None:
+            if set(ownership.work_slices) != set(iter_symbols) or set(
+                ownership.core_id_to_work_slice
+            ) != set(iter_symbols):
+                return None
+            core_to_slot = dict(ownership.core_id_to_work_slice)
+        else:
+            core_to_slot = core_to_slice_mapping(
+                iter_symbols,
+                dim_splits,
+                num_cores,
+                contiguous_dim=contiguous_dim,
+            )
+        return core_to_slot
 
     # Step 3: place each split on a device dim via stride lookup.
     #
@@ -3100,6 +3133,55 @@ def _per_core_view_from_prep(
                 dev_dim = num_stick_dim
                 split *= k
 
+        # A stride match proposes one physical axis; it does not prove that a
+        # flattened loop owns that axis's contiguous slices. For example,
+        # f in [0, 32) with coordinates (f % 8, f // 8) cannot put an eight-way
+        # split on the first axis alone. Ordinary stickification (f // 64,
+        # f % 64) is valid when each loop slice covers complete sticks.
+        if (
+            dev_dim is not None
+            and sum(
+                sym in coordinate.free_symbols
+                for coordinate in prep.dep_device_coordinates
+            )
+            > 1
+        ):
+            from .core_mapping import _LOOP_POINT, direct_axis_ownership_failure
+
+            extent = iter_space[sym]
+            if isinstance(extent, tuple):
+                extent = extent[0]
+            extent = concretize_expr(extent)
+            padded_extent = num_stick * elems_per_stick
+            if (
+                h == stick_host_stride
+                and padded_extent - elems_per_stick < extent <= padded_extent
+            ):
+                # Sticks are atomic: the device splits whole sticks, so a loop
+                # over the whole stickified axis is proved in stick-padded
+                # elements. 129 fp16 values are three sticks of 64 slots; a
+                # three-way split owns one stick each, not 43 elements each. A
+                # loop that stops short of the last stick keeps the element
+                # model.
+                extent = padded_extent
+            # Prove every logical partition, independent of the physical core
+            # order. Step 4 preserves that order using the same partition IDs.
+            if reason := direct_axis_ownership_failure(
+                extent,
+                per_sym[sym],
+                prep.dep_device_coordinates[dev_dim].xreplace({sym: _LOOP_POINT}),
+                device_size[dev_dim],
+                split,
+            ):
+                logger.debug(
+                    "cannot prove stride-selected ownership for iteration %s "
+                    "on device dim %s: %s; require exact decomposition",
+                    sym,
+                    dev_dim,
+                    reason,
+                )
+                dev_dim = None
+
         # A reshape can place more than one logical loop symbol on one physical
         # device axis.  Splitting an inner symbol while an unsplit outer symbol
         # also contributes to that axis gives each core several interleaved
@@ -3124,8 +3206,7 @@ def _per_core_view_from_prep(
                     f"on device dim {dev_dim}; returning empty_view"
                 )
                 return unrepresentable
-        # TODO: two known unhandled failure modes fall through to the
-        # empty_view fallback (cases catalogued in
+        # Two reshape cases reach the fallback below (catalogued in
         # per_core_view_failing_cases.md):
         #   (A) Collapsed-axis info loss — device_layout built from a
         #       higher-rank host tensor while dep is indexed via a lower-rank
@@ -3136,21 +3217,14 @@ def _per_core_view_from_prep(
         #       h = k * stride_map[num_stick_dim], k > 1, but
         #       split * k < num_stick (rescue above only
         #       handles the full-coverage case where they are equal).
-        # In both cases no single (dev_dim, factor) placement faithfully
-        # represents the per-core slicing; empty_view keeps the buffer on
-        # HBM via the caller's mismatch logic. Future work: extend the
-        # PerCoreView schema to express multi-dim or strided splits, or
-        # refuse the buffer earlier in scratchpad planning.
+        # Everything outside the exact rectangular subset remains
+        # unrepresentable and keeps the buffer on HBM.
         if (
             dev_dim is None
             or dev_dim in work_slice_dims
             or device_size[dev_dim] % split != 0
         ):
-            logger.debug(
-                f"could not place split h={h} factor={split} on "
-                f"stride_map={stride_map} device_size={device_size}; "
-                f"returning empty_view"
-            )
+            logger.debug("split does not fit one physical axis")
             return unrepresentable
         work_slice_dims[dev_dim] = split
         sym_to_device_dim[sym] = dev_dim
@@ -3158,20 +3232,10 @@ def _per_core_view_from_prep(
     # Step 4: model the same physical ownership SDSC will emit. LX compatibility
     # requires producer and consumer to assign each slice to the same physical
     # core; matching split factors alone is insufficient.
-    num_cores = int(math.prod(per_sym.values()))
-    iter_symbols = tuple(iter_space)
-    dim_splits = tuple(int(per_sym[sym]) for sym in iter_symbols)
-    contiguous_dim = (
-        len(dim_splits) - 1
-        if prep.is_matmul and config.core_id_k_fast_emission
-        else None
-    )
-    core_to_slot = core_to_slice_mapping(
-        iter_symbols,
-        dim_splits,
-        num_cores,
-        contiguous_dim=contiguous_dim,
-    )
+    num_cores = int(num_cores)
+    core_to_slot = iteration_core_to_slot()
+    if core_to_slot is None:
+        return unrepresentable
     # Re-key by the buffer's device-dim index (canonical) instead of the op's
     # iter symbol name. Two ops with the same per-core slicing on this buffer
     # compare equal even if they name their iter axes differently.
@@ -3193,20 +3257,24 @@ def _per_core_view_on_buf(
     dep: MemoryDep,
     buf_name: str,
     cache: Optional[dict] = None,
+    *,
+    ownership_override: TensorWorkDivision | None = None,
 ) -> tuple[PerCoreView, bool, bool]:
     """Build a PerCoreView describing how `op` slices `buf_name` via `dep`.
 
     Thin wrapper over ``_prepare_per_core_view`` + ``_per_core_view_from_prep``,
-    reading the candidate division from ``op.op_it_space_splits``. Callers
-    sweeping many candidates of one op/edge should call those two directly to
-    amortize the op-level precompute.
+    reading the complete committed division from
+    ``op.iteration_space_ownership``. Callers sweeping many candidates of one
+    op/edge should call those two directly to amortize the op-level precompute.
 
     Returns `(view, has_partial_reduction, representable)`. ``has_partial_reduction``
     is True when the op has a reduction split (partial sums left on most cores);
     callers act on it only for write-deps. ``representable`` is False only on the
     give-up cases (a split that slices this buffer can't be placed on a device
     dim), which cross-op comparisons must treat as a non-match. Pass `cache` to
-    memoize, keyed by (op name, symbol-keyed splits, dep, buf_name).
+    memoize, keyed by the op name, complete symbol-keyed ownership, dependency,
+    and buffer name. Owner formulas and the physical core count are part of the
+    key, so equal split counts with different core orders cannot alias.
 
     The op name is part of the key because the result also depends on op-derived
     write_index / read_index / iter_space / matmul-ness, not just (splits, dep,
@@ -3216,17 +3284,31 @@ def _per_core_view_on_buf(
     ``ScratchpadAllocator._cd_parent_matches`` and ``get_ncores_for_buffers``
     share one cache across a producer and consumer of the same buffer).
     """
-    ownership = getattr(op, "iteration_space_ownership", None)
+    ownership = ownership_override or getattr(op, "iteration_space_ownership", None)
     splits = ownership.work_slices if ownership is not None else {}
     key = None
     if cache is not None:
-        key = (op.get_name(), frozenset(splits.items()), dep, buf_name)
+        ownership_key = (
+            (
+                ownership.physical_core_count,
+                frozenset(ownership.core_id_to_work_slice.items()),
+            )
+            if ownership is not None
+            else None
+        )
+        key = (
+            op.get_name(),
+            frozenset(splits.items()),
+            ownership_key,
+            dep,
+            buf_name,
+        )
         hit = cache.get(key)
         if hit is not None:
             return hit
 
     if not any(n > 1 for n in splits.values()):
-        num_cores = ownership.num_cores if ownership is not None else 1
+        num_cores = ownership.physical_core_count if ownership is not None else 1
         result = (
             PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
             False,
@@ -3241,53 +3323,15 @@ def _per_core_view_on_buf(
     reduction_splits = {
         sym: split for sym, split in splits.items() if write_index.coeff(sym) == 0
     }
-    result = _per_core_view_from_prep(prep, splits, reduction_splits)
+    result = _per_core_view_from_prep(
+        prep,
+        splits,
+        reduction_splits,
+        ownership=ownership,
+    )
     if cache is not None:
         cache[key] = result
     return result
-
-
-def per_core_view_scheduled(
-    node: "SchedulerNode", dep: MemoryDep, buf_name: str
-) -> tuple[PerCoreView, bool, bool]:
-    """:func:`_per_core_view_on_buf` against the *post*-scheduler ranges.
-
-    Same result shape, but the iteration space and indices come from
-    ``node.read_writes`` / :func:`iteration_space` rather than the pre-scheduler
-    ``op.get_read_writes()``. Inductor's ``loop_ordering_after_fusion`` can
-    permute a fused op's ranges after LX planning has already committed, and
-    ``core_to_slice_mapping`` is positional, so only this post-fusion view
-    reflects the core->slice assignment codegen will really emit.
-    """
-    op = node.node
-    coeff_splits: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
-    if not any(n > 1 for d in coeff_splits for n in d.values()):
-        # No real split -> whole-buffer view; every core holds all of it.
-        return (
-            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=1),
-            False,
-            True,
-        )
-
-    rw = node.read_writes
-    write_dep = next((d for d in rw.writes if isinstance(d, MemoryDep)), None)
-    if write_dep is None:
-        # StarDep-only writer: no index to reason about, so treat as
-        # unrepresentable rather than guessing.
-        num_cores = math.prod(
-            value for group in coeff_splits for value in group.values()
-        )
-        return (
-            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
-            False,
-            False,
-        )
-    read_index = next(
-        (d.index for d in rw.reads if isinstance(d, MemoryDep)), write_dep.index
-    )
-    parts = (iteration_space(node), write_dep.index, read_index)
-    prep = _prepare_per_core_view(op, dep, buf_name, parts=parts)
-    return _per_core_view_from_prep(prep, coeff_splits)
 
 
 def format_operations(operations: list[Operation]) -> str:

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -83,9 +83,8 @@ from .scratchpad.allocator import (
 )
 from .fusion import spyre_fuse_nodes
 from .scheduler import (
-    align_lx_producer_loop_order,
     build_loop_scheduler_nodes,
-    demote_incoherent_lx_buffers,
+    prepare_spyre_kernels,
     verify_carried_reduction_ownership,
 )
 from .constants import DEVICE_NAME
@@ -266,13 +265,9 @@ class CustomPreFusionPasses(_SpyreNodePassPipeline):
     # are visible to SuperDSCScheduling.can_fuse_vertical/horizontal (which return
     # False), so loop groups survive Inductor fusion intact.
     def __init__(self):
-        # align_lx_producer_loop_order runs before build_loop_scheduler_nodes so
-        # it still sees plain SchedulerNodes (the only kind that can reorder
-        # their loops) rather than CountedLoopSchedulerNode wrappers.
         super().__init__(
             [
                 propagate_mutation_layouts,
-                align_lx_producer_loop_order,
                 build_loop_scheduler_nodes,
             ]
         )
@@ -288,15 +283,15 @@ class CustomPostFusionPasses(_SpyreNodePassPipeline):
     """
 
     def __init__(self):
-        # demote_incoherent_lx_buffers runs first: it re-checks LX core->slice
-        # coherence now that loop orders are final, and anything it demotes must
-        # still be visible to hbm_pool_planning as an unclaimed intermediate.
-        # hbm_pool_planning runs after spyre_fuse_nodes so it can compute
-        # bundle-scoped live ranges.
+        # Fusion fixes the final loop coordinates. Every bundle's kernel is
+        # then prepared once, with the real finalization, while HBM fallback
+        # is still available. HBM planning claims anything preparation demotes
+        # before the carried-reduction pass checks that its required stages
+        # still exist; emission binds only what pooling decided.
         super().__init__(
             [
-                demote_incoherent_lx_buffers,
                 spyre_fuse_nodes,
+                prepare_spyre_kernels,
                 hbm_pool_planning,
                 verify_carried_reduction_ownership,
             ]

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -435,11 +435,10 @@ def prepare_spyre_kernels(
 def verify_carried_reduction_ownership(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
-    """Verify the final physical contract of every loop-carried reduction.
+    """Require carried-reduction stages and their committed LX ownership to survive.
 
-    This runs after fusion, kernel preparation, and HBM-pool planning. Earlier
-    split metadata is only an input request; the committed physical view checked
-    here is the ownership codegen will actually emit.
+    Kernel preparation already proved each access against the physical view.
+    After HBM-pool planning, check that the stages, accesses, and view still exist.
     """
 
     grouped: dict[object, dict[str, SchedulerNode]] = {}
@@ -486,8 +485,7 @@ def verify_carried_reduction_ownership(
             (record.combine_name, "write"),
             (record.drain_name, "read"),
         )
-        expected_view = layout.lx_view
-        if expected_view is None:
+        if layout.lx_view is None:
             raise Unsupported(
                 f"carried reduction accumulator {record.accumulator_name} has "
                 "an LX address but no physical ownership"

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -23,6 +23,7 @@ from torch._inductor.utils import (
     sympy_product,
 )
 from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import NoneLayout
 from torch._inductor.scheduler import (
     BaseScheduling,
     BaseSchedulerNode,
@@ -35,48 +36,17 @@ from torch.utils._ordered_set import OrderedSet
 
 from .spyre_kernel import SpyreKernel
 from .ir import FixedTiledLayout
-from .pass_utils import (
-    PerCoreView,
-    iteration_space,
-    iteration_space_from_op,
-    per_core_view_scheduled,
-    try_device_coordinates,
-)
+from .pass_utils import iteration_space
 from .logging_utils import get_inductor_logger
 from .scratchpad.lx_relayout import (
     demote_lx_relayout_group,
-    materialized_lx_relayouts,
-    work_division_from_view,
+    materialized_lx_relayout_for_destination,
 )
 from .op_spec import LoopSpec
 from . import config as _spyre_config
 from .errors import Unsupported
 
 logger = get_inductor_logger("scheduler")
-
-
-def _ownership_projectable(
-    node: SchedulerNode,
-    dep: MemoryDep,
-    name: str,
-    view: PerCoreView,
-) -> bool:
-    """Whether final scheduled coordinates can carry ``view`` into codegen."""
-
-    buffer = V.graph.try_get_buffer(name)
-    if buffer is None:
-        return False
-    layout = buffer.get_layout()
-    if not isinstance(layout, FixedTiledLayout):
-        return False
-    coordinates = try_device_coordinates(layout.device_layout, dep, None)
-    if coordinates is None:
-        return False
-    try:
-        work_division_from_view(view, coordinates, tuple(iteration_space(node)))
-    except ValueError:
-        return False
-    return True
 
 
 class CountedLoopSchedulerNode(FusedSchedulerNode):
@@ -352,247 +322,114 @@ def build_loop_scheduler_nodes(
     return result
 
 
-def _lx_resident(node: SchedulerNode) -> bool:
-    """True if ``node``'s output buffer was pinned into LX by scratchpad planning."""
-    allocation = getattr(getattr(node.node, "layout", None), "allocation", None)
-    return allocation is not None and "lx" in allocation
-
-
-def _lx_view(name: str):
+def _lx_layout(name: str):
     buffer = V.graph.try_get_buffer(name)
     if buffer is None:
+        return None
+    # Fallback kernels can register dependency-only buffers whose NoneLayout
+    # intentionally has no tensor descriptor.  Such a buffer cannot be LX
+    # resident, and Buffer.get_layout() raises for it by contract.
+    if isinstance(getattr(buffer, "layout", None), NoneLayout):
         return None
     layout = buffer.get_layout()
     if not isinstance(layout, FixedTiledLayout):
         return None
     if "lx" not in layout.allocation:
         return None
-    return layout.lx_view
+    return layout
 
 
-def align_lx_producer_loop_order(
-    nodes: list[BaseSchedulerNode],
-) -> list[BaseSchedulerNode]:
-    """Pre-fusion pass: match an LX buffer's producer loop order to its consumers'.
+def _all_scheduler_nodes(
+    items: Sequence[BaseSchedulerNode],
+) -> Iterator[SchedulerNode]:
+    """Yield every leaf operation, including leaves inside counted loops."""
 
-    LX is per-core scratchpad, so every op touching an LX-resident buffer must
-    agree on which core owns which slice.  That mapping is *positional*:
-    ``core_to_slice_mapping`` hands out ``core_id`` strides in iteration-space
-    order, so a producer that walks the buffer in a different dim order than its
-    consumers read it gets a transposed core->slice assignment.  The split
-    factors still multiply to the same core count, so nothing downstream
-    complains -- each core simply reads the slice a different core wrote, and the
-    kernel silently returns another core's data.
-
-    Scratchpad planning creates the clone that pins a graph input into LX, and it
-    builds that clone in the buffer's natural dim order, which need not match how
-    the consumers read it.  Through PyTorch 2.12 Inductor's
-    ``loop_ordering_after_fusion`` happened to rewrite the clone into the
-    consumers' order, so the assignments lined up by accident.  As of 2.13 the
-    reorder is computed and then discarded (see
-    ``Scheduler._try_reorder_loops_for_candidates``), which exposed the
-    incoherence as wrong results for any two reductions sharing one LX-pinned
-    input.  Align the orders here so correctness does not rest on an Inductor
-    scoring heuristic.
-
-    Consumers of an LX buffer are already known to agree with each other -- a
-    disagreement is a core-division mismatch that keeps the buffer in HBM (see
-    ``get_ncores_for_buffers``) -- so matching the first consumer matches all.
-    """
-    producers: dict[str, SchedulerNode] = {}
-    for node in nodes:
-        if isinstance(node, SchedulerNode) and _lx_resident(node):
-            for dep in node.read_writes.writes:
-                if isinstance(dep, MemoryDep) and _lx_view(dep.name) is None:
-                    producers[dep.name] = node
-
-    if not producers:
-        return nodes
-
-    # Keyed by producer, not by buffer: reordering a producer twice would leave
-    # it matching only whichever consumer came last.  A ComputedBuffer has a
-    # single output (multi-output ops carry no device_layout and never reach LX),
-    # so one alignment per producer covers every LX buffer it writes.
-    aligned: OrderedSet[str] = OrderedSet()
-    for node in nodes:
-        if not isinstance(node, SchedulerNode):
-            continue
-        for read in node.read_writes.reads:
-            if not isinstance(read, MemoryDep):
-                continue
-            producer = producers.get(read.name)
-            if producer is None or producer is node:
-                continue
-            if producer.get_name() in aligned:
-                continue
-            write = next(
-                (
-                    dep
-                    for dep in producer.read_writes.writes
-                    if isinstance(dep, MemoryDep) and dep.name == read.name
-                ),
-                None,
-            )
-            if write is None:
-                continue
-            # Reorders `producer`'s loops so its write dep matches `read`.
-            if producer.reorder_loops_by_dep_pair(write, read):
-                aligned.add(producer.get_name())
-                logger.debug(
-                    "align_lx_producer_loop_order: %s reordered to match %s's "
-                    "read of LX buffer %s",
-                    producer.get_name(),
-                    node.get_name(),
-                    read.name,
-                )
-
-    return nodes
+    for item in items:
+        if isinstance(item, FusedSchedulerNode):
+            yield from _all_scheduler_nodes(item.get_nodes())
+        elif isinstance(item, SchedulerNode):
+            yield item
 
 
-def demote_incoherent_lx_buffers(
-    nodes: list[BaseSchedulerNode],
-) -> list[BaseSchedulerNode]:
-    """Post-fusion pass: drop an LX buffer whose users disagree on core->slice.
+def _touched_lx_names(node: SchedulerNode) -> list[str]:
+    """The LX buffers one operation reads or writes."""
 
-    LX planning runs before the Scheduler exists, so it reasons about each op's
-    *pre*-scheduler ranges. ``core_to_slice_mapping`` is positional -- it hands
-    ``core_id`` strides out in iteration-space order -- and Inductor's
-    ``loop_ordering_after_fusion`` may permute a fused op's ranges after planning
-    has already committed. When it permutes one user of an LX buffer and not
-    another, the two disagree about which core owns which slice: each core writes
-    one slice and reads back a different one. LX is per-core scratchpad with no
-    other copy, so the read is silently wrong (#2062).
-
-    Planning cannot see that permutation, so re-check here, where the ranges are
-    final, and demote any buffer whose users no longer agree. Clearing ``"lx"``
-    is all that is needed: this runs before ``hbm_pool_planning``, which claims
-    exactly the intermediates LX did not, so a demoted buffer lands in the HBM
-    intermediates segment on its way through.
-
-    Deliberately verification-only -- it never *adds* residency and never
-    rewrites a loop order, so it cannot perturb a graph whose users already
-    agree.
-
-    Complements :func:`align_lx_producer_loop_order`, which runs pre-fusion and
-    rewrites a producer's loop order to match its consumers'. That pass fixes the
-    incoherence it can reach; this one is the backstop for what it cannot -- a
-    disagreement introduced after it ran, or a view too irregular to represent --
-    where the only safe answer is to give up LX residency.
-    """
-    if not _spyre_config.lx_planning:
-        return nodes
-
-    # dep is needed per (node, buffer), including in-place read/write pairs.
-    users: dict[str, list[tuple[SchedulerNode, MemoryDep]]] = {}
-    lx_names: OrderedSet[str] = OrderedSet()
-    scheduled = [
-        inner
-        for node in nodes
-        for inner in node.get_nodes()
-        if isinstance(inner, SchedulerNode)
+    return [
+        dep.name
+        for dep in (*node.read_writes.reads, *node.read_writes.writes)
+        if isinstance(dep, MemoryDep) and _lx_layout(dep.name) is not None
     ]
-    plans_by_copy = {
-        copy_name: plan
-        for copy_name, plan in materialized_lx_relayouts(V.graph).values()
-    }
-    source_by_copy = {
-        copy_name: plan.source_name for copy_name, plan in plans_by_copy.items()
-    }
-    relayout_sources = set(source_by_copy.values())
 
-    copy_reads = set()
-    invalid_sources = {}
-    seen_copies = set()
-    for node in scheduled:
-        if _lx_resident(node):
-            for dep in node.read_writes.writes:
-                if isinstance(dep, MemoryDep):
-                    lx_names.add(dep.name)
-        rw = node.read_writes
-        reads = [dep for dep in rw.reads if isinstance(dep, MemoryDep)]
-        writes = [dep for dep in rw.writes if isinstance(dep, MemoryDep)]
-        for dep in [*reads, *writes]:
-            users.setdefault(dep.name, []).append((node, dep))
-        copies = [dep for dep in writes if dep.name in plans_by_copy]
-        if not copies:
-            continue
-        for dep in copies:
-            seen_copies.add(dep.name)
-            plan = plans_by_copy[dep.name]
-            source_view = _lx_view(plan.source_name)
-            destination_view = _lx_view(dep.name)
-            if (
-                source_view is None
-                or destination_view is None
-                or source_view.same_partition(destination_view)
-                or len(reads) != 1
-                or len(writes) != 1
-                or reads[0].name != plan.source_name
-                or not _ownership_projectable(
-                    node, reads[0], plan.source_name, source_view
-                )
-                or not _ownership_projectable(node, dep, dep.name, destination_view)
-            ):
-                invalid_sources[plan.source_name] = f"invalid relayout copy {dep.name}"
-            else:
-                copy_reads.add((node.get_name(), plan.source_name))
-    for copy_name, plan in plans_by_copy.items():
-        if copy_name not in seen_copies:
-            invalid_sources[plan.source_name] = f"missing relayout copy {copy_name}"
 
-    demoted = set()
+def prepare_spyre_kernels(
+    nodes: list[BaseSchedulerNode],
+) -> list[BaseSchedulerNode]:
+    """Prepare every bundle's kernel once, while HBM fallback is still available.
 
-    def demote(source_name: str, reason: str) -> None:
-        if source_name in demoted:
-            return
-        demoted.add(source_name)
-        if source_name in relayout_sources:
-            # Scheduling supplies the final ownership verdict; the relayout
-            # layer owns atomic group fallback and registry cleanup.
-            demote_lx_relayout_group(V.graph, source_name, reason)
-            return
-        buffer = V.graph.try_get_buffer(source_name)
-        if buffer is not None:
-            layout = buffer.get_layout()
-            if isinstance(layout, FixedTiledLayout):
-                layout.allocation.pop("lx", None)
-                layout.lx_view = None
-        logger.info("demoted %s out of LX: %s", source_name, reason)
+    Planning has already chosen each LX buffer's physical ownership. This pass
+    does not choose it again: it runs the real operation handlers and the real
+    finalization over every bundle and keeps each successful kernel for
+    emission. An operation whose LX placement cannot be finalized demotes the
+    LX buffers it touches (a relayout member takes its whole connected group),
+    and every kernel that touched a demoted buffer is prepared again, until no
+    placement changes. Each retry removes at least one finite LX allocation.
+    """
+    scheduler = V.graph.scheduler
+    bundles = [
+        node
+        for node in nodes
+        if isinstance(node, (FusedSchedulerNode, SchedulerNode))
+        and not (node.is_template() or node.is_extern() or node.is_foreach())
+        and isinstance(scheduler.get_backend(node.get_device()), SuperDSCScheduling)
+    ]
+    leaves = list(_all_scheduler_nodes(bundles))
 
-    for source_name, reason in invalid_sources.items():
-        demote(source_name, reason)
+    def demote(name: str, reason: str) -> None:
+        # Scheduling supplies the final ownership verdict; the relayout layer
+        # owns the fallback for a whole connected group, and for a buffer with
+        # no registered copies that group is the buffer itself. A destination
+        # demoted after its group is already gone is cleared again, harmlessly.
+        plan = materialized_lx_relayout_for_destination(V.graph, name)
+        demote_lx_relayout_group(
+            V.graph, name if plan is None else plan.source_name, reason
+        )
 
-    for name in lx_names:
-        ref = None
-        culprit = None
-        expected = _lx_view(name)
-        for node, dep in users.get(name, []):
-            # The copy executes with its destination division; the source map is
-            # carried by its input tensor and validated at the producer.
-            if (node.get_name(), name) in copy_reads:
-                continue
-            view, _, representable = per_core_view_scheduled(node, dep, name)
-            if not representable:
-                culprit = f"{node.get_name()} view unrepresentable"
+    # One attempt prepares every bundle in order. A rejected placement demotes
+    # the failing operation's LX buffers, the attempt's kernels and graph
+    # removals are dropped, and the next attempt starts over, so every kernel
+    # emission consumes was prepared against the final placement.
+    removed_at_entry = OrderedSet(V.graph.removed_buffers)
+    initial_lx_names = {name for node in leaves for name in _touched_lx_names(node)}
+    for _ in range(len(initial_lx_names) + 1):
+        kernels = []
+        for bundle in bundles:
+            backend = scheduler.get_backend(bundle.get_device())
+            kernel = SpyreKernel()
+            try:
+                backend.prepare_kernel(bundle, kernel)
+            except (Unsupported, ValueError) as exc:
+                # A rejected attempt leaves nothing behind: its kernels are
+                # dropped and the graph's removed-buffer set is restored.
+                V.graph.removed_buffers -= V.graph.removed_buffers - removed_at_entry
+                failed = kernel.failed_node
+                touched = [] if failed is None else _touched_lx_names(failed)
+                if failed is None or not touched:
+                    raise
+                reason = f"{failed.get_name()} LX ownership finalization failed: {exc}"
+                # This is a preservation check, not another placement search.
+                # Do not try subsets or keep a preferred writer: all LX buffers
+                # touched by the failed operation fall back together.
+                for touched_name in touched:
+                    demote(touched_name, reason)
                 break
-            if expected is not None:
-                if not view.same_partition(expected):
-                    culprit = f"{node.get_name()} view {view} != {expected}"
-                    break
-                if not _ownership_projectable(node, dep, name, expected):
-                    culprit = f"{node.get_name()} ownership unprojectable"
-                    break
-                continue
-            if ref is None:
-                ref = view
-            elif not view.same_partition(ref):
-                culprit = f"{node.get_name()} disagrees: {view} != {ref}"
-                break
-        if culprit is None:
-            continue
-        demote(source_by_copy.get(name, name), culprit)
-
-    return nodes
+            kernels.append((bundle, kernel))
+        else:
+            for bundle, kernel in kernels:
+                setattr(bundle, "prepared_kernel", kernel)
+            return nodes
+    raise RuntimeError(
+        "LX ownership finalization did not reach its monotone demotion fixed point"
+    )
 
 
 def verify_carried_reduction_ownership(
@@ -600,22 +437,13 @@ def verify_carried_reduction_ownership(
 ) -> list[BaseSchedulerNode]:
     """Verify the final physical contract of every loop-carried reduction.
 
-    This runs after fusion, LX demotion, and HBM-pool planning.  Earlier split
-    metadata is only an input request; the scheduled per-core views checked
-    here are the ownership codegen will actually emit.
+    This runs after fusion, kernel preparation, and HBM-pool planning. Earlier
+    split metadata is only an input request; the committed physical view checked
+    here is the ownership codegen will actually emit.
     """
 
-    def all_scheduler_nodes(
-        items: Sequence[BaseSchedulerNode],
-    ) -> Iterator[SchedulerNode]:
-        for item in items:
-            if isinstance(item, FusedSchedulerNode):
-                yield from all_scheduler_nodes(item.get_nodes())
-            elif isinstance(item, SchedulerNode):
-                yield item
-
     grouped: dict[object, dict[str, SchedulerNode]] = {}
-    for node in all_scheduler_nodes(nodes):
+    for node in _all_scheduler_nodes(nodes):
         record = getattr(node.node, "_carried_reduction_record", None)
         if record is not None:
             grouped.setdefault(record, {})[node.get_name()] = node
@@ -659,6 +487,11 @@ def verify_carried_reduction_ownership(
             (record.drain_name, "read"),
         )
         expected_view = layout.lx_view
+        if expected_view is None:
+            raise Unsupported(
+                f"carried reduction accumulator {record.accumulator_name} has "
+                "an LX address but no physical ownership"
+            )
         for op_name, access in checks:
             node = by_name[op_name]
             deps = (
@@ -693,89 +526,10 @@ def verify_carried_reduction_ownership(
                     f"{record.accumulator_name}; deps="
                     f"{[(type(candidate).__name__, candidate.name) for candidate in deps]}"
                 )
-            view, _, representable = per_core_view_scheduled(
-                node, dep, record.accumulator_name
-            )
-            if not representable:
-                raise Unsupported(
-                    f"carried reduction {op_name} {access} ownership is not "
-                    "representable"
-                )
-            if expected_view is None:
-                expected_view = view
-            elif not view.same_partition(expected_view):
-                raise Unsupported(
-                    f"carried reduction {op_name} {access} ownership {view} "
-                    f"does not match accumulator ownership {expected_view}"
-                )
-
-            # Equal physical views are necessary but not sufficient.  A
-            # 32-way split over H and a 32-way split over T can have the same
-            # total core count while assigning different logical rows to a
-            # core.  Project the final physical view back into this stage's
-            # scheduled loop symbols, then require the one split to be the
-            # row dimension named by the immutable carried-reduction record.
-            coordinates = try_device_coordinates(layout.device_layout, dep, None)
-            if coordinates is None:
-                raise Unsupported(
-                    f"carried reduction {op_name} {access} cannot map final "
-                    "accumulator coordinates back to operation loops"
-                )
-            try:
-                realized_division = work_division_from_view(
-                    view,
-                    coordinates,
-                    tuple(iteration_space(node)),
-                )
-            except ValueError as exc:
-                raise Unsupported(
-                    f"carried reduction {op_name} {access} cannot project final "
-                    f"ownership into operation loops: {exc}"
-                ) from exc
-            if realized_division is None:
-                raise Unsupported(
-                    f"carried reduction {op_name} {access} has no final work division"
-                )
-
-            # Scheduler dependency extraction alpha-renames operation symbols
-            # (for example, d0 -> c0) without changing dimension order.  The
-            # carried-reduction rewrite is explicitly limited to
-            # order-preserving pointwise stages, so translate the names across
-            # that rename here.  This is not a general positional-remapping
-            # facility: a rank change fails closed, and no other rewrite uses
-            # this path.
-            operation_symbols = tuple(iteration_space_from_op(node.node))
-            scheduled_symbols = tuple(iteration_space(node))
-            if len(operation_symbols) != len(scheduled_symbols):
-                raise Unsupported(
-                    f"carried reduction {op_name} {access} changed iteration rank "
-                    "before final ownership verification"
-                )
-            operation_named_dims = getattr(node.node, "work_div_loop_info", {})
-            named_dims = {
-                scheduled_symbol: operation_named_dims.get(operation_symbol, [])
-                for operation_symbol, scheduled_symbol in zip(
-                    operation_symbols, scheduled_symbols
-                )
-            }
-            row_symbols = [
-                symbol
-                for symbol in realized_division.work_slices
-                if record.row_dim_name in named_dims.get(symbol, [])
-            ]
-            expected_splits = (
-                {row_symbols[0]: record.required_row_split}
-                if len(row_symbols) == 1
-                else None
-            )
-            if realized_division.work_slices != expected_splits:
-                raise Unsupported(
-                    f"carried reduction {op_name} {access} expected only "
-                    f"{record.row_dim_name} split={record.required_row_split}, but "
-                    f"final logical splits are {realized_division.work_slices}"
-                )
-
-        assert expected_view is not None
+            # The row decision was made by carried_reduction_pinned_row before
+            # placement. Kernel preparation above already proved this
+            # stage can consume the committed physical view. Do not recreate a
+            # symbol correspondence from post-scheduler loop position here.
 
     return nodes
 
@@ -861,31 +615,52 @@ class SuperDSCScheduling(BaseScheduling):
                 restores.append(emit)
         return restores
 
+    def _live_nodes(self, node: BaseSchedulerNode) -> list[BaseSchedulerNode]:
+        """The members of ``node`` that scheduling has not removed."""
+
+        removed = getattr(self.scheduler, "removed_ops", ())
+        return [n for n in node.get_nodes() if n.get_name() not in removed]
+
+    def prepare_kernel(
+        self, node: BaseSchedulerNode, kernel: SpyreKernel
+    ) -> SpyreKernel:
+        """Run the real handlers over one bundle into ``kernel``.
+
+        Each operation is finished as it is constructed. On failure
+        ``kernel.failed_node`` names the operation whose description could not
+        be finalized; the kernel itself is not usable afterwards.
+        """
+        with kernel:
+            self._codegen_into_kernel(self._live_nodes(node), kernel)
+        if isinstance(node, CountedLoopSchedulerNode):
+            kernel.wrap_op_specs_in_loop(node.loop_count)
+        kernel.check_op_specs()
+        return kernel
+
     def codegen_node(
         self, node: Union[FusedSchedulerNode, SchedulerNode, CountedLoopSchedulerNode]
     ) -> None:
-        """
-        Generate a kernel given a list of pre-fused nodes.
-        """
-        if isinstance(node, CountedLoopSchedulerNode):
-            self._codegen_counted_loop(node)
-            return
+        """Emit one bundle from its prepared kernel.
 
+        Preparation ran before HBM pooling; only what pooling decided afterwards
+        is bound here: the pool size, the argument list and the HBM addresses.
+        """
         assert self.scheduler
-        nodes = [
-            n
-            for n in node.get_nodes()
-            if n.get_name() not in self.scheduler.removed_ops
-        ]
+        nodes = self._live_nodes(node)
         if len(nodes) == 0:
             return
+        name = node.get_name()
+        leaf_names = {leaf.get_name() for leaf in _all_scheduler_nodes(nodes)}
+        kernel: SpyreKernel | None = getattr(node, "prepared_kernel", None)
+        if kernel is None:
+            if any(_touched_lx_names(leaf) for leaf in _all_scheduler_nodes(nodes)):
+                raise RuntimeError(f"{name} reached codegen without a prepared kernel")
+            kernel = self.prepare_kernel(node, SpyreKernel())
+        elif {leaf.get_name() for leaf in kernel.scheduled_nodes} != leaf_names:
+            raise RuntimeError(f"{name} changed after its kernel was prepared")
+        all_schedule_nodes = kernel.scheduled_nodes
 
-        pool_sizes = getattr(V.graph, "hbm_pool_sizes", {})
-        kernel = SpyreKernel(pool_size=pool_sizes.get(node.get_name(), 0))
-        all_schedule_nodes: list[SchedulerNode] = []
-        with kernel:
-            self._codegen_into_kernel(nodes, kernel, all_schedule_nodes)
-
+        kernel.pool_size = getattr(V.graph, "hbm_pool_sizes", {}).get(name, 0)
         with V.set_kernel_handler(kernel):
             src_code = kernel.codegen_kernel()
         kernel_name = self.define_kernel(src_code, all_schedule_nodes, kernel)
@@ -905,89 +680,39 @@ class SuperDSCScheduling(BaseScheduling):
 
         self.free_buffers_in_scheduler()
 
-    def _codegen_counted_loop(self, node: CountedLoopSchedulerNode) -> None:
-        """Generate a kernel for a counted loop group."""
-        assert self.scheduler
-        inner_nodes = [
-            n
-            for n in node.get_nodes()
-            if n.get_name() not in self.scheduler.removed_ops
+    def _codegen_leaf(self, snode: SchedulerNode, kernel: SpyreKernel) -> None:
+        """Run one operation's body through the kernel's handlers."""
+
+        symbols = list(iteration_space(snode))
+        index_vars = [
+            symbols[: len(snode._body.iter_vars)],
+            symbols[len(snode._body.iter_vars) :],
         ]
-        if len(inner_nodes) == 0:
-            return
-
-        pool_sizes = getattr(V.graph, "hbm_pool_sizes", {})
-        kernel = SpyreKernel(pool_size=pool_sizes.get(node.get_name(), 0))
-        all_schedule_nodes: list[SchedulerNode] = []
-        with kernel:
-            self._codegen_into_kernel(inner_nodes, kernel, all_schedule_nodes)
-
-        kernel.wrap_op_specs_in_loop(node.loop_count)
-
-        with V.set_kernel_handler(kernel):
-            src_code = kernel.codegen_kernel()
-        kernel_name = self.define_kernel(src_code, all_schedule_nodes, kernel)
-        kernel.kernel_name = kernel_name
-        kernel.code_hash = code_hash(src_code)
-
-        with V.set_kernel_handler(kernel):
-            for snode in all_schedule_nodes:
-                snode.mark_run()
-
-        self.codegen_comment(all_schedule_nodes, kernel_name)
-        kernel.call_kernel(kernel.kernel_name)
-        kernel.emit_layout_restores(self._collect_layout_restores(all_schedule_nodes))
-
-        V.graph.removed_buffers |= kernel.removed_buffers
-        V.graph.inplaced_to_remove |= kernel.inplaced_to_remove
-
-        self.free_buffers_in_scheduler()
+        kernel.scheduled_nodes.append(snode)
+        try:
+            snode.codegen(index_vars)
+        except (Unsupported, ValueError):
+            kernel.failed_node = snode
+            raise
 
     def _codegen_loop_body(
-        self,
-        node: CountedLoopSchedulerNode,
-        kernel: SpyreKernel,
-        all_schedule_nodes: list[SchedulerNode],
-        depth: int = 1,
+        self, node: CountedLoopSchedulerNode, kernel: SpyreKernel
     ) -> None:
         """Codegen the body of a nested CountedLoopSchedulerNode into an existing kernel.
 
         The inner ops are added to the kernel's op_specs list, then wrapped
-        in a LoopSpec for the inner loop count.  Called from
-        _codegen_counted_loop to handle nesting without creating a separate kernel.
+        in a LoopSpec for the inner loop count, so nesting needs no separate
+        kernel.
         """
-        assert self.scheduler
-        inner_nodes = [
-            n
-            for n in node.get_nodes()
-            if n.get_name() not in self.scheduler.removed_ops
-        ]
         body_start = len(kernel.op_specs)
-        for inner in inner_nodes:
-            if isinstance(inner, CountedLoopSchedulerNode):
-                self._codegen_loop_body(inner, kernel, all_schedule_nodes, depth + 1)
-            else:
-                sched = self.generate_node_schedule([inner])
-                all_schedule_nodes.extend(sched)
-                for snode in sched:
-                    var_ranges = iteration_space(snode)
-                    vs = list(var_ranges.keys())
-                    index_vars = [
-                        vs[: len(snode._body.iter_vars)],
-                        vs[len(snode._body.iter_vars) :],
-                    ]
-                    snode.codegen(index_vars)
-
+        self._codegen_into_kernel(self._live_nodes(node), kernel)
         # Wrap only the newly-added op_specs entries in this inner LoopSpec.
         body = kernel.op_specs[body_start:]
         kernel.op_specs = kernel.op_specs[:body_start]
         kernel.op_specs.append(LoopSpec(count=node.loop_count, body=body))
 
     def _codegen_into_kernel(
-        self,
-        nodes: list[BaseSchedulerNode],
-        kernel: SpyreKernel,
-        all_schedule_nodes: list[SchedulerNode],
+        self, nodes: list[BaseSchedulerNode], kernel: SpyreKernel
     ) -> None:
         """Codegen a sequence of nodes into an existing kernel in order.
 
@@ -997,18 +722,10 @@ class SuperDSCScheduling(BaseScheduling):
         """
         for node in nodes:
             if isinstance(node, CountedLoopSchedulerNode):
-                self._codegen_loop_body(node, kernel, all_schedule_nodes)
+                self._codegen_loop_body(node, kernel)
             else:
-                sched = self.generate_node_schedule([node])
-                all_schedule_nodes.extend(sched)
-                for snode in sched:
-                    var_ranges = iteration_space(snode)
-                    vs = list(var_ranges.keys())
-                    index_vars = [
-                        vs[: len(snode._body.iter_vars)],
-                        vs[len(snode._body.iter_vars) :],
-                    ]
-                    snode.codegen(index_vars)
+                for snode in self.generate_node_schedule([node]):
+                    self._codegen_leaf(snode, kernel)
 
     def define_kernel(self, src_code, node_schedule, kernel):
         """

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -50,6 +50,7 @@ from torch_spyre._inductor.pass_utils import (
     _is_matmul_op,
     op_short_name,
 )
+from torch_spyre._inductor.constants import BYTES_PER_STICK
 from torch_spyre._inductor.work_division import (
     enumerate_work_division_candidates,
     work_division_splits_are_legal,
@@ -85,6 +86,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     ops_in_offset_mutation_component,
     get_op_pointwise_inputs,
     buffer_not_read_in_full,
+    is_empty_tiled_layout,
     get_ncores_for_buffers,
     _is_tiled_advancing,
     _is_read_advancing_anywhere,
@@ -512,6 +514,10 @@ class ScratchpadAllocator:
             # MultiOutputLayout tuple op). There is nothing to place, and the
             # checks below would raise.
             return "unsized (no device layout)"
+        if is_empty_tiled_layout(op.layout):
+            # The joint solver does not consult the fixed-division judge until
+            # after placement, so it must share this pre-allocation exclusion.
+            return "empty tensor"
         if name in mutated_buffers and not _is_carried_reduction_storage(op):
             return "mutation target"
         # The shared carried-reduction contract names exactly one accumulator
@@ -602,6 +608,8 @@ class ScratchpadAllocator:
         """
         if not clone_at_graph_boundaries():
             return "graph input (no clone)"
+        if is_empty_tiled_layout(getattr(graph.try_get_buffer(name), "layout", None)):
+            return "empty tensor"
         if self._read_count(uses) == 0:
             return "no consumer reads it from LX"
         if self._is_index_or_indirectly_accessed(graph, name, uses, None):
@@ -665,7 +673,7 @@ class ScratchpadAllocator:
             or isinstance(getattr(go, "data", None), ReinterpretView)
         }
         if division_is_fixed and ncores is None:
-            ncores, ncores_reasons = get_ncores_for_buffers(graph)
+            ncores, ncores_reasons, _ = get_ncores_for_buffers(graph)
         ncores = ncores or {}
         ncores_reasons = ncores_reasons or {}
         buf_user_deps = _get_buffer_user_deps(graph)
@@ -738,6 +746,7 @@ class ScratchpadAllocator:
         lifetimes: dict[str, list[int]],
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
+        lx_views: dict[str, PerCoreView],
         lifetime_end_overrides: Optional[dict[str, int]] = None,
     ) -> list[LifetimeBoundBuffer]:
         """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
@@ -777,6 +786,7 @@ class ScratchpadAllocator:
                     ),
                     residency_reason=reasons.get(output_name),
                     lifetime_end_override=lifetime_end_overrides.get(output_name),
+                    lx_view=lx_views.get(output_name),
                 )
             )
 
@@ -809,6 +819,7 @@ class ScratchpadAllocator:
                     in_place_parents=[],
                     residency_reason=reason,
                     lifetime_end_override=lifetime_end_overrides.get(input_name),
+                    lx_view=lx_views.get(input_name),
                 )
             )
 
@@ -917,7 +928,7 @@ class ScratchpadAllocator:
         num_cores = ncores.get(name, -1)
         if dev_layout is None or num_cores < 1:
             return 0
-        return math.prod(dev_layout.device_size[:-1]) * 128 // num_cores
+        return math.prod(dev_layout.device_size[:-1]) * BYTES_PER_STICK // num_cores
 
     def _determine_in_place(
         self,
@@ -984,19 +995,21 @@ class ScratchpadAllocator:
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
         lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
-        ncores, ncores_reasons = get_ncores_for_buffers(graph)
+        ncores, ncores_reasons, lx_views = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
         for plan in lx_relayout_plans:
-            for name in (plan.source_name, plan.destination_name):
-                if name not in mem_usage:
-                    continue
-                ncores[name] = plan.num_cores
-                ncores_reasons.pop(name, None)
-                mem_usage[name]["size_per_core"] = (
-                    mem_usage[name]["size"] // plan.num_cores
-                )
-                mem_usage[name]["core_div_mismatch"] = False
+            name = plan.source_name
+            if name not in mem_usage:
+                continue
+            ncores[name] = plan.source_view.num_cores or plan.num_cores
+            ncores_reasons.pop(name, None)
+            lx_views[name] = plan.source_view
+            # Only sources exist in the graph here. Each private destination
+            # receives its own view and bound in _append_lx_relayout_destinations.
+            # Retain the existing equal-share size at this prerequisite.
+            mem_usage[name]["size_per_core"] = mem_usage[name]["size"] // plan.num_cores
+            mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
         if timings is not None:
             timings["residency"] += t1 - t0
@@ -1023,6 +1036,7 @@ class ScratchpadAllocator:
             lifetimes=lifetimes,
             ncores=ncores,
             ncores_reasons=ncores_reasons,
+            lx_views=lx_views,
             lifetime_end_overrides=lifetime_end_overrides,
         )
         if lx_relayout_plans:
@@ -1092,10 +1106,12 @@ class ScratchpadAllocator:
                 destination = LifetimeBoundBuffer(
                     plan.destination_name,
                     round_up_to_alignment(
-                        source.size, _LX_ALLOCATION_GRANULARITY_BYTES
+                        source.size,
+                        _LX_ALLOCATION_GRANULARITY_BYTES,
                     ),
                     [transfer_tick, *consumer_ticks],
                     lifetime_end_override=destination_end,
+                    lx_view=plan.destination_view,
                 )
                 buffers.insert(buffers.index(source), destination)
                 source.paired_with.append(destination)
@@ -1213,27 +1229,40 @@ class ScratchpadAllocator:
             buf = graph.get_buffer(b.name)
             if b.name in inputs:
                 new_buffer = graph_editor.push_allocation_with_clone(
-                    buf, buffer_users[b.name], input=True
+                    buf,
+                    buffer_users[b.name],
+                    input=True,
+                    lx_view=b.lx_view,
                 )
-                self._set_one_allocation(new_buffer, b.address)
+                self._set_one_allocation(new_buffer, b.address, b.lx_view)
 
             elif b.name in outputs:
                 new_buffer = graph_editor.push_allocation_with_clone(
                     buf, buffer_users[b.name], input=False
                 )
-                self._set_one_allocation(buf, b.address)
+                self._set_one_allocation(buf, b.address, b.lx_view)
                 graph_editor.change_graph_output(buf, new_buffer)
 
             else:
-                self._set_one_allocation(buf, b.address)
+                self._set_one_allocation(buf, b.address, b.lx_view)
 
         # Keep graph mutation last and in pre-scheduling: solver retries require
         # the original graph, and post-grad no-op elimination has already run.
         materialize_lx_relayouts(graph, accepted_lx_relayouts)
 
-    def _set_one_allocation(self, buf: TensorBox | ComputedBuffer, address: int):
+    def _set_one_allocation(
+        self,
+        buf: TensorBox | ComputedBuffer,
+        address: int,
+        lx_view: PerCoreView | None,
+    ) -> None:
+        if lx_view is None:
+            raise RuntimeError(
+                f"LX placement for {buf.get_name()} has no accepted physical ownership"
+            )
         layout = buf.get_layout()
         layout.allocation["lx"] = address
+        layout.lx_view = lx_view
 
 
 def _lx_planning_size() -> int:
@@ -1392,8 +1421,8 @@ class ResidencyEdge:
         if parent_division.cores_used != consumer_division.cores_used:
             return False
         parent_view = self.parent_view(parent_division)
-        return parent_view is not None and parent_view == self.consumer_view(
-            consumer_division
+        return parent_view is not None and parent_view.same_partition(
+            self.consumer_view(consumer_division)
         )
 
     def match_pairs(
@@ -1411,7 +1440,7 @@ class ResidencyEdge:
             if parent_view is not None
             for j, consumer_view in enumerate(consumer_views)
             if consumer_view is not None
-            and parent_view == consumer_view
+            and parent_view.same_partition(consumer_view)
             and parent_divisions[i].cores_used == consumer_divisions[j].cores_used
         ]
 
@@ -1918,6 +1947,15 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         # pull the selected core division from the dependent buffers when the graph
         # is updated with clones in ``_push_allocation``.
         self._commit_divisions(graph, allocation)
+        _, reasons, views = get_ncores_for_buffers(graph)
+        for buffer in allocation:
+            if buffer.address is None:
+                continue
+            view = views.get(buffer.name)
+            if view is None:
+                reason = reasons.get(buffer.name, "physical ownership was not accepted")
+                raise Unsupported(f"{buffer.name}: {reason}")
+            buffer.lx_view = view
 
     def _get_spill_reasons(
         self,
@@ -2187,7 +2225,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     graph.operations[last_use].name, []
                 ).append(input_name)
                 dev_layout = graph.get_buffer(input_name).layout.device_layout
-                size = math.prod(dev_layout.device_size[:-1]) * 128
+                size = math.prod(dev_layout.device_size[:-1]) * BYTES_PER_STICK
                 buffers.append(
                     CoreDivisionBuffer(
                         input_name,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -14,7 +14,6 @@
 
 import functools
 import logging
-import math
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -50,7 +49,7 @@ from torch_spyre._inductor.pass_utils import (
     _is_matmul_op,
     op_short_name,
 )
-from torch_spyre._inductor.constants import BYTES_PER_STICK
+from torch_spyre._C import get_device_size_in_bytes
 from torch_spyre._inductor.work_division import (
     enumerate_work_division_candidates,
     work_division_splits_are_legal,
@@ -928,7 +927,7 @@ class ScratchpadAllocator:
         num_cores = ncores.get(name, -1)
         if dev_layout is None or num_cores < 1:
             return 0
-        return math.prod(dev_layout.device_size[:-1]) * BYTES_PER_STICK // num_cores
+        return get_device_size_in_bytes(dev_layout) // num_cores
 
     def _determine_in_place(
         self,
@@ -2225,7 +2224,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     graph.operations[last_use].name, []
                 ).append(input_name)
                 dev_layout = graph.get_buffer(input_name).layout.device_layout
-                size = math.prod(dev_layout.device_size[:-1]) * BYTES_PER_STICK
+                size = get_device_size_in_bytes(dev_layout)
                 buffers.append(
                     CoreDivisionBuffer(
                         input_name,

--- a/torch_spyre/_inductor/scratchpad/exhaustive_search.py
+++ b/torch_spyre/_inductor/scratchpad/exhaustive_search.py
@@ -83,6 +83,15 @@ class ExhaustiveSearchSolver(CoreDivisionLayoutSolver):
         buffers_list = cast("list[CoreDivisionBuffer]", self.buffers)
 
         buf_by_name: dict[str, CoreDivisionBuffer] = {b.name: b for b in buffers_list}
+        children_by_parent: dict[
+            str, list[tuple[CoreDivisionBuffer, list[tuple[int, int]]]]
+        ] = {}
+        for child in buffers_list:
+            for parent_name in child.parents:
+                if parent_name in buf_by_name:
+                    children_by_parent.setdefault(parent_name, []).append(
+                        (child, child.cd_parent_matches.get(parent_name, []))
+                    )
 
         # CoreDivisionBuffer.size is the total device footprint (pre-division); that
         # is exactly the HBM cost when a buffer is not pinned to LX.
@@ -102,19 +111,20 @@ class ExhaustiveSearchSolver(CoreDivisionLayoutSolver):
 
             Starts from the pre-computed ``b.residency_reason`` (computed by
             :class:`CoOptimizingAllocator` with ``division_is_fixed=False``), then
-            adds the division-compatibility check via ``cd_parent_matches``: if no
-            (parent_div, ci) pair in ``cd_parent_matches[parent]`` matches the
-            parent's currently-chosen division, the per-core views disagree and the
-            buffer must spill.
+            adds the division-compatibility check via ``cd_parent_matches``. A
+            resident producer must match every consumer: if no
+            ``(producer_div, consumer_div)`` pair matches the selected divisions,
+            the producer spills so the consumer reads it correctly from HBM. This
+            is the same direction used by the CP-SAT and annealing solvers.
             """
             if b.residency_reason is not None:
                 return b.residency_reason
-            for p_name in b.parents:
-                if p_name not in buf_by_name:
-                    continue
-                pi = chosen[p_name]
-                pairs = b.cd_parent_matches.get(p_name, [])
-                if not any(pp == pi and pc == ci for pp, pc in pairs):
+            for child, pairs in children_by_parent.get(b.name, []):
+                child_division = chosen[child.name]
+                if not any(
+                    producer_division == ci and consumer_division == child_division
+                    for producer_division, consumer_division in pairs
+                ):
                     return "core div mismatch"
             return None
 

--- a/torch_spyre/_inductor/scratchpad/graph_editor.py
+++ b/torch_spyre/_inductor/scratchpad/graph_editor.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 from torch.fx.graph import Graph
+from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ops_handler import WrapperHandler
 from torch_spyre._inductor.pass_utils import (
+    PerCoreView,
     commit_iteration_space_ownership,
+    commit_tensor_work_division,
     copy_op_metadata,
+    device_coordinates,
     iteration_space_from_op,
     invalidate_op_read_writes,
     op_read_writes,
@@ -107,8 +111,11 @@ class GraphEditor:
         *,
         input: bool,
         private: bool = False,
+        lx_view: PerCoreView | None = None,
     ) -> ComputedBuffer:
         """Insert a clone; private clones rewire only ``buffer_users``."""
+        if input and lx_view is None:
+            raise ValueError("an LX input clone requires its accepted physical view")
         if isinstance(buffer, TensorBox):
             buf_name = buffer.data.data.name  # type: ignore
         else:
@@ -179,35 +186,43 @@ class GraphEditor:
         self.lowering.register_operation(new_com_buf)
         new_buf_name = new_com_buf.get_name()
 
-        # Clone loops mirror their source/consumer symbols before Scheduler, so
-        # retain direct symbol ownership instead of round-tripping through index
-        # coefficients. A clone has no reduction split.
+        # Clone loops mirror their source/consumer symbols before Scheduler.
+        # Input ownership therefore comes directly from the accepted physical
+        # view; never rebuild its core order from index coefficients.
         metadata_owner = getattr(metadata_source, "iteration_space_ownership", None)
-        if input and metadata_owner is not None:
-            read = next(
-                (
-                    dep
-                    for dep in op_read_writes(metadata_source).reads
-                    if dep.name == buf_name
-                ),
-                None,
+        if input:
+            assert lx_view is not None
+            from torch_spyre._inductor.scratchpad.lx_relayout import (
+                work_division_from_view,
             )
-            clone_write = next(iter(op_read_writes(new_com_buf).writes))
-            by_coeff = {
-                read.index.coeff(sym): split
-                for sym, split in metadata_owner.work_slices.items()
-                if read is not None and read.index.coeff(sym) != 0
-            }
-            clone_splits = {
-                sym: by_coeff.get(clone_write.index.coeff(sym), 1)
-                for sym in iteration_space_from_op(new_com_buf)
-            }
+
+            clone_writes = [
+                dep
+                for dep in op_read_writes(new_com_buf).writes
+                if isinstance(dep, MemoryDep)
+            ]
+            if len(clone_writes) != 1:
+                raise ValueError(
+                    "LX input clone must have exactly one indexed tensor write, "
+                    f"got {len(clone_writes)}"
+                )
+            clone_write = clone_writes[0]
+            clone_space = iteration_space_from_op(new_com_buf)
+            clone_ownership = work_division_from_view(
+                lx_view,
+                clone_layout.device_layout.device_size,
+                device_coordinates(clone_layout.device_layout, clone_write, None),
+                clone_space,
+            )
+            if clone_ownership is None:
+                raise ValueError("LX clone is missing its accepted physical ownership")
+            commit_tensor_work_division(new_com_buf, clone_ownership)
         else:
             clone_splits = {
                 sym: metadata_owner.work_slices.get(sym, 1) if metadata_owner else 1
                 for sym in iteration_space_from_op(new_com_buf)
             }
-        commit_iteration_space_ownership(new_com_buf, clone_splits)
+            commit_iteration_space_ownership(new_com_buf, clone_splits)
 
         if input:
             source_users = []
@@ -248,9 +263,15 @@ class GraphEditor:
         self,
         buffer: ComputedBuffer,
         consumers: list[ComputedBuffer],
+        *,
+        lx_view: PerCoreView,
     ) -> ComputedBuffer:
         return self.push_allocation_with_clone(
-            buffer, consumers, input=True, private=True
+            buffer,
+            consumers,
+            input=True,
+            private=True,
+            lx_view=lx_view,
         )
 
     @staticmethod

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import cast
 
 import sympy
@@ -30,16 +30,25 @@ from torch._inductor.ir import (
 )
 
 from .. import config
+from ..core_mapping import (
+    core_mappings_equal,
+    owner_slots,
+    _loop_regions,
+    _LOOP_POINT,
+    _MAX_EXACT_DIRECT_AXIS_POINTS,
+    _MAX_EXACT_OWNERSHIP_POINTS,
+    _EVALUATION_ERRORS,
+    select_unique_partition_division,
+)
 from ..ir import FixedTiledLayout
 from ..logging_utils import get_inductor_logger
-from ..core_mapping import core_mappings_equal, owner_slots
 from ..op_spec import TensorWorkDivision
+from ..padding import is_restickify_op
 from ..pass_utils import (
     PerCoreView,
     _is_matmul_op,
     _per_core_view_on_buf,
     iteration_space_from_op,
-    op_short_name,
     op_read_writes,
     try_device_coordinates,
 )
@@ -71,43 +80,170 @@ class LXRelayoutPlan:
 
 def work_division_from_view(
     view: PerCoreView | None,
+    device_size: Sequence[int],
     device_coordinates: Sequence[sympy.Expr],
-    iteration_symbols: Sequence[sympy.Symbol],
+    iteration_space: Mapping[sympy.Symbol, sympy.Expr],
 ) -> TensorWorkDivision | None:
-    """Project physical per-core ownership into operation-loop symbols."""
-
+    """Interpret physical slices through an access, without choosing new owners."""
     if view is None:
         return None
-    if view.num_cores is None:
+    n = view.num_cores
+    if n is None or n <= 0:
         raise ValueError("LX ownership must carry its physical core domain")
-    loop_symbols = set(iteration_symbols)
-    splits: dict[sympy.Symbol, int] = {}
-    core_map: dict[sympy.Symbol, sympy.Expr] = {}
-    slots = dict(view.core_to_slot)
-    for device_dim, split in view.work_slice_dims:
-        if device_dim >= len(device_coordinates):
-            raise ValueError(f"missing device coordinate {device_dim}")
-        matches = device_coordinates[device_dim].free_symbols & loop_symbols
-        if len(matches) != 1:
-            raise ValueError(f"cannot map device dimension {device_dim} to one loop")
-        dim = next(iter(matches))
-        slot = sympy.sympify(slots[device_dim])
-        if dim in splits and (
-            splits[dim] != split
-            or not core_mappings_equal(
-                {dim: core_map[dim]}, {dim: slot}, view.num_cores
-            )
+    physical_splits, slots = dict(view.work_slice_dims), dict(view.core_to_slot)
+    if len(device_size) != len(device_coordinates):
+        raise ValueError("sizes and coordinates differ in rank")
+    if len(physical_splits) != len(view.work_slice_dims) or len(slots) != len(
+        view.core_to_slot
+    ):
+        raise ValueError("duplicate physical dimensions")
+    rows = owner_slots(slots, physical_splits, n)
+    axes_by_loop: dict[sympy.Symbol, list[int]] = {}
+    for axis, split in physical_splits.items():
+        if (
+            not 0 <= axis < len(device_size)
+            or sympy.sympify(device_size[axis]).is_Integer is not True
+            or device_size[axis] <= 0
+            or device_size[axis] % split
         ):
-            raise ValueError(f"conflicting ownership for loop {dim}")
-        splits[dim] = split
-        core_map[dim] = slot
-    return TensorWorkDivision(splits, core_map, num_cores=view.num_cores)
+            raise ValueError(
+                f"unsupported ownership input: axis {axis} not divisible by {split}"
+            )
+        symbols = device_coordinates[axis].free_symbols
+        if len(symbols) != 1 or not symbols <= iteration_space.keys():
+            raise ValueError(f"cannot map device dimension {axis} to one loop")
+        axes_by_loop.setdefault(next(iter(symbols)), []).append(axis)
+
+    any_fused = any(len(axes) > 1 for axes in axes_by_loop.values())
+    splits, owners, expected = {}, {}, {}
+    fused_states = 0
+    for loop, axes in axes_by_loop.items():
+        extent = iteration_space[loop]
+        extent = sympy.sympify(extent[0] if isinstance(extent, tuple) else extent)
+        if extent.is_Integer is not True or extent <= 0:
+            raise ValueError(
+                f"unsupported ownership input: loop extent {extent} is not concrete"
+            )
+        extent = int(extent)
+        first = axes[0]
+        same = all(
+            physical_splits[a] == physical_splits[first]
+            and core_mappings_equal({loop: slots[a]}, {loop: slots[first]}, n)
+            for a in axes
+        )
+        split = (
+            physical_splits[first]
+            if same
+            else math.prod(physical_splits[a] for a in axes)
+        )
+        splits[loop] = split
+        if len(axes) == 1:
+            stick = len(device_size) - 1
+            if (
+                first != stick
+                and stick not in physical_splits
+                and loop in device_coordinates[-1].free_symbols
+            ):
+                padded = int(device_size[first] * device_size[-1])
+                if padded - device_size[-1] < extent <= padded:
+                    extent = padded
+            if extent > _MAX_EXACT_DIRECT_AXIS_POINTS:
+                raise ValueError(
+                    f"proof limit: direct axis needs {extent} points; limit is {_MAX_EXACT_DIRECT_AXIS_POINTS}"
+                )
+        else:
+            fused_states += extent + split
+            if fused_states > _MAX_EXACT_OWNERSHIP_POINTS:
+                raise ValueError(
+                    f"proof limit: fused axes need {fused_states} states; limit is {_MAX_EXACT_OWNERSHIP_POINTS}"
+                )
+        if extent % split:
+            raise ValueError(
+                f"unsupported ownership input: loop {loop} not divisible by {split}"
+            )
+        try:
+            bounds = _loop_regions(
+                extent,
+                tuple(
+                    device_coordinates[a].xreplace({loop: _LOOP_POINT}) for a in axes
+                ),
+                tuple(int(device_size[a]) for a in axes),
+                split,
+            )
+        except _EVALUATION_ERRORS as exc:
+            raise ValueError(
+                f"unsupported ownership evaluation: {type(exc).__name__}: {exc}"
+            ) from exc
+        widths = [int(device_size[a]) // physical_splits[a] for a in axes]
+        signatures = [
+            tuple(low // width for (low, _), width in zip(region, widths))
+            for region in bounds
+        ]
+        if any(
+            low // width != high // width
+            for region in bounds
+            for (low, high), width in zip(region, widths)
+        ):
+            raise ValueError(
+                "ownership mismatch: one loop partition crosses physical slices"
+            )
+        if len(set(signatures)) != split:
+            raise ValueError(
+                "ownership mismatch: loop partitions do not cover distinct physical slices"
+            )
+        try:
+            table = tuple(signatures.index(tuple(row[a] for a in axes)) for row in rows)
+        except ValueError:
+            raise ValueError(
+                "ownership mismatch: a core owns slices no loop partition covers"
+            ) from None
+        if set(table) != set(range(split)) or (
+            not any_fused and signatures != [(p,) for p in range(split)]
+        ):
+            raise ValueError(
+                "ownership mismatch: loop and physical slices have different core owners"
+            )
+        expected[loop] = table
+        owners[loop] = slots[first]
+
+    if not any_fused:
+        return TensorWorkDivision(splits, owners, num_cores=n)
+    # The physical slices already determine every loop owner. Search only for
+    # the existing supported spelling, never re-prove the access per candidate.
+    expected_rows = tuple(
+        {loop: table[core] for loop, table in expected.items()} for core in range(n)
+    )
+    candidate = select_unique_partition_division(
+        tuple(loop for loop in iteration_space if loop in splits),
+        splits,
+        n,
+        lambda division: owner_slots(division.core_id_to_work_slice, splits, n)
+        == expected_rows,
+    )
+    if candidate is None:
+        raise ValueError("no unique certified canonical mapping for fused ownership")
+    return candidate
 
 
 def materialized_lx_relayouts(
     graph: GraphLowering,
 ) -> dict[tuple[str, str], tuple[str, LXRelayoutPlan]]:
     return getattr(graph, _REGISTRY, {})
+
+
+def materialized_lx_relayout_for_destination(
+    graph: GraphLowering, destination_name: str
+) -> LXRelayoutPlan | None:
+    """Return the certified plan which created one destination copy."""
+
+    return next(
+        (
+            plan
+            for copy_name, plan in materialized_lx_relayouts(graph).values()
+            if copy_name == destination_name
+        ),
+        None,
+    )
 
 
 def _discard_lx_relayout_group(graph: GraphLowering, source_name: str) -> set[str]:
@@ -155,46 +291,22 @@ def _core_slices(view: PerCoreView, num_cores: int) -> dict[int, dict[int, int]]
     return dict(enumerate(rows))
 
 
-def _overlap(a: int, an: int, b: int, bn: int) -> bool:
-    return a * bn < (b + 1) * an and b * an < (a + 1) * bn
-
-
-def _compatible_partitions(
-    source: PerCoreView, destination: PerCoreView, num_cores: int
-) -> bool:
-    source_map = _core_slices(source, num_cores)
-    destination_map = _core_slices(destination, num_cores)
-    source_splits = dict(source.work_slice_dims)
-    destination_splits = dict(destination.work_slice_dims)
-    dims = set(source_splits) | set(destination_splits)
-    edges = {
-        (s_core, d_core)
-        for s_core, s_slice in source_map.items()
-        for d_core, d_slice in destination_map.items()
-        if all(
-            _overlap(
-                s_slice.get(dim, 0),
-                source_splits.get(dim, 1),
-                d_slice.get(dim, 0),
-                destination_splits.get(dim, 1),
-            )
-            for dim in dims
-        )
-    }
-    fanout = [sum(src == core for src, _ in edges) for core in range(num_cores)]
-    fanin = [sum(dst == core for _, dst in edges) for core in range(num_cores)]
-    return bool(edges) and all(
-        (
-            len(set(fanout)) == 1,
-            len(set(fanin)) == 1,
-            len({tuple(sorted(row.items())) for row in source_map.values()})
-            == num_cores,
-            len({tuple(sorted(row.items())) for row in destination_map.values()})
-            == num_cores,
-            math.prod(source_splits.values()) == num_cores,
-            math.prod(destination_splits.values()) == num_cores,
-        )
-    )
+def movement_supported(source, destination, source_num_cores, destination_num_cores):
+    """The original relayout: two complete, distinct partitions of the same cores."""
+    if source_num_cores != destination_num_cores or source_num_cores <= 0:
+        return False
+    if source.same_partition(destination):
+        return False
+    for view in (source, destination):
+        if math.prod(dict(view.work_slice_dims).values()) != source_num_cores:
+            return False
+        rows = _core_slices(view, source_num_cores)
+        if (
+            len({tuple(sorted(row.items())) for row in rows.values()})
+            != source_num_cores
+        ):
+            return False
+    return True
 
 
 def _single_write(op: ComputedBuffer, name: str) -> MemoryDep | None:
@@ -208,10 +320,12 @@ def _single_write(op: ComputedBuffer, name: str) -> MemoryDep | None:
     return writes[0]
 
 
-def _is_activation_source(operations: dict[str, Operation], op: Operation) -> bool:
+def _is_activation_source(
+    graph: GraphLowering, operations: dict[str, Operation], op: Operation
+) -> bool:
     """Exclude restickified graph inputs and weights from activation relayout."""
 
-    return op_short_name(op) != "restickify" or any(
+    return not is_restickify_op(op, graph) or any(
         isinstance(operations.get(dep.name), ComputedBuffer)
         for dep in op_read_writes(op).reads
         if isinstance(dep, MemoryDep)
@@ -224,7 +338,7 @@ def _unsupported_relayout_transition_reason(
 ) -> str | None:
     """Reject ownership changes that the identity-copy emitter cannot represent.
 
-    ``op_spec.is_lx_relayout_identity`` recognizes a physical reshuffle only
+    ``op_spec.is_lx_relayout_identity`` recognizes a physical shuffle only
     when the two tensor work divisions differ. If distinct per-core views
     project to the same work division, codegen would lower the materialized
     copy as an ordinary identity and silently omit the required cross-core
@@ -233,16 +347,20 @@ def _unsupported_relayout_transition_reason(
     """
 
     if source_work_division.same_ownership(destination_work_division):
-        return "distinct physical ownerships collapse to the same logical work division"
+        return (
+            "cannot emit: distinct physical ownerships collapse to the same "
+            "logical work division"
+        )
     return None
 
 
-def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
+def collect_lx_relayout_plans(
+    graph: GraphLowering,
+) -> list[LXRelayoutPlan]:
     if not config.lx_planner_relayout or config.ktir_emitter:
         return []
-    assert not materialized_lx_relayouts(graph), (
-        "LX relayout planning requires an unmaterialized graph"
-    )
+    if materialized_lx_relayouts(graph):
+        raise RuntimeError("LX relayout planning requires an unmaterialized graph")
 
     cache: dict = {}
     operations = {op.get_name(): op for op in graph.operations}
@@ -262,137 +380,205 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
         ):
             continue
         source_view, partial, representable = _per_core_view_on_buf(
-            producer, write, source_name, cache
+            producer,
+            write,
+            source_name,
+            cache,
         )
-        num_cores = _op_num_cores(producer)
-        if source_view is None or partial or not representable:
+        source_num_cores = _op_num_cores(producer)
+        if (
+            source_view is None
+            or partial
+            or not representable
+            or source_view.num_cores != source_num_cores
+        ):
             continue
 
         # Activation eligibility belongs to the producer, not to an individual
         # edge. Never relayout a restickified graph input or weight.
-        if not _is_activation_source(operations, producer):
+        if not _is_activation_source(graph, operations, producer):
             continue
 
         producer_coordinates = try_device_coordinates(
             producer.layout.device_layout, write, None
         )
         if producer_coordinates is None:
+            logger.debug(
+                "rejected LX relayout candidate source=%s: "
+                "cannot represent: producer coordinates are unavailable",
+                source_name,
+            )
             continue
         try:
             work_division_from_view(
                 source_view,
+                producer.layout.device_layout.device_size,
                 producer_coordinates,
-                tuple(iteration_space_from_op(producer)),
+                iteration_space_from_op(producer),
             )
-        except ValueError:
+        except ValueError as exc:
+            logger.debug(
+                "rejected LX relayout candidate source=%s: "
+                "cannot represent: source ownership cannot be projected to producer: %s",
+                source_name,
+                exc,
+            )
             continue
 
         # Relayout copies sharing one source are allocated and materialized as
         # one atomic group. Any unsupported consumer therefore rejects the
         # group; supported consumers keep using the original buffer instead.
-        consumers_by_view: list[tuple[PerCoreView, list[str]]] = []
+        transfers = []
         seen_consumers = set()
         rejection_reason = None
         for consumer, dep in consumer_reads:
             consumer_name = consumer.get_name()
             if consumer_name in seen_consumers:
-                rejection_reason = "consumer reads the source more than once"
+                rejection_reason = (
+                    "cannot emit: consumer reads the source more than once"
+                )
                 break
             if not isinstance(consumer, ComputedBuffer) or isinstance(
                 consumer.layout, MutationLayoutSHOULDREMOVE
             ):
-                rejection_reason = "consumer is not a supported computed buffer"
+                rejection_reason = (
+                    "cannot emit: consumer is not a supported computed buffer"
+                )
                 break
             seen_consumers.add(consumer_name)
             deps = [
                 d for d in op_read_writes(consumer).reads if isinstance(d, MemoryDep)
             ]
             if any(d.is_indirect() for d in deps):
-                rejection_reason = "consumer uses indirect access"
+                rejection_reason = "cannot emit: consumer uses indirect access"
                 break
             view, consumer_partial, representable = _per_core_view_on_buf(
                 consumer, dep, source_name, cache
             )
-            if (
-                view is None
-                or consumer_partial
-                or not representable
-                or _op_num_cores(consumer) != num_cores
-            ):
+            consumer_num_cores = _op_num_cores(consumer)
+            if view is None or consumer_partial or not representable:
                 rejection_reason = (
-                    "consumer ownership is partial, unrepresentable, or uses a "
-                    "different core count"
+                    "cannot represent: consumer ownership is partial or unrepresentable"
                 )
+                break
+            if consumer_num_cores != source_num_cores:
+                rejection_reason = "cannot emit: different core counts"
                 break
             consumer_coordinates = try_device_coordinates(
                 producer.layout.device_layout, dep, None
             )
             if consumer_coordinates is None:
-                rejection_reason = "consumer coordinates are unavailable"
-                break
-            consumer_symbols = tuple(iteration_space_from_op(consumer))
-            try:
-                source_work_division = work_division_from_view(
-                    source_view, consumer_coordinates, consumer_symbols
+                rejection_reason = (
+                    "cannot represent: consumer coordinates are unavailable"
                 )
-            except ValueError:
-                rejection_reason = "source ownership cannot be projected to consumer"
                 break
-            assert source_work_division is not None
+            consumer_space = iteration_space_from_op(consumer)
             if view.same_partition(source_view):
                 continue
             is_matmul = _is_matmul_op(consumer)
             if is_matmul and len(deps) != 2:
-                rejection_reason = "matmul consumer does not have two inputs"
+                rejection_reason = (
+                    "cannot emit: matmul consumer does not have two inputs"
+                )
                 break
             if not is_matmul and not isinstance(consumer.data, Pointwise):
-                rejection_reason = "consumer is neither pointwise nor matmul"
-                break
-            try:
-                compatible = _compatible_partitions(source_view, view, num_cores)
-            except (TypeError, ValueError) as exc:
-                rejection_reason = f"invalid ownership partition: {exc}"
-                break
-            if not compatible:
-                rejection_reason = "source and destination partitions are incompatible"
-                break
-            try:
-                destination_work_division = work_division_from_view(
-                    view, consumer_coordinates, consumer_symbols
-                )
-            except ValueError:
                 rejection_reason = (
-                    "destination ownership cannot be projected to consumer"
+                    "cannot emit: consumer is neither pointwise nor matmul"
                 )
                 break
-            assert destination_work_division is not None
-            if reason := _unsupported_relayout_transition_reason(
-                source_work_division, destination_work_division
-            ):
-                rejection_reason = reason
+
+            failure = "cannot emit: unsupported ownership transfer"
+
+            try:
+                supported = movement_supported(
+                    source_view, view, source_num_cores, consumer_num_cores
+                )
+            except (TypeError, ValueError) as exc:
+                rejection_reason = (
+                    f"cannot represent: invalid ownership partition: {exc}"
+                )
                 break
-            for destination_view, consumer_names in consumers_by_view:
-                if destination_view.same_partition(view):
-                    consumer_names.append(consumer_name)
+            if not supported:
+                rejection_reason = failure
+                break
+            transfers.append(
+                (consumer_name, consumer_coordinates, consumer_space, view)
+            )
+
+        # Reuse the ownership comparison and preserve first-consumer order.
+        destinations: list[tuple[PerCoreView, list[str]]] = []
+        if rejection_reason is None:
+            for (
+                consumer_name,
+                consumer_coordinates,
+                consumer_space,
+                destination_view,
+            ) in transfers:
+                try:
+                    source_work_division = work_division_from_view(
+                        source_view,
+                        producer.layout.device_layout.device_size,
+                        consumer_coordinates,
+                        consumer_space,
+                    )
+                except ValueError as exc:
+                    rejection_reason = (
+                        "cannot represent: source ownership cannot be projected "
+                        f"to consumer: {exc}"
+                    )
                     break
-            else:
-                consumers_by_view.append((view, [consumer_name]))
+                if source_work_division is None:
+                    raise RuntimeError(
+                        "LX relayout source lost its certified physical ownership"
+                    )
+                try:
+                    destination_work_division = work_division_from_view(
+                        destination_view,
+                        producer.layout.device_layout.device_size,
+                        consumer_coordinates,
+                        consumer_space,
+                    )
+                except ValueError as exc:
+                    rejection_reason = (
+                        "cannot represent: destination ownership cannot be projected "
+                        f"to consumer: {exc}"
+                    )
+                    break
+                if destination_work_division is None:
+                    raise RuntimeError(
+                        "LX relayout destination lost its certified physical ownership"
+                    )
+                if reason := _unsupported_relayout_transition_reason(
+                    source_work_division, destination_work_division
+                ):
+                    rejection_reason = reason
+                    break
+                for group_view, consumers in destinations:
+                    if group_view.same_partition(destination_view):
+                        consumers.append(consumer_name)
+                        break
+                else:
+                    destinations.append((destination_view, [consumer_name]))
+
         if rejection_reason is None:
             result.extend(
                 LXRelayoutPlan(
-                    source_name,
-                    tuple(consumer_names),
-                    source_view,
-                    destination_view,
-                    num_cores,
+                    source_name=source_name,
+                    consumer_names=tuple(consumer_names),
+                    source_view=source_view,
+                    destination_view=destination_view,
+                    num_cores=source_num_cores,
                 )
-                for destination_view, consumer_names in consumers_by_view
+                for (
+                    destination_view,
+                    consumer_names,
+                ) in destinations
             )
         if rejection_reason is not None:
             logger.debug(
-                "rejected LX relayout candidate source=%s consumer=%s: %s",
+                "rejected LX relayout candidate source=%s consumers=%s: %s",
                 source_name,
-                consumer_name,
+                tuple(consumer.get_name() for consumer, _ in consumer_reads),
                 rejection_reason,
             )
     return result
@@ -400,30 +586,41 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
 
 def materialize_lx_relayouts(graph: GraphLowering, plans: list[LXRelayoutPlan]) -> None:
     if not plans:
-        assert not materialized_lx_relayouts(graph)
+        if materialized_lx_relayouts(graph):
+            raise RuntimeError("LX relayouts were already materialized")
         return
     from .graph_editor import GraphEditor
 
     copies = materialized_lx_relayouts(graph)
-    assert not copies, "LX relayouts were already materialized"
+    if copies:
+        raise RuntimeError("LX relayouts were already materialized")
     editor = GraphEditor(graph)
     setattr(graph, _REGISTRY, copies)
     for plan in plans:
+        if plan.source_address is None or plan.destination_address is None:
+            raise RuntimeError("LX relayout plan is missing an allocated address")
         source = cast(ComputedBuffer, graph.get_buffer(plan.source_name))
-        consumers = [
-            cast(ComputedBuffer, graph.get_buffer(name)) for name in plan.consumer_names
-        ]
-        copy = editor.insert_clone_before_consumers(source, consumers)
-        copies[plan.edge] = (copy.get_name(), plan)
-
-        assert plan.source_address is not None and plan.destination_address is not None
         if plan.source_view.same_partition(plan.destination_view):
             raise RuntimeError("LX relayout plan has identical source and destination")
         source_layout = cast(FixedTiledLayout, source.layout)
+        if (
+            source_layout.allocation.get("lx") != plan.source_address
+            or source_layout.lx_view is None
+            or not source_layout.lx_view.same_partition(plan.source_view)
+        ):
+            raise RuntimeError("placed relayout source disagrees with its plan")
+        consumers = [
+            cast(ComputedBuffer, graph.get_buffer(name)) for name in plan.consumer_names
+        ]
+        copy = editor.insert_clone_before_consumers(
+            source,
+            consumers,
+            lx_view=plan.destination_view,
+        )
+        copies[plan.edge] = (copy.get_name(), plan)
+
         copy_layout = cast(FixedTiledLayout, copy.layout)
-        source_layout.allocation["lx"] = plan.source_address
         copy_layout.allocation["lx"] = plan.destination_address
-        source_layout.lx_view = plan.source_view
         copy_layout.lx_view = plan.destination_view
         logger.debug(
             "accepted LX relayout %s -> %s: source=%s@%d destination=%s@%d",

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -25,6 +25,7 @@ from torch_spyre._inductor.logging_utils import get_inductor_logger
 from enum import Enum
 
 if TYPE_CHECKING:
+    from torch_spyre._inductor.pass_utils import PerCoreView
     from torch_spyre._inductor.scratchpad.lx_relayout import LXRelayoutPlan
 
 logger = get_inductor_logger("scratchpad.plan_solver")
@@ -96,6 +97,9 @@ class LifetimeBoundBuffer:
     lx_relayout_plans: list["LXRelayoutPlan"] = field(
         default_factory=list, repr=False, compare=False
     )
+    # The physical per-core ownership accepted by the residency judge. Placement
+    # writes this beside the LX address; it must never derive another view.
+    lx_view: Optional["PerCoreView"] = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         # Not also asserted non-empty: buffers are sometimes registered before

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -29,7 +29,7 @@ from torch.utils._sympy.value_ranges import ValueRanges, bound_sympy
 
 import sympy
 
-from torch_spyre._inductor.constants import BYTES_PER_STICK
+from torch_spyre._C import get_device_size_in_bytes
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.pass_utils import (
     PerCoreView,
@@ -236,7 +236,7 @@ def mem_usage_by_buf(
             }
             continue
         dev_layout = layout.device_layout
-        dev_size = math.prod(dev_layout.device_size[:-1]) * BYTES_PER_STICK
+        dev_size = get_device_size_in_bytes(dev_layout)
         mem_usage[buf_name] = {
             "size": dev_size,
             "size_per_core": dev_size // num_cores,

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -29,9 +29,10 @@ from torch.utils._sympy.value_ranges import ValueRanges, bound_sympy
 
 import sympy
 
-from torch_spyre._inductor import config
+from torch_spyre._inductor.constants import BYTES_PER_STICK
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.pass_utils import (
+    PerCoreView,
     _per_core_view_on_buf,
     concretize_expr,
     op_read_writes,
@@ -203,7 +204,7 @@ def mem_usage_by_buf(
     """
     # The mismatch reasons are surfaced by the residency path; here only the
     # per-buffer core count (with -1 marking a mismatch) drives mem_usage.
-    num_cores_per_op, _ = get_ncores_for_buffers(graph, cache)
+    num_cores_per_op, _, _ = get_ncores_for_buffers(graph, cache)
     mem_usage: dict = {}
 
     for op in graph.operations:
@@ -235,9 +236,7 @@ def mem_usage_by_buf(
             }
             continue
         dev_layout = layout.device_layout
-        dev_size = (
-            math.prod(dev_layout.device_size[:-1]) * 128
-        )  # num_sticks * bytes_per_stick
+        dev_size = math.prod(dev_layout.device_size[:-1]) * BYTES_PER_STICK
         mem_usage[buf_name] = {
             "size": dev_size,
             "size_per_core": dev_size // num_cores,
@@ -246,6 +245,24 @@ def mem_usage_by_buf(
         }
 
     return mem_usage
+
+
+def is_empty_tiled_layout(layout: object) -> bool:
+    """A valid empty tensor needs no LX placement or input clone.
+
+    Native stickification preserves zero outer extents. Do not confuse those
+    with malformed negative extents, a missing stick axis, or a zero physical
+    extent on a logically nonempty tensor: those still need strict validation.
+    """
+    if not isinstance(layout, FixedTiledLayout) or 0 not in layout.size:
+        return False
+    device_size = layout.device_layout.device_size
+    return (
+        bool(device_size)
+        and device_size[-1] > 0
+        and all(extent >= 0 for extent in device_size)
+        and 0 in device_size[:-1]
+    )
 
 
 def buffer_not_read_in_full(graph: GraphLowering, buf_name: str) -> bool:
@@ -520,17 +537,20 @@ def _get_buffer_user_deps(
 def _op_num_cores(op: Operation) -> int:
     """Cores implied by symbol-keyed ownership (defaults to one)."""
     ownership = getattr(op, "iteration_space_ownership", None)
-    return math.prod(ownership.work_slices.values()) if ownership is not None else 1
+    return ownership.physical_core_count if ownership is not None else 1
 
 
 def get_ncores_for_buffers(
     graph: GraphLowering, cache: Optional[dict] = None
-) -> tuple[dict[str, int], dict[str, str]]:
+) -> tuple[dict[str, int], dict[str, str], dict[str, PerCoreView]]:
     """
-    Return ``(num_cores, mismatch_reasons)``, where ``num_cores`` maps each
+    Return ``(num_cores, mismatch_reasons, accepted_views)``, where ``num_cores`` maps each
     buffer name to the number of cores used by all the operations that use the
     buffer (``-1`` on a core-division mismatch) and ``mismatch_reasons`` maps
-    each mismatched buffer name to a human-readable reason for the ``-1``.
+    each mismatched buffer name to a human-readable reason for the ``-1``, and
+    ``accepted_views`` carries the exact physical view approved by the judge.
+
+    Run before allocator post-optimization passes add dump/restore writes.
 
     Pass an optional `cache` dict to memoize `_per_core_view_on_buf`
     results across calls (e.g. across co-opt search leaves). Safe to
@@ -539,96 +559,107 @@ def get_ncores_for_buffers(
     """
     result: dict[str, int] = {}
     mismatch_reasons_cache: dict[str, str] = {}
-    using_multicore = config.sencores > 1
+    accepted_views: dict[str, PerCoreView] = {}
     buf_user_deps = _get_buffer_user_deps(graph)
     for buf_name, users in buf_user_deps.items():
+        layout = getattr(graph.try_get_buffer(buf_name), "layout", None)
+        if is_empty_tiled_layout(layout):
+            # Reject before the unsplit whole-buffer view shortcut and before
+            # positive-partition footprint measurement. The existing rejection
+            # state also prevents publishing an LX view for an input clone.
+            result[buf_name] = -1
+            mismatch_reasons_cache[buf_name] = "empty tensor"
+            continue
         # this dict includes graph input and output
         if any(isinstance(user, ExternKernel) for user, _ in users):
-            # A FallbackKernel/ExternKernel is opaque: it has no
-            # op_it_space_splits or per-core tiling at all -- it needs the
-            # whole tensor as a real, materialized HBM value (its own call
-            # argument or write target). There is no PerCoreView to compare
-            # against a producer/other consumer's, so this buffer can never be
-            # LX-resident, regardless of core count (unlike the mismatch checks
-            # below, this is not gated on using_multicore: at SENCORES=1 the
-            # branches below never compare views at all and would default this
-            # buffer to num_cores=1, i.e. "fine").
+            # An opaque operation needs a materialized HBM tensor as its own
+            # argument or result, even on one core. Dump/restore protects other
+            # LX buffers merely live across that call; it does not change this
+            # direct-operand contract.
             result[buf_name] = -1
             mismatch_reasons_cache[buf_name] = (
                 f"FallbackKernel/ExternKernel user among {[u.get_name() for u, _ in users]}"
             )
             continue
-        if using_multicore and len(users) > 1:
-            # A K-split-reduction writer leaves partial sums on most cores (only
-            # k-last cores hold the final value), so it's unsafe on LX even if
-            # geometry matches — the `flag` gate applies to write-deps only.
-            ref_view = None
-            ref_op_name = None
-            mismatch_reason = None
-            writer_cores = None
-            for op, dep in users:
-                view, flag, _ = _per_core_view_on_buf(op, dep, buf_name, cache)
-                if ref_view is None:
-                    ref_view = view
-                op_rw = op_read_writes(op)
-                if dep in op_rw.writes:
-                    # Size by the writer's core count (the writer sets per-core
-                    # footprint size/writer_cores; readers touch only their slice),
-                    # not max() over users. One writer per buffer (it's named after
-                    # its producing op; an in-place op recurs as a reader, not a
-                    # second writer). _op_num_cores folds in K-split factors, an
-                    # unfaithful output divisor — but a K-split sets `flag` and is
-                    # rejected below, so writer_cores divides only for output splits.
-                    writer_cores = _op_num_cores(op)
-                    if flag:
-                        mismatch_reason = f"K-split writer '{op.get_name()}'"
-                        break
-                else:
-                    # Broadcast-read guard. `view` is how this consumer slices the
-                    # buffer; its core count is the product of the split factors.
-                    # When a consumer splits an iteration axis the buffer does not
-                    # have (e.g. a GEMM's free/N dim over a shared activation, or
-                    # its M dim over a shared weight), that split contracts out of
-                    # the view, so the view covers fewer cores than the op runs.
-                    # An LX (per-core scratchpad) buffer would then live on
-                    # view_cores cores but be read by op_cores; the cores without
-                    # a local copy read stale scratchpad -> wrong results. There is
-                    # no single-base LX broadcast, so treat it as a core-division
-                    # mismatch and keep the buffer in HBM (correct, just unpinned).
-                    # This is not writer-relative: it catches broadcast reads even
-                    # when the buffer has no in-graph writer (a graph input cloned
-                    # into LX) or when a producer's view happens to match the
-                    # broadcast footprint -- cases the `view != ref_view` check
-                    # below cannot see.
-                    # work_slice_dims entries are (device-dim, split factor);
-                    # the per-dim core count is the split factor.
-                    view_cores = math.prod(f for _, f in view.work_slice_dims)
-                    if view_cores != _op_num_cores(op):
-                        mismatch_reason = (
-                            f"broadcast read on '{op.get_name()}': view covers "
-                            f"{view_cores} cores but op runs {_op_num_cores(op)}"
-                        )
-                        break
-                if ref_view is not None and not view.same_partition(ref_view):
+        # _get_buffer_user_deps creates an entry only while appending its first
+        # dependency, so every value in this dictionary is non-empty.
+        # A K-split-reduction writer leaves partial sums on most cores (only
+        # k-last cores hold the final value), so it's unsafe on LX even if
+        # geometry matches — the `flag` gate applies to write-deps only.
+        ref_view = None
+        ref_op_name = None
+        mismatch_reason = None
+        writer_cores = None
+        for op, dep in users:
+            view, flag, representable = _per_core_view_on_buf(op, dep, buf_name, cache)
+            if not representable:
+                mismatch_reason = (
+                    f"ownership on '{op.get_name()}' cannot be represented "
+                    "by the physical buffer layout"
+                )
+                break
+            if ref_view is None:
+                ref_view = view
+                ref_op_name = op.get_name()
+            op_rw = op_read_writes(op)
+            if dep in op_rw.writes:
+                # Size by the writer's core count (the writer sets per-core
+                # footprint size/writer_cores; readers touch only their slice),
+                # not max() over users. One writer per buffer (it's named after
+                # its producing op; an in-place op recurs as a reader, not a
+                # second writer). _op_num_cores folds in K-split factors, an
+                # unfaithful output divisor — but a K-split sets `flag` and is
+                # rejected below, so writer_cores divides only for output splits.
+                writer_cores = _op_num_cores(op)
+                if flag:
+                    mismatch_reason = f"K-split writer '{op.get_name()}'"
+                    break
+            else:
+                # Broadcast-read guard. `view` is how this consumer slices the
+                # buffer; its core count is the product of the split factors.
+                # When a consumer splits an iteration axis the buffer does not
+                # have (e.g. a GEMM's free/N dim over a shared activation, or
+                # its M dim over a shared weight), that split contracts out of
+                # the view, so the view covers fewer cores than the op runs.
+                # An LX (per-core scratchpad) buffer would then live on
+                # view_cores cores but be read by op_cores; the cores without
+                # a local copy read stale scratchpad -> wrong results. There is
+                # no single-base LX broadcast, so treat it as a core-division
+                # mismatch and keep the buffer in HBM (correct, just unpinned).
+                # This is not writer-relative: it catches broadcast reads even
+                # when the buffer has no in-graph writer (a graph input cloned
+                # into LX) or when a producer's view happens to match the
+                # broadcast footprint -- cases the partition-equivalence
+                # check below cannot see.
+                # work_slice_dims entries are (device-dim, split factor);
+                # the per-dim core count is the split factor.
+                view_cores = math.prod(f for _, f in view.work_slice_dims)
+                if view_cores != _op_num_cores(op):
                     mismatch_reason = (
-                        f"op '{ref_op_name}' ref {ref_view} != '{op.get_name()}' {view}"
+                        f"broadcast read on '{op.get_name()}': view covers "
+                        f"{view_cores} cores but op runs {_op_num_cores(op)}"
                     )
                     break
-            if mismatch_reason is not None:
-                num_cores = -1
-                mismatch_reasons_cache[buf_name] = mismatch_reason
-            elif writer_cores is not None:
-                num_cores = writer_cores
-            else:
-                # No writer (graph input, produced outside the graph): fall back
-                # to the users' (matching) max count.
-                num_cores = max(_op_num_cores(op) for op, _ in users)
-        elif using_multicore:
-            num_cores = _op_num_cores(users[0][0])
+            if ref_view is not None and not view.same_partition(ref_view):
+                mismatch_reason = (
+                    f"op '{ref_op_name}' ref {ref_view} != '{op.get_name()}' {view}"
+                )
+                break
+        if mismatch_reason is not None:
+            num_cores = -1
+            mismatch_reasons_cache[buf_name] = mismatch_reason
         else:
-            num_cores = 1
+            # No writer (graph input, produced outside the graph): fall back
+            # to the users' (matching) max count.
+            num_cores = (
+                writer_cores
+                if writer_cores is not None
+                else max(_op_num_cores(op) for op, _ in users)
+            )
+            assert ref_view is not None
+            accepted_views[buf_name] = ref_view
         result[buf_name] = num_cores
-    return result, mismatch_reasons_cache
+    return result, mismatch_reasons_cache, accepted_views
 
 
 class _GetLoadStoreIndices(WrapperHandler):

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1037,9 +1037,17 @@ class SpyreKernel(Kernel[CSEVariable]):
         """Remove scratchpad and pool buffers from the kernel's argument list.
 
         HBM pooling runs after the kernel is prepared, so this runs again at
-        emission for the intermediates pooled in between.
+        emission for the intermediates pooled in between. ``KernelArgs.output``
+        resolves mutation aliases, so its real destination may appear only in
+        ``output_buffers``, not in the recorded stores or inputs.
         """
-        for name in OrderedSet([*self.store_buffer_names, *self.args.input_buffers]):
+        for name in OrderedSet(
+            [
+                *self.store_buffer_names,
+                *self.args.input_buffers,
+                *self.args.output_buffers,
+            ]
+        ):
             buf = V.graph.get_buffer(name)
             if buf is None:
                 continue
@@ -1047,11 +1055,13 @@ class SpyreKernel(Kernel[CSEVariable]):
             if isinstance(layout, FixedTiledLayout) and (
                 "lx" in layout.allocation or "hbm_pool" in layout.allocation
             ):
-                # A name can be registered on both legs; each is pruned alone.
+                # A name can be registered on several legs; each is pruned alone.
                 if name in self.store_buffer_names:
                     self.remove_buffer(name)
                 if name in self.args.input_buffers:
                     self.args.input_buffers[name] = REMOVED  # type: ignore[assignment]
+                if name in self.args.output_buffers:
+                    self.args.output_buffers[name] = REMOVED
 
     def load(self, name: str, index: sympy.Expr):
         """Codegen a load from an InputBuffer"""

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1167,7 +1167,7 @@ class SpyreKernel(Kernel[CSEVariable]):
 
             if indirect_syms_used:
                 # Gather/scatter: coordinates are built with raw indirect symbols here;
-                # indirect_access_subs is applied later in codegen_kernel → simplify_op_spec.
+                # create_op_spec applies indirect_access_subs during simplification.
                 # Only add the indirect tensors that this specific operation uses.
                 args = [
                     self.create_tensor_arg(
@@ -1821,7 +1821,7 @@ def simplify_op_spec(
 
 
 def _finalize_tensor_work_divisions(op_spec: OpSpec) -> None:
-    """Derive tensor owners from final symbols, never planning-time formulas."""
+    """Verify committed tensor owners in the final aligned iteration space."""
     finalized = finalize_tensor_work_divisions(
         op_spec.iteration_space,
         [arg.work_division for arg in op_spec.args],

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -13,23 +13,27 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+import itertools
+import math
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
-import itertools
 
 import torch
 import sympy
 
 from torch_spyre._C import DataFormats, ElementArrangement
 
+from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.codegen.common import (
     CSEVariable,
     Kernel,
+    REMOVED,
 )
 from torch_spyre._inductor.dtype_ops import DtypeOpTable
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ops_handler import DefaultHandler, StoreMode
 from torch._inductor.utils import IndentedBuffer, sympy_index_symbol, sympy_subs
+from torch.utils._ordered_set import OrderedSet
 from torch._inductor.virtualized import V
 
 
@@ -53,31 +57,30 @@ from .core_mapping import (
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .scratchpad.lx_relayout import work_division_from_view
+from .scratchpad.lx_relayout import (
+    materialized_lx_relayout_for_destination,
+    work_division_from_view,
+)
 from .pass_utils import (
-    AlignmentAccess,
-    build_operation_alignment_inputs,
     concretize_expr,
     compute_symbolic_bounds,
     finite_upper_or_none,
     iteration_space,
     iteration_space_with_splits,
     indirect_access_subs_from_kernel,
+    input_layout_for_operation,
     is_restickify_coords,
     alignment_coordinates,
 )
-from .views import (
-    AlignmentInputs,
-    align_tensors,
-    align_tensors_pure,
-    tiling_expr_to_device_expr,
-)
+from .views import align_tensors, tiling_expr_to_device_expr
 from .logging_utils import get_inductor_logger
 from .op_spec import (
     IndirectAccess,
+    LX_RELAYOUT_INFO_KEY,
     LoopSpec,
     OpSpec,
     TensorArg,
+    TensorWorkDivision,
     UnimplementedOp as OpSpecUnimplementedOp,
     format_op_spec_list,
     is_lx_relayout_identity,
@@ -520,13 +523,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._general_tile_advance_seen: dict[str, int] = {}
         self._tile_advance_symbols: dict[int, sympy.Symbol] = {}
         self._alignment_repeat_info: dict[sympy.Symbol, dict[str, Any]] = {}
-        # Specs stay in self.op_specs until codegen, and capture precedes lookup,
-        # so id(op_spec) remains stable for this side table's lifetime.
-        self._alignment_repeat_info_by_spec: dict[
-            int, dict[sympy.Symbol, dict[str, Any]]
-        ] = {}
-        self._alignment_access_by_tensor_arg: dict[int, AlignmentAccess] = {}
-        self._alignment_inputs_by_spec: dict[int, AlignmentInputs] = {}
+        self.scheduled_nodes: list[SchedulerNode] = []
+        self.failed_node: SchedulerNode | None = None
         self.pool_size: int = pool_size
         # Live call args, deduped and filtered to names in spyre_kernel_args.
         # Set by codegen_kernel(); used by call_kernel() to ensure arg_index
@@ -770,6 +768,10 @@ class SpyreKernel(Kernel[CSEVariable]):
         tensor: TensorAccess,
         opspec_name: "str | None" = None,
     ) -> TensorArg:
+        current_node = self.current_node
+        if current_node is None or current_node.node is None:
+            raise RuntimeError("TensorArg construction requires a current operation")
+        operation = current_node.node
         # OpSpec->KTIR needs a stable per-buffer identity for register-threaded
         # fused intermediates (all arg_index == -1): _buf_id keys on TensorArg.name,
         # which is serialized into the emitted op-spec literal and read back by
@@ -780,7 +782,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         # SDSC literal byte-identical.
         if opspec_name is None and _spyre_config.ktir_emitter:
             opspec_name = name
-        it_space = iteration_space(self.current_node)
+        it_space = iteration_space(current_node)
         # With dynamic=True the host index may contain symbolic strides
         # (e.g. x0*s1+x1).  Concretize size symbols so normalize_coordinates
         # can correctly isolate each loop variable's contribution.
@@ -788,10 +790,10 @@ class SpyreKernel(Kernel[CSEVariable]):
         # insert_post_mutation_restickify may override the input layout for this input tensor.
         # Restore it here because the tensor data was uploaded as orig_stl.
         if is_input:
-            overrides = getattr(self.current_node.node, "_input_layout_overrides", {})
-            if (layout := overrides.get(name)) is not None:
-                tensor.layout = layout
+            tensor.layout = input_layout_for_operation(operation, name, tensor.layout)
 
+        if "lx" in tensor.layout.allocation and tensor.layout.lx_view is None:
+            raise ValueError(f"LX buffer {name} has no physical ownership")
         device_coords = alignment_coordinates(
             tensor.layout.device_layout,
             tensor.index,
@@ -801,8 +803,9 @@ class SpyreKernel(Kernel[CSEVariable]):
         )
         work_division = work_division_from_view(
             tensor.layout.lx_view if "lx" in tensor.layout.allocation else None,
+            tensor.layout.device_layout.device_size,
             device_coords,
-            tuple(it_space),
+            it_space,
         )
         device_tile_advance_expr = self._general_tile_advance(tensor, is_input, name)
         tensor_arg = TensorArg(
@@ -816,9 +819,6 @@ class SpyreKernel(Kernel[CSEVariable]):
             name=opspec_name,
             device_tile_advance_expr=device_tile_advance_expr,
             work_division=work_division,
-        )
-        self._alignment_access_by_tensor_arg[id(tensor_arg)] = AlignmentAccess(
-            tensor.layout.device_layout, tensor.index
         )
         if (
             "lx" not in tensor.layout.allocation
@@ -863,19 +863,6 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space_extended = iteration_space_with_splits(
             ir_node, self.current_node.read_writes, it_space
         )
-        alignment_inputs = build_operation_alignment_inputs(
-            it_space,
-            [self._alignment_access_by_tensor_arg[id(arg)] for arg in args],
-            indirect_sizes=self.indirect_sizes,
-            repeat_info=self._alignment_repeat_info,
-            aligned_iteration_space=it_space_extended,
-        )
-        for arg, tensor in zip(args, alignment_inputs.tensors):
-            if list(arg.device_coordinates) != tensor["coordinates"]:
-                raise RuntimeError(
-                    "alignment input collection disagrees with tensor codegen"
-                )
-
         # Build per-level tiled_symbols (innermost first) for this op.
         # loop_tiled_dims / loop_tiled_reduction_dims are lists of per-level
         # dim-index lists, outermost first — so we build outermost-first then
@@ -999,6 +986,28 @@ class SpyreKernel(Kernel[CSEVariable]):
             and hasattr(ir_node.data, "ranges")
             else None
         )
+        # The registry is keyed by the inserted destination buffer (``buf3``),
+        # while scheduler nodes have operation names (``op3``). Certify the
+        # identity from its write, which is the stable link between them.
+        written = V.graph.scheduler.mutation_real_name
+        relayout_plans = [
+            plan
+            for dep in self.current_node.read_writes.writes
+            if isinstance(dep, MemoryDep)
+            and (
+                plan := materialized_lx_relayout_for_destination(
+                    V.graph, written.get(dep.name, dep.name)
+                )
+            )
+            is not None
+        ]
+        if len(relayout_plans) > 1:
+            raise RuntimeError("one operation writes multiple LX relayout destinations")
+        if LX_RELAYOUT_INFO_KEY in op_info and not relayout_plans:
+            raise RuntimeError("LX relayout marker has no matching registered plan")
+        if relayout_plans:
+            op_info = {**op_info, LX_RELAYOUT_INFO_KEY: True}
+
         op_spec = OpSpec(
             op,
             is_reduction,
@@ -1011,16 +1020,26 @@ class SpyreKernel(Kernel[CSEVariable]):
             node_output_ranges=node_output_ranges,
             debug_handle=debug_handle,
         )
-        self._alignment_repeat_info_by_spec[id(op_spec)] = {
-            symbol: dict(info) for symbol, info in self._alignment_repeat_info.items()
-        }
-        if op != RESTICKIFY_OP:
-            self._alignment_inputs_by_spec[id(op_spec)] = alignment_inputs
+        # Finish the operation here, while its inputs and its node are live.
+        # Every indirect symbol it can reference was bound by its own loads,
+        # so the substitution known now is the one it needs.
+        simplify_op_spec(
+            op_spec,
+            self.indirect_sizes,
+            indirect_access_subs_from_kernel(self.indirect_vars)
+            if self.indirect_vars
+            else None,
+            repeat_info=self._alignment_repeat_info,
+        )
         return op_spec
 
     def remove_kernel_local_buffers(self) -> None:
-        """Remove buffers that have a scratchpad or temporary allocation from the kernel's arg list."""
-        for name in list(self.store_buffer_names):
+        """Remove scratchpad and pool buffers from the kernel's argument list.
+
+        HBM pooling runs after the kernel is prepared, so this runs again at
+        emission for the intermediates pooled in between.
+        """
+        for name in OrderedSet([*self.store_buffer_names, *self.args.input_buffers]):
             buf = V.graph.get_buffer(name)
             if buf is None:
                 continue
@@ -1028,7 +1047,11 @@ class SpyreKernel(Kernel[CSEVariable]):
             if isinstance(layout, FixedTiledLayout) and (
                 "lx" in layout.allocation or "hbm_pool" in layout.allocation
             ):
-                self.remove_buffer(name)
+                # A name can be registered on both legs; each is pruned alone.
+                if name in self.store_buffer_names:
+                    self.remove_buffer(name)
+                if name in self.args.input_buffers:
+                    self.args.input_buffers[name] = REMOVED  # type: ignore[assignment]
 
     def load(self, name: str, index: sympy.Expr):
         """Codegen a load from an InputBuffer"""
@@ -1272,31 +1295,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         body = self.op_specs
         self.op_specs = [LoopSpec(count=count, body=body)]
 
-    def codegen_kernel(self):
-        """Codegen the body of this kernel by pretty printing its list of OpSpecs"""
-
-        indirect_access_subs = (
-            indirect_access_subs_from_kernel(self.indirect_vars)
-            if self.indirect_vars
-            else None
-        )
-
-        if _spyre_config.validate_op_specs:
-            validate_op_specs(self.op_specs, stage="after_creation_loop_wrapping")
-        if logger.isEnabledFor(logging.INFO):
-            logger.info(
-                "OP SPECS AFTER CREATION/LOOP-WRAPPING\n%s",
-                format_op_spec_list(self.op_specs),
-            )
-
-        for op_spec in _iter_op_specs(self.op_specs):
-            simplify_op_spec(
-                op_spec,
-                self.indirect_sizes,
-                indirect_access_subs,
-                repeat_info=self._alignment_repeat_info_by_spec.get(id(op_spec)),
-                alignment_inputs=self._alignment_inputs_by_spec.get(id(op_spec)),
-            )
+    def check_op_specs(self) -> None:
+        """Validate and log the finished operation sequence after loop wrapping."""
 
         if _spyre_config.validate_op_specs:
             validate_op_specs(self.op_specs, stage="after_simplification")
@@ -1306,12 +1306,20 @@ class SpyreKernel(Kernel[CSEVariable]):
                 format_op_spec_list(self.op_specs),
             )
 
+    def codegen_kernel(self):
+        """Bind the argument list and HBM addresses, then print the finalized OpSpecs.
+
+        Everything else was final at preparation; only what HBM pooling decided
+        afterwards is bound here.
+        """
+
         def sympy_str(x: sympy.Expr) -> str:
             if isinstance(x, IndirectAccess):
                 name_sym = x.args[0]
                 return f"IndirectAccess('{name_sym}')"
             return "sympify('" + str(x) + "')"
 
+        self.remove_kernel_local_buffers()
         # Compute live, deduped call-arg list from names in spyre_kernel_args.
         # python_argdefs() includes all registered names from load()/store(),
         # but spyre_kernel_args only has those surviving to the final op specs
@@ -1328,6 +1336,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         has_pool_allocations = self.pool_size > 0
 
         for name, tensor_arg in self.spyre_kernel_args:
+            if "hbm_pool" in tensor_arg.allocation:
+                continue  # pooled after preparation; addressed inside the pool
             tensor_arg.arg_index = actuals.index(name)
             if _spyre_config.bundle_symbolic_args:
                 # On the symbolic path the HBM address is provided at runtime
@@ -1718,13 +1728,50 @@ def _restickify_restore_elided_dim(op_spec) -> None:
         _restore(new_sym, out_arg, in_arg)
 
 
+def _check_relayout_boundary(
+    iteration_space: dict, source: TensorWorkDivision, destination: TensorWorkDivision
+) -> None:
+    """Domain divisibility and extent limits stay at the preparation boundary."""
+    logical_cores = math.prod(int(split) for _, split in iteration_space.values())
+    domains = {
+        "operation": logical_cores,
+        "source": source.physical_core_count,
+        "destination": destination.physical_core_count,
+    }
+    execution_cores = max(domains.values())
+    owners = {
+        "source": math.prod(int(s) for s in source.work_slices.values()),
+        "destination": math.prod(int(s) for s in destination.work_slices.values()),
+    }
+    if any(d <= 0 or execution_cores % d for d in domains.values()) or any(
+        n <= 0 or domains[name] % n for name, n in owners.items()
+    ):
+        raise ValueError(
+            "LX relayout operation and tensor core domains must divide the "
+            f"execution domain; domains={domains}, owners={owners}"
+        )
+    oversized = {
+        name: {
+            str(dim): (int(split), int(iteration_space[dim][0]))
+            for dim, split in division.work_slices.items()
+            if sympy.sympify(iteration_space[dim][0]).is_number
+            and int(split) > int(iteration_space[dim][0])
+        }
+        for name, division in (("source", source), ("destination", destination))
+    }
+    oversized = {name: dims for name, dims in oversized.items() if dims}
+    if oversized:
+        raise ValueError(
+            f"LX relayout tensor split exceeds its aligned extent: {oversized}"
+        )
+
+
 def simplify_op_spec(
     op_spec,
     indirect_sizes=None,
     indirect_access_subs=None,
     *,
     repeat_info=None,
-    alignment_inputs: AlignmentInputs | None = None,
 ):
     # Both parameters must be provided together for gather kernels — indirect_sizes
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
@@ -1734,25 +1781,15 @@ def simplify_op_spec(
         # symbol on both operands, so align_tensors matches them by that symbol.
         _restickify_restore_elided_dim(op_spec)
 
-    it_space = op_spec.iteration_space
-    if alignment_inputs is None:
-        new_op_space_splits, new_tensors, work_division_remap = align_tensors(
-            it_space,
-            [
-                {"size": arg.device_size, "coordinates": arg.device_coordinates}
-                for arg in op_spec.args
-            ],
-            indirect_sizes,
-            repeat_info=repeat_info,
-        )
-    else:
-        if alignment_inputs.iteration_space != it_space:
-            raise RuntimeError(
-                "captured alignment iteration space changed before codegen"
-            )
-        new_op_space_splits, new_tensors, work_division_remap = align_tensors_pure(
-            alignment_inputs
-        )
+    new_op_space_splits, new_tensors, work_division_remap = align_tensors(
+        op_spec.iteration_space,
+        [
+            {"size": arg.device_size, "coordinates": arg.device_coordinates}
+            for arg in op_spec.args
+        ],
+        indirect_sizes,
+        repeat_info=repeat_info,
+    )
     op_spec.iteration_space = new_op_space_splits
 
     for arg, t in zip(op_spec.args, new_tensors):
@@ -1771,10 +1808,11 @@ def simplify_op_spec(
             ]
 
     _finalize_tensor_work_divisions(op_spec)
-    is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
+    is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args, op_spec.op_info)
     if is_relayout:
-        destination = op_spec.args[-1].work_division
-        assert destination is not None
+        source, destination = (arg.work_division for arg in op_spec.args)
+        assert source is not None and destination is not None
+        _check_relayout_boundary(op_spec.iteration_space, source, destination)
         op_spec.core_id_to_work_slice = dict(destination.core_id_to_work_slice)
     else:
         _finalize_core_mapping(op_spec, use_tensor_constraints=True)

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -494,32 +494,8 @@ class Term:
     dim_size: sympy.Expr
     offset: sympy.Expr = sympy.S.Zero  # offset
 
-
-def normalize_coordinates(
-    var_ranges: dict[sympy.Symbol, sympy.Expr],
-    size: Sequence[sympy.Expr],
-    coordinates: Sequence[sympy.Expr],
-    synthetic_var_fn: Callable[[], sympy.Symbol],
-    indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
-    compare_value: Callable[[sympy.Expr], int | float] = _concretize_for_cmp,
-) -> list[Term]:
-    """
-    Normalize coordinate expressions obtained from compute_coordinates.
-
-    If mod is absent from term assume term does not overflow dim_size.
-    Assume num or den is 1.
-
-    Break each expression into list of terms.
-    If expr has no mod, use var_range instead.
-
-    Split dimension into n dimensions if expression has n>1 terms.
-    Split dim_size into n according to iteration range of each term.
-    Fuse contiguous dimensions if corresponding terms can be fused.  Size-1
-    device dims with a constant zero coordinate are dropped, and do not stop
-    the dims on either side of them from fusing.
-    """
-
-    def normalize_var_expr(term, var, var_range, dim_size):
+    @staticmethod
+    def from_coordinate(term, var, var_range, dim_size):
         """Convert one single-variable coordinate term to ``Term``.
 
         ``Mod(FloorDiv(var, divisor), radix)`` is one digit of a
@@ -564,6 +540,31 @@ def normalize_coordinates(
             modulus,
             dim_size,
         )
+
+
+def normalize_coordinates(
+    var_ranges: dict[sympy.Symbol, sympy.Expr],
+    size: Sequence[sympy.Expr],
+    coordinates: Sequence[sympy.Expr],
+    synthetic_var_fn: Callable[[], sympy.Symbol],
+    indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    compare_value: Callable[[sympy.Expr], int | float] = _concretize_for_cmp,
+) -> list[Term]:
+    """
+    Normalize coordinate expressions obtained from compute_coordinates.
+
+    If mod is absent from term assume term does not overflow dim_size.
+    Assume num or den is 1.
+
+    Break each expression into list of terms.
+    If expr has no mod, use var_range instead.
+
+    Split dimension into n dimensions if expression has n>1 terms.
+    Split dim_size into n according to iteration range of each term.
+    Fuse contiguous dimensions if corresponding terms can be fused.  Size-1
+    device dims with a constant zero coordinate are dropped, and do not stop
+    the dims on either side of them from fusing.
+    """
 
     # terms in non-increasing stride order
     terms = []
@@ -612,7 +613,7 @@ def normalize_coordinates(
 
             # extract term for each var
             term = expr.xreplace({v: 0 for v in vars - {var}}) - offset
-            dim_terms.append(normalize_var_expr(term, var, var_range, dim_size))
+            dim_terms.append(Term.from_coordinate(term, var, var_range, dim_size))
         # sort dim_terms in increasing (num, mod) order so that z + offset
         # vars (num=1, mod=1) always sort before real iteration vars (num=1, mod=N)
         # when num is equal

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -60,6 +60,7 @@ from .pass_utils import (
     device_coordinates,
     finite_upper_or_none,
     get_mem_deps_from_rw,
+    input_layout_for_operation,
     iteration_space_from_op,
     commit_iteration_space_ownership,
     op_read_writes,
@@ -472,6 +473,11 @@ def get_per_core_span(
     symbol_meta: SymbolMeta,
 ) -> int:
     """Compute per-core memory span in bytes for a tensor under the given splits.
+
+    This is a pre-placement split-selection estimate.  LX capacity checks use
+    the finalized stick-aligned device layout instead; the two calculations
+    must not be merged unless they are proved equal for aligned shapes.  Track
+    that possible consolidation under #3049.
 
     coordinate expressions from compute_coordinates() in views.py are sums of
     independent single-variable terms, so max of the full expression equals the
@@ -1894,10 +1900,13 @@ def _apply_input_layout_overrides(
     The same tag is also used by SpyreKernel.create_tensor_arg, so work
     division and codegen agree on the input layout.
     """
-    overrides: dict[str, FixedTiledLayout] = getattr(op, "_input_layout_overrides", {})
-    if not overrides:
-        return args
-    return [SchedNodeArg(a.dep, overrides.get(a.dep.name, a.layout)) for a in args]
+    return [
+        SchedNodeArg(
+            arg.dep,
+            input_layout_for_operation(op, arg.dep.name, arg.layout),
+        )
+        for arg in args
+    ]
 
 
 def span_reduction(graph: GraphLowering) -> None:


### PR DESCRIPTION
Part of [Epic #3049](https://github.com/torch-spyre/torch-spyre/issues/3049).

Merged foundation; subsequent PRs now build on main containing #4283 and #4284. The original description below records the pre-merge review history.

---

## Summary

Choose each buffer's physical ownership before scheduling, then prepare its real kernel once and emit that accepted result. A loop rename must not silently change which values a core reads.

## Architecture and scope

- Keep `layout.lx_view` as the physical buffer authority. Project it through final access coordinates into the existing per-tensor work divisions; do not rebuild ownership from split counts or loop position.
- Replace the preview/emission pair with real `prepare_kernel` execution before HBM pooling. Store the successful `SpyreKernel` on its bundle; emission consumes that same object. This is not two callers independently rebuilding the same answer.
- If preparation cannot preserve an LX placement, use the existing connected-group HBM fallback and retry before pooling. Emission has no late placement search or silent ownership repair.
- Remove the positional producer-order repair and final-view/argument-ID side tables. Input clones commit compatible ownership during planning.
- Use the exact direct-axis check before publishing a proposed physical view. Exact multi-axis decomposition remains in #4152.

This is the preparatory ownership-flow change requested in the #3440 review. It carries most of the stack's refactoring, including deletion of replaced scheduler/codegen paths. It does not introduce a new ownership record or change the SuperDSC contract. The original full-partition movement path is retained; #3440 adds the gather/broadcast cases.

## Review boundary and dependencies

Built on upstream main commit `e5ed9481f246dcee6720a2b3c7e38d1626d4c662` (not a claim that this is today's main tip). Head: `e4542ca11b1c8da4e923a2b65dd6d5f02b1f7585`.

Depends on **#4283**, parent `b5d37f2033e968d7be2f937dcf35eab58b1b23f7`. [Review only this level's incremental changes](https://github.com/AdnanHoque/torch-spyre/compare/b5d37f2033e968d7be2f937dcf35eab58b1b23f7...e4542ca11b1c8da4e923a2b65dd6d5f02b1f7585).

All existing PR bases remain `main`; the dependency chain is explicit below. Merge prerequisites first, then rebase children. The cumulative GitHub diff includes prerequisites and is not the size of this level alone.

```text
main (e5ed9481)
└─ #4283 ownership values
   └─ #4284 physical ownership + prepare/emit
      └─ #3440 gathers and broadcasts
         ├─ #4152 exact fused-axis ownership
         │  └─ #4153 consumer order + local restickify
         └─ #3955 completed-reduction handoff
```

#3439 remains the original relayout foundation. #4177 is an independent clone-elision optimization, not a prerequisite of these compiler changes. #3955 is optional alongside the #4152/#4153 chain.

## Validation and remaining gates

Fresh focused host inventory on this exact head: **50 passed**, using the existing native stand-in and excluding real device/compile tests. The integrated local composition also passes its focused inventory. Signed commits and DCO, Ruff 0.14.5, and repository-isolated mypy 2.1.0 were checked; the full pre-commit suite passes on the integrated publication tree.

**Draft: source review is not device certification or code-owner approval.** The independent local adversarial review closed its two blockers; CI on the newly published commits and the relevant native/device/application checks are still required. Broader native-dependent host suites are not claimed green. Historical workload results name their own exact commits and must not be presented as measurements of this publication. No application source, cost-model policy, or SuperDSC contract is changed.
