### PR TITLE
perf(moe): preserve direct weight reads through compiler rewrites

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_read_copy_elision_views_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_read_copy_elision_views_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_read_copy_elision_views.py
+      unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_read_copy_rewrites_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_read_copy_rewrites_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_read_copy_rewrites.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_read_copy_elision_views.py
+++ b/tests/inductor/test_read_copy_elision_views.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read-copy ownership must be compared in a proven common coordinate basis."""
+
+import dataclasses
+
+import pytest
+import sympy
+
+from torch_spyre._inductor.pass_utils import PerCoreView
+from torch_spyre._inductor.read_copy_elision import (
+    _views_match_through_read_coordinates,
+)
+
+
+H, F = sympy.symbols("h f", integer=True)
+# Match the compiler's physical-core symbol, including its assumptions.
+C = sympy.Symbol("core_id")
+DIRECT = PerCoreView(((1, 4),), ((1, sympy.Mod(C, 4)),), 32)
+STAGED = PerCoreView(((2, 4),), ((2, sympy.Mod(C, 4)),), 32)
+DIRECT_SIZE = [128, 2816, 11, 64]
+STAGED_SIZE = [1, 11, 2816, 64]
+DIRECT_COORDS = [0, H, sympy.floor(F / 64), sympy.Mod(F, 64)]
+STAGED_COORDS = [0, sympy.floor(F / 64), H, sympy.Mod(F, 64)]
+
+
+def check(
+    staged=STAGED,
+    direct=DIRECT,
+    staged_size=STAGED_SIZE,
+    direct_size=DIRECT_SIZE,
+    staged_coords=STAGED_COORDS,
+    direct_coords=DIRECT_COORDS,
+):
+    return _views_match_through_read_coordinates(
+        staged, staged_size, staged_coords, direct, direct_size, direct_coords
+    )
+
+
+def test_permuted_layout_preserves_same_logical_weight_slice():
+    assert check()
+
+
+def test_same_layout_preserves_same_core_owners():
+    assert check(staged=DIRECT, staged_size=DIRECT_SIZE, staged_coords=DIRECT_COORDS)
+
+
+def test_equal_splits_different_core_owners_declines():
+    assert not check(
+        direct=dataclasses.replace(
+            DIRECT, core_to_slot=((1, sympy.Mod(sympy.floor(C / 8), 4)),)
+        )
+    )
+
+
+def test_different_physical_core_count_declines():
+    assert not check(direct=dataclasses.replace(DIRECT, num_cores=16))
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        [0, H + 1, sympy.floor(F / 64), sympy.Mod(F, 64)],
+        [0, F, sympy.floor(H / 64), sympy.Mod(H, 64)],
+        [0, H, H, sympy.Mod(F, 64)],
+    ],
+)
+def test_shifted_wrong_or_ambiguous_coordinates_decline(coordinates):
+    assert not check(direct_size=[128, 2816, 2816, 64], direct_coords=coordinates)
+
+
+def test_different_extent_declines():
+    assert not check(direct_size=[128, 5632, 11, 64])
+
+
+def test_missing_coordinate_declines():
+    assert not check(direct_coords=DIRECT_COORDS[:-1])
+
+
+def test_missing_owner_declines():
+    assert not check(staged=dataclasses.replace(STAGED, core_to_slot=()))

--- a/tests/inductor/test_read_copy_rewrites.py
+++ b/tests/inductor/test_read_copy_rewrites.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Saved candidates undergo the same non-weight transforms as live consumers."""
+
+from types import SimpleNamespace
+
+import pytest
+import sympy
+import torch
+from torch._inductor.ir import Pointwise
+from torch._inductor.virtualized import V
+
+from torch_spyre._inductor.loop_info import ReadCopyElisionRecord
+from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
+from torch_spyre._inductor.wsr.coarse_tile import (
+    _RetiledBufferInfo,
+    _retile_elision_record,
+)
+
+
+ROW, COL = sympy.symbols("i j", integer=True, nonnegative=True)
+
+
+class Loads:
+    def load(self, name, index):
+        return name, index
+
+
+def direct(index):
+    i, j = index
+    return V.ops.load("activation", 32 * i + j), V.ops.load("bank", 64 * i + j)
+
+
+def staged(index):
+    i, j = index
+    return V.ops.load("activation", 32 * i + j), V.ops.load("copy", 64 * i + j)
+
+
+def record():
+    return ReadCopyElisionRecord("matmul", "copy", "bank", direct)
+
+
+def read(fn):
+    with V.set_ops_handler(Loads()):
+        return fn([ROW, COL])
+
+
+def info():
+    return _RetiledBufferInfo(
+        old_size=(sympy.Integer(8), sympy.Integer(32)),
+        new_size=(sympy.Integer(8), sympy.Integer(8)),
+        old_stride=(sympy.Integer(32), sympy.Integer(1)),
+        new_stride=(sympy.Integer(8), sympy.Integer(1)),
+    )
+
+
+def test_retile_candidate_updates_activation_but_not_bank():
+    original = record()
+    updated = _retile_elision_record(original, {"activation": info()})
+    assert read(updated.direct_inner_fn) == (
+        ("activation", 8 * ROW + COL),
+        ("bank", 64 * ROW + COL),
+    )
+    assert read(original.direct_inner_fn)[0] == ("activation", 32 * ROW + COL)
+    assert (updated.consumer_name, updated.copy_name, updated.source_name) == (
+        "matmul",
+        "copy",
+        "bank",
+    )
+
+
+@pytest.mark.parametrize("name", ["copy", "bank"])
+def test_retile_of_saved_weight_contract_invalidates_candidate(name):
+    assert _retile_elision_record(record(), {name: info()}) is None
+
+
+@pytest.mark.parametrize("unknown", [None, object()])
+def test_retile_does_not_invent_a_candidate(unknown):
+    assert _retile_elision_record(unknown, {"activation": info()}) is None
+
+
+def operation(saved=True):
+    result = SimpleNamespace(
+        data=Pointwise(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=staged,
+            ranges=[8, 32],
+        )
+    )
+    if saved:
+        result._read_copy_elision_record = record()
+    return result
+
+
+def editor():
+    # This unit exercises the actual graph rewrite without building an FX graph.
+    return object.__new__(GraphEditor)
+
+
+def test_relayout_renames_activation_in_live_and_saved_forms():
+    op = operation()
+    op._ts_cached_read_writes = object()
+    editor()._replace_loop_input(op, "activation", "moved_activation")
+    assert read(op.data.inner_fn) == (
+        ("moved_activation", 32 * ROW + COL),
+        ("copy", 64 * ROW + COL),
+    )
+    assert read(op._read_copy_elision_record.direct_inner_fn) == (
+        ("moved_activation", 32 * ROW + COL),
+        ("bank", 64 * ROW + COL),
+    )
+    assert not hasattr(op, "_ts_cached_read_writes")
+
+
+@pytest.mark.parametrize("name", ["copy", "bank"])
+def test_relayout_of_saved_weight_contract_invalidates_candidate(name):
+    op = operation()
+    editor()._replace_loop_input(op, name, "different_weight")
+    assert not hasattr(op, "_read_copy_elision_record")
+
+
+def test_relayout_does_not_invent_a_candidate():
+    op = operation(saved=False)
+    editor()._replace_loop_input(op, "activation", "moved_activation")
+    assert not hasattr(op, "_read_copy_elision_record")
+
+
+def test_retile_then_two_relayouts_compose_without_rewriting_bank():
+    op = operation()
+    op._read_copy_elision_record = _retile_elision_record(
+        record(), {"activation": info()}
+    )
+    rewrite = editor()
+    rewrite._replace_loop_input(op, "activation", "first_move")
+    rewrite._replace_loop_input(op, "first_move", "second_move")
+    assert read(op._read_copy_elision_record.direct_inner_fn) == (
+        ("second_move", 8 * ROW + COL),
+        ("bank", 64 * ROW + COL),
+    )

--- a/torch_spyre/_inductor/read_copy_elision.py
+++ b/torch_spyre/_inductor/read_copy_elision.py
@@ -33,10 +33,12 @@ from torch._inductor.virtualized import V
 
 from . import config
 from .constants import MATMUL_REDUCTION_OPS
+from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
 from .loop_info import CoarseTileInfo, ReadCopyElisionRecord, copy_op_metadata
 from .pass_utils import (
+    PerCoreView,
     _per_core_view_on_buf,
     device_coordinates,
     find_matmul_generated_var,
@@ -174,6 +176,54 @@ def _clone_direct_consumer(
     return direct_op
 
 
+def _views_match_through_read_coordinates(
+    staged_view: PerCoreView,
+    staged_size,
+    staged_coordinates,
+    direct_view: PerCoreView,
+    direct_size,
+    direct_coordinates,
+) -> bool:
+    """Compare different layouts only after proving their split-axis identity.
+
+    Both coordinate lists are reads traced in the SAME matmul iteration space.
+    For example H is axis 1 of [E,H,F/64,64], but axis 2 of
+    [1,F/64,H,64]. Raw device-axis numbers cannot be compared across buffers.
+    Require a unique equal coordinate AND extent, then retain the exact
+    per-core owner check on this common physical basis. No split count or
+    loop-position approximation is permitted.
+    """
+    if len(staged_size) != len(staged_coordinates) or len(direct_size) != len(
+        direct_coordinates
+    ):
+        return False
+    mapping: dict[int, int] = {}
+    for dim, _ in staged_view.work_slice_dims:
+        if not 0 <= dim < len(staged_size):
+            return False
+        matches = [
+            target
+            for target, coordinate in enumerate(direct_coordinates)
+            if sympy.simplify(staged_size[dim] - direct_size[target]) == 0
+            and sympy.simplify(staged_coordinates[dim] - coordinate) == 0
+        ]
+        if len(matches) != 1 or matches[0] in mapping.values():
+            return False
+        mapping[dim] = matches[0]
+    if set(dict(staged_view.core_to_slot)) != set(mapping):
+        return False
+    remapped = PerCoreView(
+        work_slice_dims=tuple(
+            sorted((mapping[dim], split) for dim, split in staged_view.work_slice_dims)
+        ),
+        core_to_slot=tuple(
+            sorted((mapping[dim], owner) for dim, owner in staged_view.core_to_slot)
+        ),
+        num_cores=staged_view.num_cores,
+    )
+    return per_core_views_equal(remapped, direct_view)
+
+
 def _prove_matmul_direct_read(
     consumer: ComputedBuffer,
     copy_op: ComputedBuffer,
@@ -306,7 +356,18 @@ def _prove_matmul_direct_read(
     # assigning different source slices to the same core.  The staging copy
     # is the behavior being replaced, so the direct HBM read must preserve
     # its exact physical core-to-slice map.
-    if not per_core_views_equal(copy_view, source_view):
+    try:
+        matching_owners = _views_match_through_read_coordinates(
+            copy_view,
+            copy_layout.device_layout.device_size,
+            device_coordinates(copy_layout.device_layout, copy_dep, None),
+            source_view,
+            source_layout.device_layout.device_size,
+            device_coordinates(source_layout.device_layout, weight_dep, None),
+        )
+    except Unsupported as exc:
+        return None, f"weight layout identity is not provable: {exc}"
+    if not matching_owners:
         return None, (
             "direct source ownership does not match the staged copy: "
             f"{source_view} != {copy_view}"

--- a/torch_spyre/_inductor/scratchpad/graph_editor.py
+++ b/torch_spyre/_inductor/scratchpad/graph_editor.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+
 from torch.fx.graph import Graph
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
@@ -39,6 +41,7 @@ from torch._inductor.ir import (
 from torch._inductor.lowering import clone as clone_lowering, lowerings
 
 from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.loop_info import ReadCopyElisionRecord
 from torch_spyre._inductor.split_multi_ops import _origin_in_graph
 
 
@@ -310,6 +313,24 @@ class GraphEditor:
             old_loop.data, name_map={old_name: new_name}
         )
         old_loop.data = new_loop
+        # A relayout of the other operand must also update the saved direct
+        # weight-read candidate. Keeping the old closure would read the
+        # pre-relayout operand; blindly copying the record is not sufficient.
+        record = getattr(old_loop, "_read_copy_elision_record", None)
+        if isinstance(record, ReadCopyElisionRecord):
+            if old_name in (record.source_name, record.copy_name):
+                del old_loop._read_copy_elision_record
+            else:
+
+                def direct_inner(*args, _original=record.direct_inner_fn):
+                    with V.set_ops_handler(
+                        self._NameSwapHandler(V.ops, {old_name: new_name})
+                    ):
+                        return _original(*args)
+
+                old_loop._read_copy_elision_record = dataclasses.replace(
+                    record, direct_inner_fn=direct_inner
+                )
         # The dependency set changed; force the next query to retrace the loop.
         invalidate_op_read_writes(old_loop)
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -6420,6 +6420,27 @@ def _replace_group_op(
             return
 
 
+def _retile_elision_record(
+    record: object, infos_by_name: dict[str, _RetiledBufferInfo]
+) -> ReadCopyElisionRecord | None:
+    """Apply the same non-weight retile to the saved direct-read candidate.
+
+    This is not a safety decision: post-allocation elision still proves every
+    address and owner. If the transformation changes either side of the saved
+    weight copy, decline instead of pretending its original contract survived.
+    """
+    if not isinstance(record, ReadCopyElisionRecord):
+        return None
+    if {record.source_name, record.copy_name}.intersection(infos_by_name):
+        return None
+
+    def direct_inner(*args, _original=record.direct_inner_fn, _infos=infos_by_name):
+        with V.set_ops_handler(_RetileLoadIndexHandler(V.ops, _infos)):
+            return _original(*args)
+
+    return dataclasses.replace(record, direct_inner_fn=direct_inner)
+
+
 def _patch_retiled_load_indexes(
     group_id: tuple[int, ...],
     group_ops: list[Operation],
@@ -6449,6 +6470,9 @@ def _patch_retiled_load_indexes(
             continue
 
         orig_inner = op.data.inner_fn
+        direct_record = _retile_elision_record(
+            getattr(op, "_read_copy_elision_record", None), infos_by_name
+        )
 
         def new_inner_fn(
             *args,
@@ -6466,6 +6490,8 @@ def _patch_retiled_load_indexes(
             pass_name="coarse_tile",
             reason="rewrite retiled load indexes",
         )
+        if direct_record is not None:
+            new_op._read_copy_elision_record = direct_record  # type: ignore[attr-defined]
         _replace_group_op(group_ops, op, new_op)
         V.graph.name_to_buffer[new_op.get_name()] = new_op
 


### PR DESCRIPTION
## Summary

**Fresh performance conclusion:** no demonstrated incremental Gemma speedup from the two remaining rewrite fixes on current main. The new paired comparison and its exact scope are recorded below; the older 24.4% expert-function result is historical, not the current gain.

**September 16 refresh:** merged main `17faf49ed65c1d8ee4d478492c9e7d888942a001`, including #4558's safe loop-read-copy changes. Current head: `65e701e08fb569669409a7944c6519360a720c8e`. Fresh CI is required; older SDK2452 failures are not results for this refreshed head.

Preserve a proven direct read of the original weight bank through later compiler rewrites. If a non-weight operand changes shape or name, update the saved direct-read candidate in the same way; if the weight source itself changes, discard the candidate.

**Seven files, +399/−3** against the frozen refresh base: production +118/−3, tests +271, registrations +10. This remains independently based on main; neither #4347 nor #4349 is included. The signed merge preserves the published branch history.

## Implemented approach

A tiled matmul may otherwise read weights, write an HBM temporary, then read it again. This PR lets the existing final proof recognize more safe original-bank reads:

1. Match staged and original-bank physical axes by traced read coordinates and extents before comparing ownership. Equal positions or split counts are insufficient.
2. Apply the ordinary coarse-tile read-index transformation to the saved direct-read candidate when a non-weight input is retiled.
3. Apply the graph editor's same operand renaming to the candidate.
4. Invalidate the candidate if either the bank or staged weight-copy contract changes.
5. Keep the existing final address, ownership, sole-reader, capacity and work-division proof as the only authority to remove the copy.

Candidate preservation is not permission to elide. Without preservation, the missing record makes the existing pass retain the copy—correct execution with a missed optimization.

No new flag: existing `read_copy_elision` remains default on. No routing or arithmetic change, model constant, new backend operation, allocator relaxation or independent ownership decision.

## Composition with main's #4558

Main now records address advances for explicit loops, checks storage encoding, and supports safe pointwise direct reads. Those changes stay intact. This refresh resolves the shared proof site as follows:

- Matmul weight reads retain this PR's exact coordinate-and-extent correspondence before comparing physical owners.
- Pointwise readers retain main's existing logical-ownership proof; no matmul weight-role assumption is applied to them.
- Rewrites of the other operand preserve the newly recorded direct-loop advances. A regression test covers retile followed by operand renaming without losing either advance field.
- Changes to the original source or staged copy still invalidate the candidate. No safety check or numerical tolerance is weakened.

## Dependencies and composition

- **Code:** main only. #4347 and the pending LX stack are no longer source prerequisites.
- **Historical performance:** the measured composition used LX ownership/transfers, completed-sum support and private activation-stage selection. That is a performance-composition dependency, not a Git dependency of this patch.
- **Stage-selection home:** [#4347](https://github.com/torch-spyre/torch-spyre/pull/4347). It remains a separate candidate-selection change; this refresh does not modify or embed it.
- **Adapter:** [hf-adapters#485](https://github.com/torch-spyre/hf-adapters/pull/485), now the single review unit replacing HF #486–490. Its historical improved prefill assignments used the LX/staging composition. Reproducing the recorded copy savings also requires the rewrite-preserved cases to be exercised; the adapter has since moved to explicit loops, so emitted-program evidence is needed again.
- The adapter's `read_copy_elision` flag probe cannot prove that these rewrite-preserved cases exist. Confirm copy removal from emitted code; do not add a dummy capability flag.
- [#4177](https://github.com/torch-spyre/torch-spyre/pull/4177) is separate: it removes expanded-input broadcast clones in 4-D BMM, not coarse-tile read copies.
- [#4349](https://github.com/torch-spyre/torch-spyre/pull/4349) serves decode indexed selections independently.

## Current performance — September 16 measurement

**Result:** the remaining rewrite-preservation fixes provide **no demonstrated incremental speedup on the current Gemma path**. Current main already removes all three expert-weight copies. The historical 24.4% expert-function result is not the current gain.

**Scope of this comparison:** main `6bd03782622c0d9a24c722366ee711125ad44c02` versus that same main with only the two fixes recommended by the current-main review: preserve the saved direct-read expression through non-weight retiling and operand renaming. Main's common ownership proof stays unchanged. This is a local narrowed treatment, **not the entire published `65e701e` diff**; the duplicate coordinate-proof replacement is not included. No compiler branch was pushed.

**Fresh performance:** HF #485 `06f2a70f705394c637e1b7f097c435a98ed516f7`, batch 1, 512 input tokens, greedy generation, 32 decode steps after the prefill-produced token. Same card, SDK2457/native binary, greedy layout solver, 32 cores and `DXP_LX_FRAC_AVAIL=0.2`. No pending #4347/#4349/LX changes were included.

| Generation boundary | Main | Main + rewrite fixes | Observed change |
| --- | ---: | ---: | ---: |
| First-token / prefill step | 1482.337 ms | 1485.436 ms | 0.209% slower |
| Decode, all 32 steps | 218.376 ms/token | 218.547 ms/token | 0.078% slower |

These are medians of five interleaved pairs using the adapter's built-in timing, not device-only times. First-token timing excludes request/cache allocation. Both versions compiled and warmed separately; profiling and tensor capture were off. Five additional control/control pairs established variation. Only 1/5 pairs improved in each phase; neither passes the positive-gain rule. Median paired savings were -3.882 ms prefill and -0.171 ms/token decode, versus maximum control/control differences of 2.165 ms and 0.155 ms/token. The small negative differences are reported as measured, not relabeled as a gain.

**Generated-program evidence:**

- Both arms created three saved expert-weight candidates, and the existing main proof accepted all three.
- Neither changed site encountered a candidate requiring retile or rename.
- All **16 distinct emitted programs match** after removing only debug provenance; layouts, allocations, work divisions, address expressions, loop counts and pool sizes remain in the comparison.
- Gate/up/down already read the full original HBM banks directly in the E128 loop and produce LX outputs. **The treatment removes zero additional copies.**
- There was no compilation in the 20 measured requests, and all returned the same 33 greedy tokens. That is a matching-output smoke check, not independent full token/logit numerical acceptance. Identical emitted programs do not attribute the small wall-time differences to a changed device program.

**What this means for dependencies:** do not count #4350 as a performance prerequisite for this measured Gemma configuration, or carry forward 24.4% as its current gain. The focused regressions still demonstrate the general saved-record gap, but a performance claim needs a reachable workload that uses these rewrites. The older result remains historical evidence for the older staging/relayout composition. #4349's indexed-layout benefit and #4347's stage-selection composition are separate and were not priced by this comparison.

**Version boundary:** this uses the published HF #485 head above; it does not include upstream HF #520's subsequent shared-helper extraction (`bff08bdf`). The description now records the fresh result and this limitation. This measurement does not change source, draft state or CI status.

## Recorded performance — historical, not this refreshed head

Batch 1 / 512 tokens; persistent E128/H2816/F704 expert function; structured mixed-sign inputs; same frozen compiler/runtime/card; greedy, 32 cores, `DXP_LX_FRAC_AVAIL=0.2` (backend reservation).

| Boundary | Immediate control | Rewrite-preserving treatment | Less time |
|---|---:|---:|---:|
| Warm expert-function wall time | 41.521 ms | 31.406 ms | 24.4% |
| Separately profiled device time | 40.587 ms | 30.464 ms | 24.9% |

Five interleaved pairs all improved. Median paired wall saving: 10.103 ms; largest control/control fluctuation: 0.1585 ms.

The control **already included coordinate-based copy proof, relayout and the private activation-stage choice**. The 24.4% is the incremental gain from preserving the remaining down-copy candidate through rewrites, not this entire patch versus main.

The historical emitted treatment read all three original banks directly with no HBM-pool intermediate. Removed temporary writes/rereads: **1,015,021,568 modeled bytes across E128**, not hardware-counter bytes. No new full-model gain is claimed; percentages from other optimizations are not additive.

## September 16 validation

- **459 tests and 35 subtests passed**: the 21 focused coordinate/rewrite checks, the coarse-tiling and work-division unit suites, and three graph-editor/planning host checks. This includes main's direct-read ownership/advance tests and the new recorded-advance preservation regression.
- Built a fresh native extension against the refreshed main's changed native inputs, SDK2457 and PyTorch 2.13 in isolated pod sources. Both PRs' native inputs matched byte-for-byte; binary SHA-256: `9adc0eafb1305c516b251316d3ae0376b9417984d3099efd58434e446b9095e0`.
- Repository-pinned Ruff 0.14.5 lint/format, mypy 2.1.0 (**203 source files**) and owned-delta whitespace checks pass. Both signed merge commits retain the existing branch history; no shared installation changed.

## Remaining gates

Fresh-head CI is pending; the PR's existing non-draft state is unchanged. Native-backed host checks do not establish device or full-model numerical acceptance.

The fresh comparison above prices only the recommended rewrite-only treatment on main `6bd0378`; it demonstrates no incremental benefit for the measured HF #485 path. It does **not** validate the full published coordinate-proof replacement or a future adapter rebase. The historical expert-region composition remains a separate result. Keep numerical limits unchanged, and require a reachable rewrite-affected consumer before restoring a current performance claim.
