### PR TITLE
fix(test configs): add missing trunk label to 3 regression-only test configs

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_matmul_rewrites_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_matmul_rewrites_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [regression]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_matmul_rewrites.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scatter_copy_insertion_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scatter_copy_insertion_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [unit, regression, integration]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scatter_copy_insertion.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scatter_layout_helpers_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scatter_layout_helpers_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [unit, regression]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scatter_layout_helpers.py
       unlisted_test_mode: mandatory_success


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup