### PR TITLE
fix(inductor): pass SDPA head tile counts

### DIFF
--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -14,6 +14,7 @@
 
 import dataclasses
 import math
+import sys
 import unittest
 from unittest import mock
 
@@ -565,6 +566,17 @@ class TestBuildingBlocks(unittest.TestCase):
             q.to("spyre"), k.to("spyre"), v.to("spyre")
         ).cpu()
         torch.testing.assert_close(actual, expected, atol=0.2, rtol=0.2)
+
+    def test_sdpa_head_tiles_limit_heads_per_tile(self):
+        """The hint value is a tile count, not a per-tile head extent."""
+        # The backend entry point loaded by ``import torch`` has already
+        # registered this module. Fetch it without importing torch_spyre here.
+        decompositions = sys.modules["torch_spyre._inductor.decompositions"]
+        num_head_tiles = decompositions._sdpa_num_head_tiles
+
+        self.assertEqual(num_head_tiles(32), 8)
+        self.assertEqual(num_head_tiles(16), 4)
+        self.assertEqual(num_head_tiles(14), 7)
 
     @unittest.skip("Runs for long time, possibly hang.  Keeping disabled")
     @mock.patch("torch_spyre._inductor.decompositions._SDPA_MAX_SEQUENCE_TILE_SIZE", 64)

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -50,11 +50,11 @@ _SDPA_MAX_TILE_PAIRS_PER_LOOP_GROUP = 16
 _SDPA_PREFERRED_HEADS_PER_TILE = (4, 2, 1)
 
 
-def _sdpa_heads_per_tile(num_heads: int) -> int:
-    """Pick the largest divisible heads-per-tile from the preference list."""
-    for h in _SDPA_PREFERRED_HEADS_PER_TILE:
-        if num_heads % h == 0:
-            return h
+def _sdpa_num_head_tiles(num_heads: int) -> int:
+    """Use at most four heads per tile and return the required tile count."""
+    for heads_per_tile in _SDPA_PREFERRED_HEADS_PER_TILE:
+        if num_heads % heads_per_tile == 0:
+            return num_heads // heads_per_tile
     return 1
 
 
@@ -580,7 +580,7 @@ def spyre__sdpa_overrideable(
             block_group_start + kv_blocks_per_loop_group, num_kv_blocks
         )
         with spyre_hint(tiles={"batch_size": max(1, batch_size // 2)}):
-            with spyre_hint(tiles={"num_heads": _sdpa_heads_per_tile(num_heads)}):
+            with spyre_hint(tiles={"num_heads": _sdpa_num_head_tiles(num_heads)}):
                 with spyre_hint(num_tiles_per_dim={"max_seqlen_q": num_q_tiles}):
                     for blk in range(block_group_start, block_group_end):
                         start = blk * kv_block_size


### PR DESCRIPTION
## Summary

- pass the number of head tiles to spyre_hint instead of the desired heads per tile
- retain the existing preference of at most four heads per tile
- add regression coverage for 32-, 16-, and 14-head attention

## Context

PR #4276 introduced a heads-per-tile helper, but the tiles hint consumes a tile count. For example, 32 heads need 8 tiles to produce four heads per tile; passing 4 instead produces eight heads per tile. This affects the Ministral VLM path in torch-spyre/hf-adapters#414.

This is based on current main, including merged PR #4296. PR #4296 resolves the compile-time Granite and irregular-KV failures, but this correction is still needed for Ministral numerical accuracy: decode-3 cosine improves from 0.988989 on clean main to 0.997643, above the 0.99 test threshold.

## Validation

- focused building-block test: 2 passed
- Ministral-3-3B VLM: 5/5 token agreement and matching free-run output
- LFM2-350M: 5/5 token agreement
- Granite Vision 4.1 4B: 5/5 token agreement and matching free-run output
- pre-commit: passed