### PR TITLE
Fix scalar type conversion

### DIFF
--- a/tests/inductor/test_inductor_dtype_scalars.py
+++ b/tests/inductor/test_inductor_dtype_scalars.py
@@ -17,7 +17,29 @@ import pytest
 import torch
 import torch._dynamo as dynamo
 
+from torch_spyre._inductor.dtype_ops import DtypeOpTable
+
 from utils_inductor import DEVICE, cached_randn, compare_with_cpu
+
+
+def _dtype_name(dt):
+    return str(dt).split(".")[-1]
+
+
+_DTYPE_CONVERSION_PAIRS = [
+    pytest.param(src, dst, id=f"{_dtype_name(src)}-{_dtype_name(dst)}")
+    for src, dst in DtypeOpTable.get_dtype_pairs()
+    if src not in (torch.float8_e4m3fn, torch.int32)
+    and dst not in (torch.float8_e4m3fn, torch.int32)
+]
+
+# FIXME: Remove these once the issue with CPU vs Spyre dtype mismatch error is fixed
+_DTYPE_PROMOTION_XFAIL = [
+    (torch.bfloat16, torch.float16),
+    (torch.float32, torch.float16),
+    (torch.float16, torch.bfloat16),
+    (torch.float32, torch.bfloat16),
+]
 
 
 def _compare_modes(execution_mode, fn, *args, atol=0.1, rtol=0.1):
@@ -372,6 +394,29 @@ class TestDatatypeScalarOperations:
         x = cached_randn((10, 10), dtype=torch.float32) * 1e-10
         # For large numbers, atol must be large, but rtol is the real gate
         _compare_modes(execution_mode, large_scalar_mul, x, atol=1e25, rtol=1e-3)
+
+    @pytest.mark.parametrize("src_dtype,dst_dtype", _DTYPE_CONVERSION_PAIRS)
+    def test_dtype_conversion(self, execution_mode, src_dtype, dst_dtype):
+        """Type conversions with scalars"""
+
+        def convert_scalar(s):
+            return s.to(dst_dtype)
+
+        s = torch.tensor(2.0, dtype=src_dtype)
+        _compare_modes(execution_mode, convert_scalar, s, atol=1e-3, rtol=1e-3)
+
+    @pytest.mark.parametrize("src_dtype,dst_dtype", _DTYPE_CONVERSION_PAIRS)
+    def test_dtype_promotion(self, execution_mode, src_dtype, dst_dtype):
+        """Type promotion with scalars"""
+        if (src_dtype, dst_dtype) in _DTYPE_PROMOTION_XFAIL:
+            pytest.xfail(reason="Spyre vs CPU dtype mismatch due to type promotion")
+
+        def promote_scalar(x, s):
+            return x + s
+
+        x = torch.ones(64, dtype=dst_dtype)
+        s = torch.tensor(2.0, dtype=src_dtype)
+        _compare_modes(execution_mode, promote_scalar, x, s, atol=1e-3, rtol=1e-3)
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
     def test_dtype_conversion_with_symbolic_dimensions(self, execution_mode):

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -1957,8 +1957,8 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         DtypeOpTable.is_dtype_op(op_spec.op) and op_spec.op != IDENTITY_OP
     )
 
-    if is_non_identity_dtype_op and op_stick_dim is None:
-        input_stick_label_idx = ndim if ndim != 0 else ndim + 1
+    if is_non_identity_dtype_op and ndim == 0 and op_stick_dim is None:
+        input_stick_label_idx = 1  # ndim=0, so use INPUT_DIM_LABELS[1] = "x"
         input_stick_sym = Symbol(INPUT_DIM_LABELS[input_stick_label_idx])
         sdsc_iteration_space[input_stick_sym] = op_spec.args[
             0

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -1953,9 +1953,29 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     # require at least one outer spatial dim beyond the stick; inject a
     # virtual mb=1 row when the op's tensor has only the stick dim.
     mb_sym: Symbol | None = None
+    is_non_identity_dtype_op = (
+        DtypeOpTable.is_dtype_op(op_spec.op) and op_spec.op != IDENTITY_OP
+    )
+
+    if is_non_identity_dtype_op and op_stick_dim is None:
+        input_stick_label_idx = ndim if ndim != 0 else ndim + 1
+        input_stick_sym = Symbol(INPUT_DIM_LABELS[input_stick_label_idx])
+        sdsc_iteration_space[input_stick_sym] = op_spec.args[
+            0
+        ].device_dtype.elems_per_stick()
+        work_slices[input_stick_sym] = 1
+        dim_splits[input_stick_sym] = 1
+        output_stick_sym = Symbol(OUTPUT_DIM_LABELS[0])
+        sdsc_iteration_space[output_stick_sym] = max(
+            arg.device_dtype.elems_per_stick() for arg in op_spec.args
+        )
+        work_slices[output_stick_sym] = 1
+        dim_splits[output_stick_sym] = 1
+        op_dim_order = [output_stick_sym]
+        op_stick_dim = output_stick_sym
+
     if (
-        (DtypeOpTable.is_dtype_op(op_spec.op) or op_spec.op == "qfp8ch")
-        and op_spec.op != IDENTITY_OP
+        (is_non_identity_dtype_op or op_spec.op == "qfp8ch")
         and op_stick_dim is not None
         and all(d is op_stick_dim for d in op_dim_order)
     ):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR addresses the issues in PR https://github.com/torch-spyre/torch-spyre/pull/3912 and fixes https://github.com/torch-spyre/torch-spyre/issues/2845

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2845

#### Special notes for your reviewer:

This PR only fixes explicit type conversions with scalars.

It excludes these dtypes due to special handling required: `int32` & `float8`.

Excludes the type promotion due to an issue https://github.com/torch-spyre/torch-spyre/issues/4336 with fp32 that differs from CPU dtype and results in dtype attribute mismatch error.

#### Does this PR introduce a user-facing change?

NA

#### Additional note:

NA