### PR TITLE
docs: refresh documentation to match current code

### DIFF
--- a/docs/source/_ext/extract_graph.py
+++ b/docs/source/_ext/extract_graph.py
@@ -1011,6 +1011,8 @@ def build_graph(torch_spyre_root):
         root / "__init__.py",
         root / "logging_config.py",
         root / "profiler" / "_ffdc.py",
+        root / "_inductor" / "dump_common.py",
+        root / "_inductor" / "dump_cost_model.py",
     ]:
         if extra_config.exists():
             n, e = _run_file_extractor(extract_config, extra_config, repo_root)

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -724,6 +724,29 @@ Environment Variables
        alternative to ``SPYRE_INDUCTOR_IGNORE_HINTS``.  Defaults to
        ``1`` (disabled/opt-in): set to ``0`` to enable automatic
        span-overflow coarse tiling.
+   * - ``SPYRE_INDUCTOR_SDSC_CACHE``
+     - Cache and reuse ``sdsc.json`` files during codegen when two OpSpecs
+       produce identical SuperDSC content, reducing bundle size for
+       programs with loops (default ``1``; set ``0`` to disable)
+   * - ``SPYRE_VALIDATE_OP_SPECS``
+     - Validate OpSpecs at pipeline stage boundaries to catch invariant
+       violations early (default ``1``; set ``0`` to disable)
+   * - ``SPYRE_CONV2D_DIRECT``
+     - Emit a native conv2d SDSC (``opFuncName="conv2d"`` on the ``pt``
+       unit) instead of the im2col + matmul decomposition. Off by default
+       (``0``); the decomposition remains the default path and the fallback
+       for grouped, transposed, or non-fp16 cases
+   * - ``SPYRE_INDUCTOR_DISABLE_CONV2D_SPATIAL_SPLIT``
+     - For a strided direct-lowered conv2d, forbid splitting the output
+       spatial dims across cores so each core computes whole spatial rows
+       and columns (default ``1``; set ``0`` to opt out)
+   * - ``TORCH_SPYRE_KTIR``
+     - Opt-in OpSpec-to-KTIR emitter (experimental). When enabled the
+       scheduler emits ``async_compile.ktir(...)`` instead of the SDSC
+       bundle; inert by default (``0``), leaving the SDSC path unchanged
+   * - ``KTIR_DEVICE_MLIR``
+     - Path to a ``.mlir`` file declaring the target device for the KTIR
+       execution path (default empty)
 
 **Device enumeration** (``torch_spyre/csrc/spyre_device_enum.cpp``):
 

--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -179,9 +179,10 @@ For the full hardware overview see
   that hard-codes "64 fp16 elements" is fp16-specific.
 - **The cost-model planner does not change correctness.** Pass 2's
   matmul split is correct on its own. The runtime benefit of any
-  K-split comes from a paired codegen layer in `codegen/superdsc.py`
-  that permutes physical core IDs so K-collaborators occupy adjacent
-  ring positions.
+  K-split comes from a paired core-ID permutation
+  (`core_to_slice_mapping` in `core_mapping.py`, applied during
+  pre-scheduling in `pass_utils.py`) that permutes physical core IDs so
+  K-collaborators occupy adjacent ring positions.
 :::
 
 ## Pass 1 — Span Reduction (`span_reduction`)
@@ -502,7 +503,8 @@ Final split: `{M: 16, N: 1, K: 2}`.
 ### Core grid
 
 The 32 cores form a 16 × 2 grid: 16 along M, paired up across the K
-split. The codegen-side permutation in `codegen/superdsc.py` (see
+split. The core-ID permutation (`core_to_slice_mapping` in
+`core_mapping.py`, applied in `pass_utils.py`; see
 [Codegen pairing for K-splits](#codegen-pairing-for-k-splits))
 arranges the K-collaborators on adjacent ring positions, so
 `(c0, c1)` accumulate M-slice 0, `(c2, c3)` accumulate M-slice 1,
@@ -531,12 +533,13 @@ commits the argmin. Pass 3 skips the op.
 
 ### Codegen pairing for K-splits
 
-When any planner selects a K-split, the SDSC emitter permutes physical
+When any planner selects a K-split, the compiler permutes physical
 core IDs so the cores collaborating on the K reduction occupy adjacent
 ring positions. The permutation is implemented in
 `core_to_slice_mapping` in `core_mapping.py`, invoked from
-`codegen/superdsc.py` with a `contiguous_dim` argument, and gated by the
-`core_id_k_fast_emission` config flag. It drops PSUM accumulation hops from
+`pass_utils.py` with a `contiguous_dim` argument, and gated by the
+`core_id_k_fast_emission` config flag (checked in `pass_utils.py` and
+`spyre_kernel.py`). It drops PSUM accumulation hops from
 `m × n` to 1, which is what makes cross-core K reductions cheap at
 runtime. The flag `SPYRE_CORE_ID_K_FAST_EMISSION` (default on)
 controls this codegen-side permutation. The name is legacy from when

--- a/docs/source/runtime/index.md
+++ b/docs/source/runtime/index.md
@@ -28,7 +28,7 @@ The PyTorch Dispatcher routes each operation to the correct device implementatio
 Torch-Spyre registers `spyre` as a PyTorch device using the
 `PrivateUse1` mechanism — the standard PyTorch pathway for out-of-tree
 accelerators. Registration happens in `torch_spyre/__init__.py`'s
-`_autoload()`:
+`_autoload_impl()`, invoked by the run-once `_autoload()` entry point:
 
 ```python
 torch.utils.rename_privateuse1_backend("spyre")
@@ -56,7 +56,7 @@ The count itself comes from `flex::getNumDevices`.
 
 | File | Responsibility |
 |------|---------------|
-| `csrc/module.cpp` | pybind11 entry point for the `_C` extension module. Device registration itself happens in `torch_spyre/__init__.py::_autoload()`. |
+| `csrc/module.cpp` | pybind11 entry point for the `_C` extension module. Device registration itself happens in `torch_spyre/__init__.py::_autoload_impl()`. |
 | `csrc/spyre_tensor_impl.cpp` | `SpyreTensorImpl`, the device tensor backing store. |
 | `csrc/spyre_mem.cpp` | Device tensor factory ops (`spyre_empty*`, `resize_`) and host↔device copy: builds the `DataConversionInfo` (DCI) descriptors via `generate_dci` that drive `copyAsync` transfers between host memory and LPDDR5. |
 | `csrc/spyre_allocator.cpp` | `SpyreAllocator`, which bridges PyTorch's `c10::Allocator` to `flex::FlexAllocator`. |

--- a/docs/source/user_guide/debugging/unified_logging_framework.md
+++ b/docs/source/user_guide/debugging/unified_logging_framework.md
@@ -296,6 +296,7 @@ These components are defined in `DEFAULT_LOG_LEVELS` in
 | `spyre.inductor` | All Inductor compiler passes and codegen | `torch_spyre/_inductor/` |
 | `spyre.inductor.lowering` | Op lowering (ATen → Spyre IR) | `_inductor/lowering.py` |
 | `spyre.inductor.codegen` | Code generation (parent) | `_inductor/codegen/bundle.py` |
+| `spyre.inductor.sdsc` | SuperDSC bundle generation | `_inductor/codegen/bundle.py` |
 | `spyre.inductor.stickify` | Tensor stickification passes | `_inductor/insert_restickify.py` |
 | `spyre.inductor.passes` | General compiler passes | `_inductor/passes.py` |
 | `spyre.runtime` | C++ runtime (allocator, streams, distributed) | `torch_spyre/csrc/` |

--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -76,6 +76,8 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.linalg.matrix_norm` | | Y | Spyre | Compiled only; eager misroutes the `ord` argument |
 | `torch.linalg.norm` | | Y | Spyre | Compiled only; eager misroutes the `ord` argument |
 | `torch.aminmax` | | Y | Spyre | Compiled only; eager not yet supported |
+| `torch.any` | Y | Y | Spyre | Custom lowering; reduces over `dim`/`dims` or the full tensor |
+| `torch.all` | Y | Y | Spyre | Custom decomposition (`abs` + `amin`) |
 | **View Ops** [^views] | | | | |
 | `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` (a C++ device view, not an Inductor lowering) |
 | `torch.transpose` | Y | Y | Spyre | |
@@ -112,6 +114,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | **Indexing** | | | | |
 | `torch.embedding` | Y | Y | Spyre | Registered on the compiled path (`ops/eager.py`) |
 | `torch.index_select` | Y | Y | Spyre | Registered on the compiled path (`ops/eager.py`) |
+| `torch.index_add` | | Y | Spyre | Compiled only; custom decomposition (gather + add + overwrite-scatter); requires unique indices |
 | `torch.masked_scatter` | Y | Y | Spyre | Custom decomposition; supported for masks that broadcast along the last (stick) dimension, other masks raise `Unsupported` |
 | **Utility** | | | | |
 | `torch.item` | Y | Y | Spyre | Copies to CPU, returns Python scalar |
@@ -128,7 +131,6 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.argmax` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.argmin` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.cumsum` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
-| `torch.any` | Y | | CPU fallback | `all_out` overload only; runs on CPU |
 | `torch.index_copy` | Y | | CPU fallback | Eager only; runs on CPU |
 
 > **Column key:**


### PR DESCRIPTION
## Summary

Documentation refresh that resolves drift found by auditing `docs/source`
against the current `torch_spyre` code base. Doc-only changes plus one
extractor fix; no runtime or API behavior changes.

## Changes

- **Supported operations** (`user_guide/supported_operations.md`)
  - `torch.any` is a native Spyre op on both the eager and compiled paths
    (custom lowerings for `any.dim`/`any.dims`/`any.default`, an eager kernel
    via `ops/eager.py`, and no CPU fallback). It was listed under CPU Fallback
    as compiled-unsupported; moved to Reduction and marked eager + compiled.
  - Added `torch.all` (custom decomposition to `abs` + `amin`, tested eager and
    compiled) and `torch.index_add` (compiled-only custom decomposition) rows.
- **API reference** (`api/torch_spyre.rst`)
  - Documented six previously undocumented `config.py` environment variables:
    `SPYRE_INDUCTOR_SDSC_CACHE`, `SPYRE_VALIDATE_OP_SPECS`, `SPYRE_CONV2D_DIRECT`,
    `SPYRE_INDUCTOR_DISABLE_CONV2D_SPATIAL_SPLIT`, `TORCH_SPYRE_KTIR`, and
    `KTIR_DEVICE_MLIR`.
- **Work division planning** (`compiler/work_division_planning.md`)
  - The K-split core-ID permutation is implemented in `core_to_slice_mapping`
    (`core_mapping.py`), invoked from `pass_utils.py`, and gated by
    `core_id_k_fast_emission` in `pass_utils.py` and `spyre_kernel.py`.
    Corrected three stale `codegen/superdsc.py` file pointers.
- **Runtime** (`runtime/index.md`)
  - Device registration runs in `_autoload_impl()`, invoked by the run-once
    `_autoload()` entry point.
- **Unified logging** (`user_guide/debugging/unified_logging_framework.md`)
  - Added the `spyre.inductor.sdsc` logging component present in
    `DEFAULT_LOG_LEVELS`.
- **Knowledge graph extractor** (`_ext/extract_graph.py`)
  - Scan `dump_common.py` and `dump_cost_model.py` so the Configuration view
    captures `SPYRE_DUMP_COST_FILE`.

## Verification

- `sphinx-build` (`make html`) completes with no warnings or errors.
- `extract_graph.py` runs clean; `env_var` node count increases from 30 to 31
  (now includes `SPYRE_DUMP_COST_FILE`).
- `pre-commit` passes on all changed files (ruff, ruff-format, PyMarkdown,
  import-regex, filename checks). The `mypy` hook was skipped locally because it
  requires Python >= 3.10; CI covers it.