### PR TITLE
restickify: bug fix in validation of candidate layouts

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -3418,14 +3418,10 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D, b_tiles=1, h_tiles=1, lq_tiles=1, lk_ti
 
 
 @pytest.mark.skip(
-    reason="AssertionError in _stick_symbol: within-stick coordinate"
-    " carries 2 free symbols, want exactly 1 -- v4's view+transpose"
-    " layout produces a coordinate expression padding.py cannot solve."
-    " Named-dims tracking is no longer the cause (buf1/buf25/buf29 are"
-    " now correctly named end to end); propagate_layouts.py's multi-arg"
-    " pointwise candidate search still picks an interleaved (H+Lq) stick"
-    " layout for buf29 even with full naming -- fix belongs in"
-    " propagate_layouts.py's candidate acceptance, not naming."
+    reason="No restickify/candidate layout bridges buf25's two inputs"
+    " (output sticks on D, correction sticks on Lq) once H's nested-in-Lq"
+    " host stride is correctly rejected as infeasible -- layout-propagation"
+    " architectural gap, see torch-spyre/torch-spyre#4292"
 )
 def test_flash_v4_tile_H():
     """Flash v4: tile num_heads÷4 only."""
@@ -3437,9 +3433,10 @@ def test_flash_v4_tile_H():
 
 
 @pytest.mark.skip(
-    reason="AssertionError in _stick_symbol: within-stick coordinate"
-    " carries 2 free symbols, want exactly 1 -- v4's view+transpose"
-    " layout produces a coordinate expression padding.py cannot solve"
+    reason="Same buf25 layout-propagation gap as test_flash_v4_tile_H --"
+    " no restickify/candidate layout bridges output (sticks on D) and"
+    " correction (sticks on Lq) given H nested in Lq's host stride,"
+    " see torch-spyre/torch-spyre#4292"
 )
 def test_flash_v4_tile_B():
     """Flash v4: tile batch_size÷2 only. B=2."""
@@ -3451,9 +3448,10 @@ def test_flash_v4_tile_B():
 
 
 @pytest.mark.skip(
-    reason="AssertionError in _stick_symbol: within-stick coordinate"
-    " carries 2 free symbols, want exactly 1 -- v4's view+transpose"
-    " layout produces a coordinate expression padding.py cannot solve"
+    reason="Same buf25 layout-propagation gap as test_flash_v4_tile_H --"
+    " no restickify/candidate layout bridges output (sticks on D) and"
+    " correction (sticks on Lq) given H nested in Lq's host stride,"
+    " see torch-spyre/torch-spyre#4292"
 )
 def test_flash_v4_tile_Lq():
     """Flash v4: tile max_seqlen_q÷2 only."""
@@ -3465,9 +3463,10 @@ def test_flash_v4_tile_Lq():
 
 
 @pytest.mark.skip(
-    reason="AssertionError in _stick_symbol: within-stick coordinate"
-    " carries 2 free symbols, want exactly 1 -- v4's view+transpose"
-    " layout produces a coordinate expression padding.py cannot solve"
+    reason="Same buf25 layout-propagation gap as test_flash_v4_tile_H --"
+    " no restickify/candidate layout bridges output (sticks on D) and"
+    " correction (sticks on Lq) given H nested in Lq's host stride,"
+    " see torch-spyre/torch-spyre#4292"
 )
 def test_flash_v4_tile_H_Lq():
     """Flash v4: tile num_heads÷4 max_seqlen_q÷2. Equivalent to original test_flash_v4."""
@@ -3483,7 +3482,10 @@ def test_flash_v4_tile_H_Lq():
 @pytest.mark.skip(
     reason="Hangs rather than failing fast (observed: no completion after"
     " 2+ minutes, killed) -- distinct from the other v4 tile combinations,"
-    " which fail at compile time; root cause not yet investigated"
+    " which fail at compile time via the buf25 layout-propagation gap"
+    " (torch-spyre/torch-spyre#4292); this test's own root cause -- and"
+    " whether it shares that gap or hangs before reaching it -- is not"
+    " yet investigated"
 )
 def test_flash_v4_tile_H_Lq_Lk():
     """Flash v4: tile num_heads÷4 max_seqlen_q÷2 max_seqlen_kv÷2."""

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2128,9 +2128,26 @@ def compute_restickify_needed(
         if reduction_vars:
             red_var = min(reduction_vars, key=str)
             target_stick = sympy.Mod(red_var, in_stl.elems_per_stick())
-    return True, compute_restickify_target_layout(
-        in_stl, in_host, target_stick, ic, idc
-    )
+    new_stl = compute_restickify_target_layout(in_stl, in_host, target_stick, ic, idc)
+    if new_stl is not None:
+        # restickify_device_size/restickify_stride_map swap the old and new
+        # stick's outer device slots as if they were stride-independent. When
+        # the new stick's host dim is nested inside the old stick's host
+        # stride (e.g. a transpose where the new stick varies faster in
+        # memory than the old one did), the swap leaves the old stick's
+        # leftover high-order bits with nowhere to go but the new stick slot,
+        # producing a two-symbol stick coordinate that codegen cannot address
+        # (see issue tracked alongside the flash-v4 tiling tests). The
+        # restickify buffer will be consumed via out_dep's indexing (that's
+        # what target_stick was derived from), so validate against out_dep
+        # rather than in_dep: it's the future read pattern that must produce
+        # a clean stick, not the old one.
+        new_idc = try_device_coordinates(new_stl, out_dep, ind_sizes)
+        if new_idc is None or not is_stick_expr_offset_free(
+            new_idc[-1], new_stl.elems_per_stick()
+        ):
+            new_stl = None
+    return True, new_stl
 
 
 def copy_fx_custom_meta(src: "torch.fx.Node", dst: "torch.fx.Node") -> None:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`compute_restickify_needed` (`pass_utils.py`) built its candidate stick
target from `out_dep` (the future consumer's own indexing) but validated
its feasibility against `in_dep` (the producer's existing indexing). The
two dependencies can legitimately differ (e.g. a transposed read), and
validating against the wrong one let an unrepresentable two-free-symbol
stick coordinate through undetected. Downstream, this surfaced as an
opaque `_stick_symbol` `AssertionError` in `padding.py` instead of a clean
rejection at the point where the restickify was actually decided.

This PR changes `compute_restickify_needed` to validate the candidate
restickify target's stick coordinate against `out_dep` -- the pattern the
restickified buffer will actually be read with -- instead of `in_dep`.
An infeasible candidate is now rejected as `(True, None)`, which
`optimize_restickify.py`'s beam search (`AllSameNode`/`EdgeCostMap`)
already knows how to cost as `INF`, the same contract used elsewhere.

This does **not** make any currently-skipped test pass. Root-causing the
`test_flash_v4_tile_*` skips (`tests/inductor/test_coarse_tile_e2e.py`)
led here: with this fix, `test_flash_v4_tile_H` no longer crashes with
`_stick_symbol`'s assertion, but fails cleanly with
`NotImplementedError: buf25 (Pointwise): no mechanism to resolve stick
incompatibility` -- a deeper, genuinely architectural layout-propagation
gap (no single-step restickify or shared candidate layout can bridge
`buf25`'s two inputs, whose natural sticks land on host dimensions nested
inside one another). That gap is filed as its own issue for the
layout-propagation owner to weigh a redesign; this PR is the standalone,
independently-correct piece of that investigation. Skip reasons on the
affected tests are updated to reference the new issue instead of the
stale `_stick_symbol` symptom text, and `test_flash_v4_tile_H`'s skip
decorator (temporarily removed for direct repro during the investigation)
is restored.

Verified no regressions: `tests/inductor/test_coarse_tile_e2e.py` +
`tests/inductor/test_building_blocks.py` -- 265 passed, 9 skipped,
1 xfailed, 0 new failures (the only failure is the still-skipped
`test_flash_v4_tile_H`, expected).

#### Which issue(s) this PR is related to:

Part of #206.
Exposes/tracked by torch-spyre/torch-spyre#4292 (layout-propagation
architectural gap -- not fixed by this PR).

#### Special notes for your reviewer:

- The fix is intentionally narrow and local to `compute_restickify_needed`
  -- it corrects which dependency feasibility is checked against, nothing
  else. No change to `compute_restickify_target_layout`'s dimension-swap
  logic itself.
- This is a diagnostics/correctness improvement (turns a silent path into
  an explicit `INF`-cost rejection) that is general beyond the flash-v4
  tests -- it applies to any restickify candidate where `in_dep` and
  `out_dep` disagree.
- See #4292 for the full root-cause write-up, including why the deeper
  `buf25` gap could not be resolved by a local patch (verified via
  temporary instrumentation, since reverted, that both of `buf25`'s two
  legitimate output-layout candidates require an infeasible restickify on
  one input or the other).

#### Does this PR introduce a user-facing change?

No. Internal compiler pass behavior only; converts a crash into a
different (still-failing) diagnostic for an already-skipped test family.

#### Additional note:

Two commits: the `pass_utils.py` fix, and the test-file skip-reason
updates (including restoring `test_flash_v4_tile_H`'s decorator).