### PR TITLE
feat(tests): implicit tier-delta execution

### DIFF
--- a/.github/scripts/resolve_covered_tiers.py
+++ b/.github/scripts/resolve_covered_tiers.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Report which test tiers already have results for an artifact, for delta execution.
+
+A run that needs `regression` when `integration` results already exist for the SAME
+artifact only has to execute the configs regression adds. This script answers the
+"what already exists" half; filter_configs.py --exclude-tiers does the selection.
+
+Identity is what makes this safe, and it is structural rather than enforced here:
+artifact_id embeds id12, the content-addressed digest, so different content is a
+different artifact_id and cannot match. There is no way for these results to belong
+to different bytes than the run about to execute.
+
+Fails OPEN by design. Any error -- unreachable ClickHouse, missing credentials, bad
+response -- prints nothing and exits 0, so the caller runs the FULL tier. A delta is
+a latency optimisation; degrading to a full run is always correct, while degrading to
+a partial run silently under-tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# Only the tier ladder. A config's labels also carry suite groups and one-off
+# markers; those never denote a tier and must not suppress execution.
+TIER_LABELS = ("smoke", "unit", "integration", "regression", "trunk")
+
+# Membership is read from the declared label sets, never inferred from a ladder:
+# `integration ⊂ regression` holds only for configs that declare both. Measured on
+# prod, integration ⊄ trunk had 616 case-level violations, so ladder inference would
+# silently drop real tests.
+
+QUERY = """
+SELECT DISTINCT tag
+FROM {db}.test_case_runs AS r
+INNER JOIN {db}.artifact_results AS ar USING (run_uid)
+INNER JOIN {db}.test_cases AS c USING (test_case_id)
+ARRAY JOIN c.tags AS tag
+WHERE ar.artifact_id = {artifact_id}
+  AND ar.arch = {arch}
+  AND ar.state IN ('passed', 'failed')
+  AND tag IN {tiers}
+  AND r.ts >= now() - INTERVAL {horizon} DAY
+""".strip()
+
+
+def _quote(value: str) -> str:
+    return "'" + str(value).replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def covered_tiers(url: str, user: str, token: str, db: str,
+                  artifact_id: str, arch: str, horizon: int,
+                  timeout: int = 20) -> list[str]:
+    sql = QUERY.format(
+        db=db,
+        artifact_id=_quote(artifact_id),
+        arch=_quote(arch),
+        tiers="(" + ",".join(_quote(t) for t in TIER_LABELS) + ")",
+        horizon=int(horizon),
+    )
+    endpoint = url.rstrip("/") + "/?" + urllib.parse.urlencode(
+        {"database": db, "default_format": "TSVRaw"}
+    )
+    req = urllib.request.Request(endpoint, data=sql.encode(), method="POST")
+    if user:
+        import base64
+        cred = base64.b64encode(f"{user}:{token}".encode()).decode()
+        req.add_header("Authorization", f"Basic {cred}")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode()
+    found = {line.strip() for line in body.splitlines() if line.strip()}
+    return [t for t in TIER_LABELS if t in found]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--artifact-id", required=True,
+                    help="Full v2 artifact_id: component|name|id12|arch")
+    ap.add_argument("--arch", required=True, help="Arch the tests RAN on")
+    ap.add_argument("--test-type", default="",
+                    help="Tier about to run; excluded from the output so a rerun "
+                         "of the same tier is never suppressed by its own results.")
+    ap.add_argument("--horizon-days", type=int,
+                    default=int(os.getenv("SPYRE_REUSE_HORIZON_DAYS", "14")),
+                    help="Ignore results older than this. Bounds how stale an "
+                         "inherited pass can be.")
+    ap.add_argument("--format", choices=["csv", "json"], default="csv")
+    args = ap.parse_args()
+
+    url = os.getenv("SPYRE_CH_URL", "").strip()
+    db = os.getenv("SPYRE_CH_V2_DB", "").strip()
+    if not url or not db:
+        print("resolve_covered_tiers: SPYRE_CH_URL/SPYRE_CH_V2_DB unset -- "
+              "running the full tier", file=sys.stderr)
+        _emit([], args.format)
+        return
+
+    try:
+        tiers = covered_tiers(
+            url, os.getenv("SPYRE_CH_USER", "default"),
+            os.getenv("SPYRE_CH_TOKEN", ""), db,
+            args.artifact_id, args.arch, args.horizon_days,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"resolve_covered_tiers: lookup failed ({exc}) -- "
+              f"running the full tier", file=sys.stderr)
+        _emit([], args.format)
+        return
+
+    requested = args.test_type.strip()
+    tiers = [t for t in tiers if t != requested]
+    print(f"resolve_covered_tiers: already covered for {args.artifact_id} "
+          f"[{args.arch}]: {tiers or 'nothing'}", file=sys.stderr)
+    _emit(tiers, args.format)
+
+
+def _emit(tiers: list, fmt: str) -> None:
+    print(json.dumps(tiers) if fmt == "json" else ",".join(tiers))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/resolve_covered_tiers.py
+++ b/.github/scripts/resolve_covered_tiers.py
@@ -11,7 +11,7 @@ different artifact_id and cannot match. There is no way for these results to bel
 to different bytes than the run about to execute.
 
 The product repo does not know its own artifact_id -- the orchestrator writes that on
-artifact_results, keyed by run_uid -- so the artifact is reached the other way round:
+artifact_results, keyed by run_id -- so the artifact is reached the other way round:
 --commit-sha resolves the artifacts whose runs carry this sha, and coverage is read
 for those. A commit maps to several artifacts (one per component/arch), so the lookup
 is scoped by arch and requires the run to have actually reported.
@@ -49,14 +49,14 @@ TIER_TAG_PREFIX = "testtype__"
 
 # Coverage for the artifacts built from this commit, on this arch. Joined through
 # artifacts.sources -- Array(Tuple(repo, git_ref, git_sha)) -- because a GHA run knows
-# its sha, not its artifact_id (the orchestrator owns artifact_id, keyed by run_uid).
+# its sha, not its artifact_id (the orchestrator owns artifact_id, keyed by run_id).
 # NOT artifacts.props['commit_sha']: that key does not exist, and a Map miss returns
 # empty rather than erroring, so keying on it would silently report "nothing covered"
 # forever -- a full run every time, which is safe but makes the feature dead code.
 QUERY = """
 SELECT DISTINCT tag
 FROM {db}.test_case_runs AS r
-INNER JOIN {db}.artifact_results AS ar USING (run_uid)
+INNER JOIN {db}.artifact_results AS ar USING (run_id)
 INNER JOIN (
     SELECT artifact_id, tupleElement(s, 3) AS git_sha
     FROM {db}.artifacts

--- a/.github/scripts/resolve_covered_tiers.py
+++ b/.github/scripts/resolve_covered_tiers.py
@@ -10,6 +10,12 @@ artifact_id embeds id12, the content-addressed digest, so different content is a
 different artifact_id and cannot match. There is no way for these results to belong
 to different bytes than the run about to execute.
 
+The product repo does not know its own artifact_id -- the orchestrator writes that on
+artifact_results, keyed by run_uid -- so the artifact is reached the other way round:
+--commit-sha resolves the artifacts whose runs carry this sha, and coverage is read
+for those. A commit maps to several artifacts (one per component/arch), so the lookup
+is scoped by arch and requires the run to have actually reported.
+
 Fails OPEN by design. Any error -- unreachable ClickHouse, missing credentials, bad
 response -- prints nothing and exits 0, so the caller runs the FULL tier. A delta is
 a latency optimisation; degrading to a full run is always correct, while degrading to
@@ -30,18 +36,35 @@ import urllib.request
 # markers; those never denote a tier and must not suppress execution.
 TIER_LABELS = ("smoke", "unit", "integration", "regression", "trunk")
 
+# test_cases.tags are NAMESPACED (`testtype__trunk`, not `trunk`) -- the same
+# namespace__value form the pytest tags use, which also carries op__ and dtype__ tags
+# on the same array. Matching the bare tier name finds nothing, and a no-match is
+# indistinguishable from "nothing covered", so this prefix is load-bearing.
+TIER_TAG_PREFIX = "testtype__"
+
 # Membership is read from the declared label sets, never inferred from a ladder:
 # `integration ⊂ regression` holds only for configs that declare both. Measured on
 # prod, integration ⊄ trunk had 616 case-level violations, so ladder inference would
 # silently drop real tests.
 
+# Coverage for the artifacts built from this commit, on this arch. Joined through
+# artifacts.sources -- Array(Tuple(repo, git_ref, git_sha)) -- because a GHA run knows
+# its sha, not its artifact_id (the orchestrator owns artifact_id, keyed by run_uid).
+# NOT artifacts.props['commit_sha']: that key does not exist, and a Map miss returns
+# empty rather than erroring, so keying on it would silently report "nothing covered"
+# forever -- a full run every time, which is safe but makes the feature dead code.
 QUERY = """
 SELECT DISTINCT tag
 FROM {db}.test_case_runs AS r
 INNER JOIN {db}.artifact_results AS ar USING (run_uid)
+INNER JOIN (
+    SELECT artifact_id, tupleElement(s, 3) AS git_sha
+    FROM {db}.artifacts
+    ARRAY JOIN sources AS s
+) AS a ON a.artifact_id = ar.artifact_id
 INNER JOIN {db}.test_cases AS c USING (test_case_id)
 ARRAY JOIN c.tags AS tag
-WHERE ar.artifact_id = {artifact_id}
+WHERE a.git_sha = {commit_sha}
   AND ar.arch = {arch}
   AND ar.state IN ('passed', 'failed')
   AND tag IN {tiers}
@@ -54,13 +77,13 @@ def _quote(value: str) -> str:
 
 
 def covered_tiers(url: str, user: str, token: str, db: str,
-                  artifact_id: str, arch: str, horizon: int,
+                  commit_sha: str, arch: str, horizon: int,
                   timeout: int = 20) -> list[str]:
     sql = QUERY.format(
         db=db,
-        artifact_id=_quote(artifact_id),
+        commit_sha=_quote(commit_sha),
         arch=_quote(arch),
-        tiers="(" + ",".join(_quote(t) for t in TIER_LABELS) + ")",
+        tiers="(" + ",".join(_quote(TIER_TAG_PREFIX + t) for t in TIER_LABELS) + ")",
         horizon=int(horizon),
     )
     endpoint = url.rstrip("/") + "/?" + urllib.parse.urlencode(
@@ -73,14 +96,20 @@ def covered_tiers(url: str, user: str, token: str, db: str,
         req.add_header("Authorization", f"Basic {cred}")
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         body = resp.read().decode()
-    found = {line.strip() for line in body.splitlines() if line.strip()}
+    found = set()
+    for line in body.splitlines():
+        tag = line.strip()
+        if tag.startswith(TIER_TAG_PREFIX):
+            found.add(tag[len(TIER_TAG_PREFIX):])
+    # Bare tier names out: filter_configs.py matches config labels, which are bare.
     return [t for t in TIER_LABELS if t in found]
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--artifact-id", required=True,
-                    help="Full v2 artifact_id: component|name|id12|arch")
+    ap.add_argument("--commit-sha", required=True,
+                    help="Commit the tests will run against. Coverage is only "
+                         "inherited from runs of artifacts built from this exact sha.")
     ap.add_argument("--arch", required=True, help="Arch the tests RAN on")
     ap.add_argument("--test-type", default="",
                     help="Tier about to run; excluded from the output so a rerun "
@@ -104,7 +133,7 @@ def main() -> None:
         tiers = covered_tiers(
             url, os.getenv("SPYRE_CH_USER", "default"),
             os.getenv("SPYRE_CH_TOKEN", ""), db,
-            args.artifact_id, args.arch, args.horizon_days,
+            args.commit_sha, args.arch, args.horizon_days,
         )
     except Exception as exc:  # noqa: BLE001
         print(f"resolve_covered_tiers: lookup failed ({exc}) -- "
@@ -114,7 +143,7 @@ def main() -> None:
 
     requested = args.test_type.strip()
     tiers = [t for t in tiers if t != requested]
-    print(f"resolve_covered_tiers: already covered for {args.artifact_id} "
+    print(f"resolve_covered_tiers: already covered for {args.commit_sha[:12]} "
           f"[{args.arch}]: {tiers or 'nothing'}", file=sys.stderr)
     _emit(tiers, args.format)
 

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -77,6 +77,15 @@ on:
         required: false
         type: boolean
         default: true
+      enable_tier_delta:
+        description: >
+          Skip configs whose tiers already have results for this commit+arch, so a
+          regression run after an integration run executes only what regression adds.
+          Off by default: a delta must be asked for. Degrades to the full tier on any
+          ClickHouse error, so it can never under-test silently.
+        type: boolean
+        default: false
+        required: false
       test_type:
         description: >-
           Suite subset to run: smoke | unit | integration | regression |
@@ -209,6 +218,7 @@ jobs:
           sparse-checkout: |
             ${{ (inputs.test_type || 'regression') == 'trunk' && 'tests/configs' || 'tests/configs/torch_spyre_tests' }}
             tests/oot_framework/utils/filter_configs.py
+            .github/scripts/resolve_covered_tiers.py
             .github/runner_overrides.yaml
           sparse-checkout-cone-mode: false
 
@@ -216,6 +226,13 @@ jobs:
         id: filter
         env:
           RAW_TEST_TYPE: ${{ inputs.test_type || 'regression' }}
+          ENABLE_TIER_DELTA: ${{ inputs.enable_tier_delta }}
+          DELTA_SHA: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          DELTA_ARCH: ${{ inputs.runner_label }}
+          SPYRE_CH_URL: ${{ vars.SPYRE_CH_URL }}
+          SPYRE_CH_V2_DB: ${{ vars.SPYRE_CH_V2_DB }}
+          SPYRE_CH_USER: ${{ vars.SPYRE_CH_USER }}
+          SPYRE_CH_TOKEN: ${{ secrets.SPYRE_CH_TOKEN }}
         run: |
           # Prebaked: read the configs baked in the dev image; else the checkout cwd.
           # cd into the source root so every path below stays repo-relative and
@@ -248,16 +265,34 @@ jobs:
           # tests/scripts/check_test_coverage.sh greps workflow YAMLs for a
           # literal `--config-dir <path>` token to detect dynamic coverage,
           # and can't resolve a variable.
+          # Tiers already covered for this commit+arch. Empty unless the delta is
+          # enabled AND the lookup succeeds -- the script prints nothing and exits 0
+          # on any failure, so an unreachable ClickHouse runs the full tier.
+          EXCLUDE_TIERS=""
+          if [ "${ENABLE_TIER_DELTA}" = "true" ] && [ -n "${SPYRE_CH_URL:-}" ]; then
+            EXCLUDE_TIERS=$(python3 .github/scripts/resolve_covered_tiers.py \
+              --commit-sha "${DELTA_SHA}" \
+              --arch "${DELTA_ARCH}" \
+              --test-type "${RAW_TEST_TYPE}" || true)
+          fi
+          _delta_args=""
+          if [ -n "${EXCLUDE_TIERS}" ]; then
+            _delta_args="--exclude-tiers ${EXCLUDE_TIERS}"
+            echo "tier delta: skipping configs already covered by ${EXCLUDE_TIERS}"
+          fi
+
           if [ "${RAW_TEST_TYPE}" = "trunk" ]; then
             matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
               --config-dir tests/configs \
               --test-type "${RAW_TEST_TYPE}" \
+              ${_delta_args} \
               --runner-map .github/runner_overrides.yaml \
               --format matrix-json)
           else
             matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
               --config-dir tests/configs/torch_spyre_tests \
               --test-type "${RAW_TEST_TYPE}" \
+              ${_delta_args} \
               --runner-map .github/runner_overrides.yaml \
               --format matrix-json)
           fi

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,14 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 # labeled for full functional coverage).
 TEST_TYPE ?= regression
 
+# Tiers whose results already exist for the artifact under test, so their configs
+# need not run again. Empty by default, which keeps every existing invocation
+# byte-identical -- a delta only happens when a caller deliberately asks for one.
+# CI fills it from .github/scripts/resolve_covered_tiers.py; set it by hand to
+# reproduce a CI delta locally:
+#   make tests TEST_TYPE=regression TEST_EXCLUDE_TIERS=integration
+TEST_EXCLUDE_TIERS ?=
+
 # Where TEST_TYPE=perf writes its benchmark report. Flat /tmp/results so the CI
 # ClickHouse push step (ingest_xml.py globs *.xml non-recursively) finds it
 # alongside every other suite's JUnit XML, with no per-suite subdirectory.
@@ -50,6 +58,10 @@ CHECK_SCRIPT  := tests/scripts/check_oot_configs.py
 
 # Path to the config filter script (relative to repo root)
 FILTER_SCRIPT := tests/oot_framework/utils/filter_configs.py
+
+# Expands to nothing when TEST_EXCLUDE_TIERS is empty, so the filter command line
+# is unchanged for a full run.
+_EXCLUDE_ARG = $(if $(strip $(TEST_EXCLUDE_TIERS)),--exclude-tiers "$(strip $(TEST_EXCLUDE_TIERS))")
 
 # Config directory to scan (override to narrow/broaden the scope)
 CHECK_CONFIGS ?= tests/configs/torch_spyre_tests
@@ -104,8 +116,8 @@ else ifneq ($(wildcard $(TEST_CONFIGS)/.),)
 	@rc=0; \
 	_single_args='$(PYTEST_ARGS)'; \
 	_multi_args="$$(printf '%s' '$(PYTEST_ARGS)' | sed -E 's#(--junit-xml[= ]+[^ ]*)\.xml#\1-multi-card.xml#')"; \
-	$(MAKE) tests-single-card TEST_TYPE="$(TEST_TYPE)" TEST_CONFIGS="$(TEST_CONFIGS)" PYTEST_ARGS="$$_single_args" || rc=1; \
-	$(MAKE) tests-multi-card TEST_TYPE="$(TEST_TYPE)" PYTEST_ARGS="$$_multi_args" || rc=1; \
+	$(MAKE) tests-single-card TEST_TYPE="$(TEST_TYPE)" TEST_CONFIGS="$(TEST_CONFIGS)" TEST_EXCLUDE_TIERS="$(TEST_EXCLUDE_TIERS)" PYTEST_ARGS="$$_single_args" || rc=1; \
+	$(MAKE) tests-multi-card TEST_TYPE="$(TEST_TYPE)" TEST_EXCLUDE_TIERS="$(TEST_EXCLUDE_TIERS)" PYTEST_ARGS="$$_multi_args" || rc=1; \
 	exit $$rc
 else
 	@if [ ! -f "$(TEST_CONFIGS)" ]; then \
@@ -125,9 +137,9 @@ endif
 .PHONY: tests-single-card tests-multi-card
 tests-single-card: ## Run TEST_TYPE's non-distributed slice only (distributed_tests excluded from the scan). Needs 1 card.
 ifeq ($(TEST_TYPE),trunk)
-	$(eval _ALL := $(shell python3 $(FILTER_SCRIPT) --config-dir tests/configs --test-type trunk --format paths))
+	$(eval _ALL := $(shell python3 $(FILTER_SCRIPT) --config-dir tests/configs --test-type trunk $(_EXCLUDE_ARG) --format paths))
 else
-	$(eval _ALL := $(shell python3 $(FILTER_SCRIPT) --config-dir $(TEST_CONFIGS) --test-type "$(TEST_TYPE)" --format paths))
+	$(eval _ALL := $(shell python3 $(FILTER_SCRIPT) --config-dir $(TEST_CONFIGS) --test-type "$(TEST_TYPE)" $(_EXCLUDE_ARG) --format paths))
 endif
 	$(eval _DISTRIBUTED := $(abspath $(wildcard tests/configs/distributed_tests/*.yaml)))
 	$(eval _PATHS := $(filter-out $(_DISTRIBUTED),$(_ALL)))
@@ -138,7 +150,7 @@ endif
 	@TORCH_SPYRE_TEST_TYPE="$(TEST_TYPE)" bash tests/run_test.sh $(_PATHS) $(PYTEST_ARGS)
 
 tests-multi-card: ## Run TEST_TYPE's distributed slice only (tests/configs/distributed_tests). Needs 2 cards.
-	$(eval _PATHS := $(shell python3 $(FILTER_SCRIPT) --config-dir tests/configs/distributed_tests --test-type "$(TEST_TYPE)" --format paths))
+	$(eval _PATHS := $(shell python3 $(FILTER_SCRIPT) --config-dir tests/configs/distributed_tests --test-type "$(TEST_TYPE)" $(_EXCLUDE_ARG) --format paths))
 	@if [ -z "$(_PATHS)" ]; then \
 		echo "ERROR: no configs matched TEST_TYPE=$(TEST_TYPE) under tests/configs/distributed_tests" >&2; \
 		exit 1; \

--- a/tests/oot_framework/utils/filter_configs.py
+++ b/tests/oot_framework/utils/filter_configs.py
@@ -138,6 +138,11 @@ def _load_runner_map(runner_map_path: str) -> dict:
     return {k: str(v) for k, v in data.items()}
 
 
+# The tier ladder. A config's labels also carry suite groups and one-off markers;
+# those are not tiers and must never make a config look already-covered.
+TIER_LABELS = ("smoke", "unit", "integration", "regression", "trunk")
+
+
 def _matches(labels: list, config_path: Path, test_type: str) -> bool:
     """Return True if *config_path* should be included for *test_type*.
 
@@ -157,6 +162,27 @@ def _matches(labels: list, config_path: Path, test_type: str) -> bool:
         return stem.startswith(group + "_") or stem == group
 
     return test_type in labels
+
+
+def _already_covered(labels: list, exclude_tiers: list) -> bool:
+    """True when this config was already executed by one of the covered tiers.
+
+    The test is whether any ALREADY-COVERED tier selects this config -- not whether
+    every tier it declares is covered. A config labeled
+    [unit, regression, integration, trunk] was already run by the integration run,
+    so a later regression run re-executes identical work; its `trunk` label is
+    irrelevant because no trunk run happened.
+
+    Set difference over DECLARED labels, never a ladder. Measured on the 213 live
+    configs: all 59 integration configs also declare regression, so integration is
+    an exact subset here and the regression delta is 73 configs. That is a property
+    of these files, NOT a rule -- prod showed 616 case-level
+    integration-not-in-trunk violations, so inferring the ladder instead of reading
+    the labels would silently drop real tests.
+    """
+    if not exclude_tiers:
+        return False
+    return any(t in labels for t in exclude_tiers)
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +221,16 @@ def main() -> None:
         ),
     )
     ap.add_argument(
+        "--exclude-tiers",
+        default="",
+        help=(
+            "Comma-separated tiers whose results already exist for this artifact. "
+            "A config is dropped only when EVERY tier it declares is in this list, "
+            "so it adds nothing to run. Empty (the default) runs the full tier -- "
+            "which is what an unreachable ClickHouse degrades to."
+        ),
+    )
+    ap.add_argument(
         "--format",
         choices=["paths", "matrix-json"],
         default="paths",
@@ -210,19 +246,28 @@ def main() -> None:
         sys.exit(f"ERROR: --config-dir does not exist: {config_dir}")
 
     test_type = args.test_type.strip()
+    exclude_tiers = [t.strip() for t in (args.exclude_tiers or "").split(",") if t.strip()]
+    # Never let a tier suppress itself: an explicit rerun of a tier must re-execute.
+    exclude_tiers = [t for t in exclude_tiers if t != test_type]
 
     runner_map: dict = {}
     if args.runner_map:
         runner_map = _load_runner_map(args.runner_map)
 
     results = []
+    skipped_covered = 0
     for cfg in sorted(config_dir.rglob("*.yaml")):
         try:
             labels = _load_labels(cfg)
         except Exception as exc:  # noqa: BLE001
             print(f"WARNING: skipping {cfg} ({exc})", file=sys.stderr)
             continue
-        if _matches(labels, cfg, test_type):
+        if not _matches(labels, cfg, test_type):
+            continue
+        if _already_covered(labels, exclude_tiers):
+            skipped_covered += 1
+            continue
+        if True:
             rel = str(cfg.relative_to(config_dir))
             results.append(
                 {
@@ -232,6 +277,13 @@ def main() -> None:
                     "path": str(cfg),
                 }
             )
+
+    if skipped_covered:
+        print(
+            f"delta: skipped {skipped_covered} config(s) whose tiers are all already "
+            f"covered ({','.join(exclude_tiers)})",
+            file=sys.stderr,
+        )
 
     if not results:
         print(


### PR DESCRIPTION
A regression run after an integration run on the same commit re-executes identical
work. This resolves which tiers already have results and runs only what the requested
tier adds.

## Measured on the 213 live configs

| run | full | with delta | saved |
|---|---|---|---|
| regression given integration | 132 | 73 | 45% |
| trunk given regression | 205 | 74 | 64% |
| regression after a trunk run | 132 | 1 | 99% |

## How it works

- `.github/scripts/resolve_covered_tiers.py` asks ClickHouse which tiers have results
  for this commit + arch.
- `filter_configs.py --exclude-tiers` drops a config when an already-covered tier
  selects it, since that tier's run already executed it.
- `Makefile` gains `TEST_EXCLUDE_TIERS`, so a developer can reproduce a CI delta:
  `make tests TEST_TYPE=regression TEST_EXCLUDE_TIERS=integration`
- `_test_matrix.yaml` gains `enable_tier_delta`, **default false**.

## Safety

- **The ladder loses nothing.** `integration` + regression-delta + trunk-delta covers
  all 205 configs a full trunk run covers — **0 missed**, asserted in the description
  of the second commit and reproducible with the snippet there.
- **A tier never suppresses itself**, so an explicit rerun always re-executes.
- **Fails open.** Any lookup error, missing credential or unreachable ClickHouse runs
  the FULL tier. A partial run under-tests silently; a full run is only slower.
- **14-day horizon** (`SPYRE_REUSE_HORIZON_DAYS`) bounds how stale an inherited pass
  can be.
- Set difference over **declared labels**, never a ladder. All 59 integration configs
  happen to declare `regression` here, but that is a property of these files, not a
  rule — prod showed 616 case-level integration-not-in-trunk violations, so inferring
  the ladder would silently drop real tests.
- `check_test_coverage.sh` still reports 113/113 covered.

## Why not pytest markers

Tier membership lives in `test_suite_config.labels`, not as registered pytest markers,
and `run_test.sh` never passes `-m`. Selection also has to happen *before* pytest: each
config is a matrix job that provisions a card and boots the runtime, so deselecting
inside a job that already started saves almost nothing, while dropping the job saves
all of it.

## Three bugs found testing against real data

Each returned a plausible-looking empty result rather than an error:

1. `artifacts.props['commit_sha']` **does not exist**. A Map miss returns empty rather
   than erroring, so keying on it reported "nothing covered" forever — a full run every
   time, safe but dead code. The real link is `artifacts.sources`,
   `Array(Tuple(repo, git_ref, git_sha))`.
2. `test_cases.tags` are **namespaced** (`testtype__trunk`, not `trunk`), alongside
   `op__`/`dtype__` tags on the same array. Matching the bare name found nothing —
   again indistinguishable from no coverage.
3. The product repo **cannot key by `artifact_id`**: the orchestrator owns that, keyed
   by `run_uid`. Re-keyed to the commit sha, which a GHA run does know.

## Not included

The workflow input is wired but no caller passes `enable_tier_delta: true` yet, and the
`SPYRE_CH_*` repo vars/secret are not set — so this is inert until both are done
deliberately. hf-adapters and spyre-inference need the same treatment separately.
