### PR TITLE
docs: update hf-adapters generation examples

### DIFF
--- a/docs/source/user_guide/running_hf_models.md
+++ b/docs/source/user_guide/running_hf_models.md
@@ -85,26 +85,29 @@ it to the device. The tokenizer is the stock HF one.
 from hf_adapters import AutoSpyreModelForCausalLM
 from transformers import AutoTokenizer
 
-model = AutoSpyreModelForCausalLM.from_pretrained(
-    "ibm-granite/granite-3.3-8b-instruct"
-)
-tokenizer = AutoTokenizer.from_pretrained("ibm-granite/granite-3.3-8b-instruct")
+model_id = "ibm-granite/granite-3.3-8b-instruct"
+model = AutoSpyreModelForCausalLM.from_pretrained(model_id)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-outputs = model.generate(tokenizer, ["What is 2+2?"], max_new_tokens=128)
+inputs = tokenizer(["What is 2+2?"], return_tensors="pt", padding=True)
+sequences = model.generate(**inputs, max_new_tokens=128)
+outputs = tokenizer.batch_decode(
+    sequences[:, inputs["input_ids"].shape[1] :],
+    skip_special_tokens=True,
+)
 print(outputs[0])
 ```
 
-The `generate` method attached to the model is not the stock HF one. It runs a
-64-block padded decode loop and takes the tokenizer and a list of prompts
-rather than pre-tokenized `input_ids`. Its signature is
-`generate(tokenizer, prompts, max_new_tokens, do_sample=None,
-temperature=None, top_k=None, top_p=None, eos_token_id=..., timing=False)`.
-`max_new_tokens` is required. The sampling parameters default to `None` and
-resolve from the model's `generation_config` at call time, so the effective
-default follows `explicit kwarg > generation_config > HF global default`. See
+The only change from a stock Hugging Face script is the model class:
+`AutoSpyreModelForCausalLM` replaces `AutoModelForCausalLM`. Tokenization,
+generation arguments, and decoding follow the stock API. `model.generate()`
+takes pre-tokenized `input_ids` and an optional `attention_mask`, and returns a
+token tensor containing the input prefix followed by the generated tokens.
+`hf_adapters.encode_prompts()` is also available for model-aware tokenization;
+it applies the checkpoint's chat template for instruct models. See
 [docs/generate_vs_stock_hf.md](https://github.com/torch-spyre/hf-adapters/blob/main/docs/generate_vs_stock_hf.md)
-in the project for the full contract and how it differs from
-`transformers.generate`.
+in the project for the supported generation features and remaining differences
+from `transformers.generate`.
 
 ## Embedding models
 
@@ -163,24 +166,22 @@ batch = processor.apply_chat_template(
     return_tensors="pt",
 )
 
-texts = model.generate(
-    processor,
-    batch["input_ids"],
-    batch["attention_mask"],
-    batch["pixel_values"],
-    batch["image_sizes"],
-    max_new_tokens=64,
+sequences = model.generate(**batch, max_new_tokens=64)
+prompt_length = batch["input_ids"].shape[1]
+texts = processor.batch_decode(
+    sequences[:, prompt_length:],
+    skip_special_tokens=True,
 )
 print(texts[0])
 ```
 
-The multimodal `generate` takes the processor, the tokenized `input_ids` and
-`attention_mask`, and the image tensors, then runs the same padded decode loop
-as the text path. The extra image inputs vary by model: Granite Vision and
-Mistral3 Vision take `image_sizes` for anyres tiling, and Gemma 4 takes
-`image_position_ids` and `mm_token_type_ids`. Pass whatever the processor
-produced. To run only the text backbone of a multimodal checkpoint, load it
-with `AutoSpyreModelForCausalLM` instead, which discards the vision tower.
+The multimodal `generate` takes the processor's tokenized batch as keyword
+arguments and returns token sequences, following the same input and output
+conventions as the text path. Forward the entire batch so the model receives
+the inputs appropriate to that checkpoint, then decode the generated
+continuation with the processor. To run only the text backbone of a multimodal
+checkpoint, load it with `AutoSpyreModelForCausalLM` instead, which discards
+the vision tower.
 
 ## A note on numerical accuracy
 


### PR DESCRIPTION
## Summary

- update the causal-LM example to pass tokenized inputs to `model.generate()` and decode the returned token sequences
- update the vision-language example to forward the processor batch with `**batch` and decode the generated continuation
- replace the obsolete generation signature description with the current Hugging Face-shaped API

## Testing

- `conda run -n hf_adapters pre-commit run --files docs/source/user_guide/running_hf_models.md`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)