### PR TITLE
Split test_cpu_selection_algorithm into more parts

### DIFF
--- a/.github/workflows/_upstream_tests_beta_matrix.yaml
+++ b/.github/workflows/_upstream_tests_beta_matrix.yaml
@@ -213,6 +213,10 @@ jobs:
             config: inductor-test_cpu_select_algorithm_part2.yaml
           - name: Inductor test cpu select algorithm part 3
             config: inductor-test_cpu_select_algorithm_part3.yaml
+          - name: Inductor test cpu select algorithm part 4
+            config: inductor-test_cpu_select_algorithm_part4.yaml
+          - name: Inductor test cpu select algorithm part 5
+            config: inductor-test_cpu_select_algorithm_part5.yaml
           ####################
           - name: Inductor test custom op autotune
             config: inductor-test_custom_op_autotune.yaml

--- a/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part1.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part1.yaml
@@ -5,60 +5,27 @@ test_suite_config:
     - path: ${TORCH_ROOT}/test/inductor/test_cpu_select_algorithm.py
       unlisted_test_mode: skip
       tests:
-        # These tests primarily exercise matrix multiplication (bmm, mm) and linear operations (linear) with various data types (bfloat16, float16, float32) and tensor shapes.
+        # These tests exercise various linear and batch matrix multiplication (bmm) operations with different data types and tensor shapes.
         # They are classified as mandatory_success because they test core functionalities that must pass for the backend to be considered operational.
-        # The relevance of these tests is determined by the backend's support for specific data types and operations, particularly bfloat16 and float16, which are critical for performance on AI accelerators like Spyre.
+        # The relevance of these tests is determined by the backend's support for specific data types and operations, particularly bfloat16 and float16, which are critical for performance on AI accelerators.
         - names:
-            - TestSelectAlgorithmDynamicShapes::test_bmm_dynamic_bm_stride
-            - TestSelectAlgorithmDynamicShapes::test_bmm_with_pointwise_dynamic_shapes
-            - TestSelectAlgorithmDynamicShapes::test_bmm_with_pointwise_with_reshape_dynamic_shapes
-            - TestSelectAlgorithm::test_bmm
-            - TestSelectAlgorithm::test_bmm_amp
-            - TestSelectAlgorithm::test_bmm_amx
-            - TestSelectAlgorithm::test_bmm_freezing
-            - TestSelectAlgorithm::test_bmm_self_permute
             - TestSelectAlgorithm::test_bmm_self_square
-            - TestSelectAlgorithm::test_bmm_with_broadcasted_mat1
-            - TestSelectAlgorithm::test_bmm_with_pointwise
-            - TestSelectAlgorithm::test_cpp_coordinate_descent_tuning
+            - TestSelectAlgorithm::test_cpp_weight_prune
+            - TestSelectAlgorithm::test_grouped_linear
+            - TestSelectAlgorithm::test_int4_woq_mm_amx_Nc_larger_than_one
+            - TestSelectAlgorithm::test_linear_k_slicing
+            - TestSelectAlgorithm::test_linear_static_shapes
+            - TestSelectAlgorithm::test_linear_wgt_multi_users
+            - TestSelectAlgorithmDynamicShapes::test_bmm_with_pointwise_with_reshape_dynamic_shapes
           mode: mandatory_success
-        # These tests exercise various linear and batch matrix multiplication operations with different data types and tensor layouts.
-        # They are classified as xfail due to unsupported dynamic shapes and fused epilogues, which are not yet supported by the Spyre backend.
-        # The relevant Spyre limitations include lack of support for dynamic tensor shapes and certain fused operations, particularly with bfloat16 and float16 data types.
+        # These tests exercise various linear and batch matrix multiplication (bmm) operations with different data types and tensor shapes.
+        # They are classified as xfail on the backend due to unsupported dynamic shapes and certain fused epilogues, which are not fully supported by the current implementation.
+        # The most relevant backend capabilities include handling bfloat16 and float32 data types, but limitations in dynamic shape support and fused operations lead to these tests failing.
         - names:
-            - TestSelectAlgorithmDynamicShapes::test_bmm_epilogue_dynamic_reshape
-            - TestSelectAlgorithm::test_aoti_bmm_unique_identifiers
             - TestSelectAlgorithm::test_aoti_linear
-            - TestSelectAlgorithm::test_aoti_linear_multi_view_operations
-            - TestSelectAlgorithm::test_bmm_with_fused_epilogues
-            - TestSelectAlgorithm::test_bmm_with_y_storage_offset
-            - TestSelectAlgorithm::test_int4_woq_mm_avx512
-            - TestSelectAlgorithm::test_int8_woq_mm
             - TestSelectAlgorithm::test_int8_woq_mm_concat
-            - TestSelectAlgorithm::test_linear_local_and_global_buffer_dynamic_shapes
-            - TestSelectAlgorithm::test_linear_to_lowp_fp
-            - TestSelectAlgorithm::test_linear_unsupported_epilogue_fusion
-            - TestSelectAlgorithm::test_linear_with_in_out_buffer
-            - TestSelectAlgorithm::test_linear_with_indirect_indexing
-            - TestSelectAlgorithm::test_linear_with_input_of_flexible_layout
-            - TestSelectAlgorithm::test_linear_with_multiple_reindexers
-            - TestSelectAlgorithm::test_linear_with_permute
             - TestSelectAlgorithm::test_local_and_global_accumulator
-            - TestSelectAlgorithm::test_qlinear_pointwise_int8_layout
-            - TestSelectAlgorithm::test_grouped_linear_epilogue
           mode: xfail
-        # These tests exercise the `bmm` operation with flexible tensor layouts.
-        # They are classified as `xfail` due to a missing module in the Spyre backend.
-        # The relevant Spyre limitation is the unavailability of the `_oot_pre_test_cpu_select_algorithm` module.
-        - names:
-            - TestSelectAlgorithm::test_bmm_flexible_layout
-          mode: xfail  # xfail: torch._dynamo.exc.InternalTorchDynamoError
-        # These tests exercise the `bmm` operation with various tensor dimensions and data types.
-        # They are skipped because the tests do not invoke the torch-spyre layer, which is required for backend-specific operations.
-        # The relevant Spyre capability is the support for `bmm` with specific data types, which is not engaged in these tests.
-        - names:
-            - TestSelectAlgorithm::test_bmm_2d_permute
-          mode: skip  # does not engage the torch-spyre layer
 
   global:
     supported_dtypes:

--- a/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part2.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part2.yaml
@@ -5,60 +5,36 @@ test_suite_config:
     - path: ${TORCH_ROOT}/test/inductor/test_cpu_select_algorithm.py
       unlisted_test_mode: skip
       tests:
-        # These tests primarily exercise matrix multiplication (bmm, mm) and linear operations (linear) with various data types (bfloat16, float16, float32) and tensor shapes.
+        # These tests exercise various linear and batch matrix multiplication (bmm) operations with different data types and tensor shapes.
         # They are classified as mandatory_success because they test core functionalities that must pass for the backend to be considered operational.
-        # The relevance of these tests is determined by the backend's support for specific data types and operations, particularly bfloat16 and float16, which are critical for performance on AI accelerators like Spyre.
+        # The relevance of these tests is determined by the backend's support for specific data types and operations, particularly bfloat16 and float16, which are critical for performance on AI accelerators.
         - names:
-            - TestSelectAlgorithm::test_cpp_weight_prune
-            - TestSelectAlgorithm::test_grouped_linear
-            - TestSelectAlgorithm::test_grouped_linear_invalid
-            - TestSelectAlgorithm::test_int4_concat_woq_mm
-            - TestSelectAlgorithm::test_int4_woq_mm_amx
-            - TestSelectAlgorithm::test_int4_woq_mm_amx_Nc_larger_than_one
-            - TestSelectAlgorithm::test_int4_woq_mm_with_small_buffer_config
-            - TestSelectAlgorithm::test_linear_amx
+            - TestSelectAlgorithm::test_bmm
             - TestSelectAlgorithm::test_linear_cache_blocking
-            - TestSelectAlgorithm::test_linear_input_transpose
-            - TestSelectAlgorithm::test_linear_k_slicing
             - TestSelectAlgorithm::test_linear_reuse_kernels
+            - TestSelectAlgorithm::test_linear_with_pointwise
+            - TestSelectAlgorithm::test_qlinear_binary_with_dynamic_x_scale
+            - TestSelectAlgorithmDynamicShapes::test_bmm_with_pointwise_dynamic_shapes
           mode: mandatory_success
-        # These tests exercise various linear and batch matrix multiplication operations with different data types and tensor layouts.
-        # They are classified as xfail due to unsupported dynamic shapes and fused epilogues, which are not yet supported by the Spyre backend.
-        # The relevant Spyre limitations include lack of support for dynamic tensor shapes and certain fused operations, particularly with bfloat16 and float16 data types.
+
+        # These tests exercise various linear and batch matrix multiplication (bmm) operations with different data types and tensor shapes.
+        # They are classified as xfail on the backend due to unsupported dynamic shapes and certain fused epilogues, which are not fully supported by the current implementation.
+        # The most relevant backend capabilities include handling bfloat16 and float32 data types, but limitations in dynamic shape support and fused operations lead to these tests failing.
         - names:
-            - TestSelectAlgorithmDynamicShapes::test_bmm_epilogue_dynamic_reshape
             - TestSelectAlgorithm::test_aoti_bmm_unique_identifiers
-            - TestSelectAlgorithm::test_aoti_linear
-            - TestSelectAlgorithm::test_aoti_linear_multi_view_operations
-            - TestSelectAlgorithm::test_bmm_with_fused_epilogues
             - TestSelectAlgorithm::test_bmm_with_y_storage_offset
-            - TestSelectAlgorithm::test_int4_woq_mm_avx512
             - TestSelectAlgorithm::test_int8_woq_mm
-            - TestSelectAlgorithm::test_int8_woq_mm_concat
-            - TestSelectAlgorithm::test_linear_local_and_global_buffer_dynamic_shapes
-            - TestSelectAlgorithm::test_linear_to_lowp_fp
             - TestSelectAlgorithm::test_linear_unsupported_epilogue_fusion
-            - TestSelectAlgorithm::test_linear_with_in_out_buffer
-            - TestSelectAlgorithm::test_linear_with_indirect_indexing
-            - TestSelectAlgorithm::test_linear_with_input_of_flexible_layout
             - TestSelectAlgorithm::test_linear_with_multiple_reindexers
             - TestSelectAlgorithm::test_linear_with_permute
-            - TestSelectAlgorithm::test_local_and_global_accumulator
-            - TestSelectAlgorithm::test_qlinear_pointwise_int8_layout
-            - TestSelectAlgorithm::test_grouped_linear_epilogue
           mode: xfail
-        # These tests exercise the `bmm` operation with flexible tensor layouts.
-        # They are classified as `xfail` due to a missing module in the Spyre backend.
-        # The relevant Spyre limitation is the unavailability of the `_oot_pre_test_cpu_select_algorithm` module.
-        - names:
-            - TestSelectAlgorithm::test_bmm_flexible_layout
-          mode: xfail  # xfail: torch._dynamo.exc.InternalTorchDynamoError
-        # These tests exercise the `bmm` operation with various tensor dimensions and data types.
-        # They are skipped because the tests do not invoke the torch-spyre layer, which is required for backend-specific operations.
-        # The relevant Spyre capability is the support for `bmm` with specific data types, which is not engaged in these tests.
+
+        # These tests exercise batched matrix multiplication (bmm) with various tensor permutations and data types.
+        # They are skipped because the backend layer does not engage with these operations.
+        # Relevant backend limitations include lack of support for tensor permutations in bmm operations.
         - names:
             - TestSelectAlgorithm::test_bmm_2d_permute
-          mode: skip  # does not engage the torch-spyre layer
+          mode: skip
 
   global:
     supported_dtypes:

--- a/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part4.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part4.yaml
@@ -9,24 +9,26 @@ test_suite_config:
         # They are classified as mandatory_success because they test core functionalities that must pass for the backend to be considered operational.
         # The relevance of these tests is determined by the backend's support for specific data types and operations, particularly bfloat16 and float16, which are critical for performance on AI accelerators.
         - names:
-            - TestSelectAlgorithm::test_bmm_amp
-            - TestSelectAlgorithm::test_bmm_self_permute
-            - TestSelectAlgorithm::test_bmm_with_broadcasted_mat1
-            - TestSelectAlgorithm::test_bmm_with_pointwise
-            - TestSelectAlgorithm::test_grouped_linear_invalid
-            - TestSelectAlgorithm::test_qlinear_unary_with_computed_buffer_x_zp
-            - TestSelectAlgorithm::test_quantized_linear_with_pointwise
-            - TestSelectAlgorithmDynamicShapes::test_bmm_dynamic_bm_stride
+            - TestSelectAlgorithm::test_bmm_amx
+            - TestSelectAlgorithm::test_bmm_freezing
+            - TestSelectAlgorithm::test_int4_woq_mm_with_small_buffer_config
+            - TestSelectAlgorithm::test_linear_amx
+            - TestSelectAlgorithm::test_linear_input_transpose
+            - TestSelectAlgorithm::test_linear_with_binary_input_3d
+            - TestSelectAlgorithm::test_linear_with_embedding
+            - TestSelectAlgorithm::test_qlinear_binary_with_computed_buffer_x_zp
+            - TestSelectAlgorithm::test_quantized_linear_with_pointwise_binary
           mode: mandatory_success
 
         # These tests exercise various linear and batch matrix multiplication (bmm) operations with different data types and tensor shapes.
         # They are classified as xfail on the backend due to unsupported dynamic shapes and certain fused epilogues, which are not fully supported by the current implementation.
         # The most relevant backend capabilities include handling bfloat16 and float32 data types, but limitations in dynamic shape support and fused operations lead to these tests failing.
         - names:
-            - TestSelectAlgorithm::test_aoti_linear_multi_view_operations
-            - TestSelectAlgorithm::test_bmm_with_fused_epilogues
-            - TestSelectAlgorithm::test_int4_woq_mm_avx512
-            - TestSelectAlgorithm::test_qlinear_pointwise_int8_layout
+            - TestSelectAlgorithm::test_bmm_flexible_layout
+            - TestSelectAlgorithm::test_linear_local_and_global_buffer_dynamic_shapes
+            - TestSelectAlgorithm::test_linear_with_in_out_buffer
+            - TestSelectAlgorithm::test_linear_with_indirect_indexing
+            - TestSelectAlgorithmDynamicShapes::test_bmm_epilogue_dynamic_reshape
           mode: xfail
 
   global:

--- a/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part5.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part5.yaml
@@ -9,24 +9,24 @@ test_suite_config:
         # They are classified as mandatory_success because they test core functionalities that must pass for the backend to be considered operational.
         # The relevance of these tests is determined by the backend's support for specific data types and operations, particularly bfloat16 and float16, which are critical for performance on AI accelerators.
         - names:
-            - TestSelectAlgorithm::test_bmm_amp
-            - TestSelectAlgorithm::test_bmm_self_permute
-            - TestSelectAlgorithm::test_bmm_with_broadcasted_mat1
-            - TestSelectAlgorithm::test_bmm_with_pointwise
-            - TestSelectAlgorithm::test_grouped_linear_invalid
-            - TestSelectAlgorithm::test_qlinear_unary_with_computed_buffer_x_zp
-            - TestSelectAlgorithm::test_quantized_linear_with_pointwise
-            - TestSelectAlgorithmDynamicShapes::test_bmm_dynamic_bm_stride
+            - TestSelectAlgorithm::test_cpp_coordinate_descent_tuning
+            - TestSelectAlgorithm::test_grouped_linear_epilogue
+            - TestSelectAlgorithm::test_int4_concat_woq_mm
+            - TestSelectAlgorithm::test_int4_woq_mm_amx
+            - TestSelectAlgorithm::test_linear_thread_factors
+            - TestSelectAlgorithm::test_linear_thread_factors_k_slicing_misaligned_cache_blocks
+            - TestSelectAlgorithm::test_linear_with_transpose
+            - TestSelectAlgorithm::test_linear_with_unary_binary
+            - TestSelectAlgorithm::test_qlinear_unary_with_dynamic_x_scale
+            - TestSelectAlgorithm::test_quantized_linear_amx
           mode: mandatory_success
 
         # These tests exercise various linear and batch matrix multiplication (bmm) operations with different data types and tensor shapes.
         # They are classified as xfail on the backend due to unsupported dynamic shapes and certain fused epilogues, which are not fully supported by the current implementation.
         # The most relevant backend capabilities include handling bfloat16 and float32 data types, but limitations in dynamic shape support and fused operations lead to these tests failing.
         - names:
-            - TestSelectAlgorithm::test_aoti_linear_multi_view_operations
-            - TestSelectAlgorithm::test_bmm_with_fused_epilogues
-            - TestSelectAlgorithm::test_int4_woq_mm_avx512
-            - TestSelectAlgorithm::test_qlinear_pointwise_int8_layout
+            - TestSelectAlgorithm::test_linear_to_lowp_fp
+            - TestSelectAlgorithm::test_linear_with_input_of_flexible_layout
           mode: xfail
 
   global:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Splits `test_cpu_selection_algorithm` into 5 parts, with each part taking roughly 11 minutes to execute.

The previous split into 3 parts resulted in individual test groups taking too long to complete. This PR further splits the tests into 5 parts using a greedy approach to distribute the tests more evenly, targeting an average execution time of approximately 11 minutes per part.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer: 
The changes only restructure the test selection/splitting and are intended to improve test execution time distribution. Test behavior is otherwise unchanged.



#### Does this PR introduce a user-facing change?
No

#### Additional note:
