### PR TITLE
fix(inductor): resolve hf-adapters model regressions

### DIFF
--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -543,6 +543,29 @@ class TestBuildingBlocks(unittest.TestCase):
             reshape_output=True,
         )
 
+    def test_siglip_multicrop_attention_span(self):
+        """A seven-crop SigLIP prefill must fit each tiled BMM under 256 MB."""
+        B, H, L, D = 7, 16, 576, 128
+        generator = torch.Generator().manual_seed(1337)
+        q = torch.randn((B, L, H, D), dtype=torch.bfloat16, generator=generator)
+        k = torch.randn((B, L, H, D), dtype=torch.bfloat16, generator=generator)
+        v = torch.randn((B, L, H, D), dtype=torch.bfloat16, generator=generator)
+
+        def sdpa(q, k, v):
+            return F.scaled_dot_product_attention(
+                q.transpose(1, 2),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+                dropout_p=0.0,
+                scale=72**-0.5,
+            )
+
+        expected = sdpa(q, k, v)
+        actual = torch.compile(sdpa, dynamic=False)(
+            q.to("spyre"), k.to("spyre"), v.to("spyre")
+        ).cpu()
+        torch.testing.assert_close(actual, expected, atol=0.2, rtol=0.2)
+
     @unittest.skip("Runs for long time, possibly hang.  Keeping disabled")
     @mock.patch("torch_spyre._inductor.decompositions._SDPA_MAX_SEQUENCE_TILE_SIZE", 64)
     def test_granite_gqa_prefill_grouped_sixteen_by_sixteen_tiling(self):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -78,6 +78,7 @@ from torch_spyre._inductor.wsr.coarse_tile import (
     _RetiledBufferInfo,
     _apply_plan,
     _compute_fill_loop_info_planned,
+    _compute_read_copy_strides,
     _consumer_own_dim_symbol,
     _divide_ranges,
     _full_buffer_read_deps,
@@ -5959,9 +5960,6 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
         ]
         self.assertEqual(len(copy_bufs), 2)
 
-    @unittest.skip(
-        "non-divisible padding raises Unsupported after row-major fallback removal"
-    )
     def test_offset_read_gets_its_own_copy(self):
         """a+shift(a)-style: two reads of the same buffer with identical
         per-var index coefficients but a different constant offset must
@@ -6032,6 +6030,10 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
             if isinstance(op, ComputedBuffer) and op.get_name() != "tiled_op0"
         ]
         self.assertEqual(len(copy_bufs), 2)
+        self.assertEqual(
+            [list(copy_buf.layout.stride) for copy_buf in copy_bufs],
+            [[Integer(8), Integer(1)], [Integer(8), Integer(1)]],
+        )
 
     def test_disable_flag_skips_everything(self):
         """An empty read_copy_plans dict (the insert_read_copies=False case)
@@ -7983,6 +7985,12 @@ class TestTileHelpers(unittest.TestCase):
     def test_compute_tile_stride_3d_padding(self):
         self.assertEqual(
             compute_tile_stride([8, 16, 32], [544, 32, 1], [2, 4, 8]), [34, 8, 1]
+        )
+
+    def test_compute_read_copy_strides_non_divisible_padded_extent(self):
+        self.assertEqual(
+            _compute_read_copy_strides([32, 640, 128], [81920, 128, 1], [8, 192, 128]),
+            [24576, 128, 1],
         )
 
     def test_compute_tile_offset_1d(self):

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -1015,6 +1015,23 @@ def test_reshape_1d_to_2d_exp():
         )
 
 
+def test_constant_indexed_dim_is_consumed_without_mapping():
+    """A fixed source slice consumes its name but has no output loop variable."""
+    rows, cols = 2, 128
+    x = torch.randn(rows, cols, dtype=torch.float16, device=DEVICE)
+
+    def fn(x):
+        return x[0].exp()
+
+    _run_and_capture(
+        fn,
+        [x],
+        named_dims={"R": rows, "C": cols},
+        tensor_dims={x: ["R", "C"]},
+        expected_propagated_dims=["C"],
+    )
+
+
 # -------- Stride-0 broadcast (torch.expand) tests --------
 
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -153,6 +153,38 @@ def same_device_size(t1: torch.dtype, t2: torch.dtype) -> bool:
     return get_elem_in_stick(t1) == get_elem_in_stick(t2)
 
 
+def _compact_broadcast_device_dims(stl: SpyreTensorLayout) -> SpyreTensorLayout:
+    """Remove physical extent from logical stride-zero dimensions.
+
+    The generic layout constructor retains a broadcast dimension's logical
+    extent in ``device_size`` even though its zero ``stride_map`` makes every
+    access land at coordinate zero.  That is useful for host transfers, which
+    materialize expanded tensors, but it needlessly multiplies the allocation
+    and span of compiler-generated overlapping buffers such as coarse-tile read
+    copies.  Collapse every such non-stick device dimension to one.  The final
+    device dimension remains a full hardware stick; making its stride sparse is
+    enough to represent a broadcast stick.
+    """
+    device_size = list(stl.device_size)
+    stride_map = list(stl.stride_map)
+    changed = False
+    for dim, stride in enumerate(stride_map):
+        if stride != 0:
+            continue
+        stride_map[dim] = -1
+        if dim != len(device_size) - 1:
+            device_size[dim] = 1
+        changed = True
+    if not changed:
+        return stl
+    return SpyreTensorLayout(
+        device_size,
+        stride_map,
+        stl.device_dtype,
+        stl.element_arrangement,
+    )
+
+
 def infer_bool_device_dtype(args: list[PropArg]) -> DataFormats:
     """Infer the on-device format for a torch.bool pointwise output.
 
@@ -1806,6 +1838,8 @@ def compute_layouts(
             op, output, output_dep, args[0].dep, args[0].layout, stl
         )
         layouts.extend(result)
+    if any(stride == 0 for stride in output.stride):
+        layouts = [_compact_broadcast_device_dims(stl) for stl in layouts]
     if not layouts:
         raise Unsupported(
             f"{op.get_name()} ({aten_op}): no supported output layout found for "

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3724,6 +3724,41 @@ def _rescale_index(
     return new_index
 
 
+def _compute_read_copy_strides(
+    full_sizes: list[Expr],
+    full_strides: list[Expr],
+    copy_sizes: list[Expr],
+) -> list[Expr]:
+    """Resize source strides for a compact read-copy allocation.
+
+    Unlike an ordinary tensor tile, a staged read may cover a proper slice whose
+    extent does not divide the backing buffer (for example, 192 columns from a
+    640-column source).  Preserve the source layout's proportional padding while
+    shrinking each already-processed physical dimension to the copy extent.
+    """
+    copy_strides = [sympy.S.Zero] * len(copy_sizes)
+    dims = [
+        d
+        for d, (size, stride) in enumerate(zip(full_sizes, full_strides))
+        if size != 1 and stride != 0
+    ]
+    dims.sort(key=lambda d: full_strides[d])
+    cumulative_scale: Expr = sympy.S.One
+    for d in dims:
+        resized_stride = sympy.cancel(sympy.sympify(full_strides[d]) / cumulative_scale)
+        if resized_stride.is_integer is False:
+            raise Unsupported(
+                f"source stride {full_strides[d]} at dim {d} cannot be "
+                f"resized by cumulative scale {cumulative_scale}"
+            )
+        if copy_sizes[d] > 1:
+            copy_strides[d] = resized_stride
+        cumulative_scale *= sympy.cancel(
+            sympy.sympify(full_sizes[d]) / sympy.sympify(copy_sizes[d])
+        )
+    return copy_strides
+
+
 def _propagate_read_copy_named_dims(copy_buf: ComputedBuffer, dep: MemoryDep) -> None:
     """Give a read-copy staging buffer the named dims its source dep carries.
 
@@ -3902,7 +3937,7 @@ def _insert_one_read_copy(
                 else next_stride // active_full_strides[k]
             )
         active_tile_ranges = [dep.size[i] for i in active_idx]
-        active_tile_strides = compute_tile_stride(
+        active_tile_strides = _compute_read_copy_strides(
             active_full_sizes, active_full_strides, active_tile_ranges
         )
         # active_tile_strides[i] corresponds to active_idx[i]: both are indexed

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -187,9 +187,12 @@ def compute_input_named_dims(dep: MemoryDep, op=None, ind_sizes=None) -> dict:
             # One loop var covers all fused names (e.g. a flat [A, B*D*E] read)
             result.setdefault(loop_vars[0], []).extend(names)
         elif len(loop_vars) == 0:
-            # This layout dim is index-selected by a gather/scatter index
-            # symbol (e.g. `tmp0`).  Raise for anything else — a constant
-            # or unexpected coord should not be silently skipped.
+            # This layout dim is either fixed to a constant source slice, or
+            # index-selected by a gather/scatter symbol (e.g. ``tmp0``).
+            # Its name was consumed above to keep later dimensions aligned,
+            # but there is no iteration variable to attach it to.
+            if not coord.free_symbols:
+                continue
             sym = _lone_sym(coord)
             if sym is not None and is_indirect(sym.name):
                 continue


### PR DESCRIPTION
## Summary

- preserve proportional padding when a coarse-tile read copy stages a non-divisible source slice
- consume named dimensions selected by constant indices without assigning them to loop variables
- compact stride-zero dimensions in compiler-generated pointwise buffers so broadcast axes do not inflate physical spans

## Context

These fix the new failures in `hf-adapters` PR #366 after updating to current torch-spyre `main`:

- Ministral 3B VLM and 8B smoke/token comparison: `tile sizes ... do not divide tensor sizes ...`
- Gemma 4 26B smoke/token comparison: constant-indexed layout dimension had no loop variable
- Granite Vision 4.1 4B: seven-crop SigLIP attention exceeded the 256 MB per-core span because a stride-zero read-copy dimension retained its logical extent physically

## Validation

- `pytest -q tests/inductor/test_coarse_tiling.py` — 355 passed
- `pytest -q tests/inductor/test_propagate_named_dims.py` — 41 passed
- focused sparse-broadcast and seven-crop SigLIP tests — 4 passed
- hf-adapters Granite Vision 4.1 4B VLM e2e — 5/5 teacher-forced tokens, matching free-run text
- hf-adapters Ministral 3B VLM e2e, fresh cache — 5/5 teacher-forced tokens, matching free-run text
- hf-adapters Gemma 4 26B token comparison — 5/5 tokens
- hf-adapters Ministral 8B token comparison — 5/5 tokens
- fresh-cache Gemma 4 26B smoke — passed
- fresh-cache Ministral 8B smoke — passed

All commits are GPG- and DCO-signed.

Test-With: https://github.com/torch-spyre/hf-adapters/pull/366