### PR TITLE
fix(inductor): constrain topk input layout instead of sharing it with the output

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1302,6 +1302,16 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             },
         },
+        ("test_topk_fused_softmax", "test_topk_fused_softmax_router"): {
+            "param_sets": {
+                # Stick-aligned (64 fp16 per 128-byte stick) and unaligned.
+                "w64": (64,),
+                "w96": (96,),
+                "w128": (128,),
+                "w160": (160,),
+                "w192": (192,),
+            },
+        },
         ("test_topk", "test_topk_cpu"): {
             "param_sets": {
                 "2d_k1_dim0": (unique_randn_along_dim((64, 256), dim=0), 1, 0),
@@ -6473,6 +6483,17 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         assert out.shape == (T, E)
         torch.testing.assert_close(out_c.float(), ref.float(), atol=1e-2, rtol=1e-2)
+
+    def test_topk_fused_softmax_router(self, width: int):
+        # Fused softmax->topk: the producer's layout reaches topk through the
+        # restickify graph, so the reduction dim must be pushed off the stick
+        # instead of inherited. Stick-aligned and unaligned widths both covered.
+        x = unique_randn_along_dim((64, width), dim=-1)
+        self.compare_with_cpu(
+            lambda x: torch.topk(torch.softmax(x, dim=-1), 4, dim=-1)[0],
+            x,
+            run_eager=False,
+        )
 
     def test_topk_keep_by_index_moe_router(self):
         T, E, K = 64, 128, 8

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1649,34 +1649,27 @@ def _topk_layouts(
         if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is not None
     ]
 
-    # Collect candidate output stick dims. A valid input stick passes through;
-    # a stick on the reduction var requires a restickify, so every surviving
-    # coord becomes a candidate.
-    out_stick_dims: set[int | None] = set()
-    for stl in x.layouts:
-        x_stick_expr = device_coordinates(stl, x.dep, None)[-1]
-        if reduction_var in x_stick_expr.free_symbols:
-            for c in surviving_coords:
-                out_stick_dims.add(matching_dim(out_coords, c))
-        else:
-            out_stick_dims.add(matching_dim(out_coords, x_stick_expr))
+    # The reduction dim must not be the stick, so pin x to a layout that keeps
+    # it off the stick; a restickify is scheduled when the producer differs.
+    x_req_stl = _find_layout_avoiding_var_on_stick(x, reduction_var, "topk")
 
-    # Build one output STL per candidate stick dim.
-    # Note: the stick dim STL will never be added so will never be
-    #       selected as a candidate output STL
+    # Output sticks on whichever surviving coord x's required layout sticks on.
+    x_stick_expr = device_coordinates(x_req_stl, x.dep, None)[-1]
+    out_stick_dim = matching_dim(out_coords, x_stick_expr)
+    if out_stick_dim is None and surviving_coords:
+        out_stick_dim = matching_dim(out_coords, surviving_coords[0])
+
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
-    results: list[SpyreTensorLayout] = []
-    for out_stick_dim in out_stick_dims:
-        if out_stick_dim is None:
-            out_dim_order = list(range(len(output.size))) + [-1]
-        else:
-            out_dim_order = [d for d in range(len(output.size)) if d != out_stick_dim]
-            out_dim_order += [out_stick_dim]
-        results.append(SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order))
+    if out_stick_dim is None:
+        out_dim_order = list(range(len(output.size))) + [-1]
+    else:
+        out_dim_order = [d for d in range(len(output.size)) if d != out_stick_dim]
+        out_dim_order += [out_stick_dim]
+    out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
 
-    op.restick_cost_fn = AllSameNode.from_args(args, results, output_dep, op)
-    return results
+    op.restick_cost_fn = FixedInOutNode.from_args([x], out_stl, [x_req_stl], op)
+    return [out_stl]
 
 
 def _keep_by_index_layouts(


### PR DESCRIPTION
## Problem

`torch.topk` requires its input and output to stick on *different* dimensions — the reduction dim must not be innermost, which `_check_stick_topk` enforces.

`_topk_layouts` attached `AllSameNode`, which forces input and output to share a stick, and only widened the output candidates when the input *already* sticked on the reduction var. It never constrained the input.

The consequence depends on where topk's input comes from:

- **From a graph input** — the layout is chosen freely and happens to be legal, so isolated `topk` works. This is why the minimal repro in #3768 shows `topk`-only passing at every width.
- **From a producer such as `softmax`** — `AllSameNode` pins the producer's reduction-on-stick layout onto topk (`c0: (64, 32)`, 32 rows packed into the stick) and compilation fails in `OpSpecValidation`:

  ```
  OpSpecValidationError: topk stick must not contain the reduction or k dimension
  ```

The failure is width-independent; the pow2/stick-multiple pattern reported in #3768 no longer reproduces on `main` (fixed by #3782/#3874/#3890).

The bug fires only when topk's **values** feed downstream with no `keep_by_index` in the graph. With `keep_by_index` present, its own (already correct) input pinning propagates a legal layout back through the graph and topk works by consequence:

| graph | before | after |
|---|---|---|
| `softmax` → `topk` values | ABORTS | RUNS |
| `softmax` → `topk` indices → `keep_by_index` | RUNS | RUNS |
| both values and `keep_by_index` | RUNS | RUNS |

## Fix

Mirror `_keep_by_index_layouts`, which already handles this correctly: pin the required input layout with `_find_layout_avoiding_var_on_stick` and schedule the restickify through `FixedInOutNode` instead of `AllSameNode`.

The restickify is injected as expected (`buf1 → buf2, [64,128,1] -> [8192,1,128]`) and topk's tiling changes from `c0: (64, 32)` to `c0: (64, 1)`.

## Tests

New `test_topk_fused_softmax_router` covers fused `softmax`→`topk` at stick-aligned (64/128/192) and unaligned (96/160) widths. All 5 fail on `main` with `OpSpecValidationError` and pass with this change.

Numerics on the E=128 case: values maxdiff 7.14e-04, gathered maxdiff 0.0, no non-tie fp16 mismatches.

## Relationship to #4183

#4183 edits the same block and will conflict textually, but **both changes are needed — they fix different failures.**

- #4183 handles shapes where the reduction dim is the only non-trivial axis (`(1, N)` with `dim=1`): no surviving coord exists, so it adds a `None` fallback to the candidate set.
- This PR handles a reduction-on-stick layout arriving *from a producer*, which #4183 does not address — it keeps `AllSameNode`, so fused `softmax`→`topk` still fails.

With this PR alone, `(1, 128) dim=1` still fails, but with a clean `Unsupported: topk: no surviving coordinates after removing d1` rather than #4183's `AllSameNode.from_args: out_layouts is empty` assert. Whichever merges second, #4183's `None` fallback should fold into `_find_layout_avoiding_var_on_stick`. Happy to rebase on top of #4183 if it lands first.

Closes #3768. Verified orthogonal to #3875 (sliced mutation writes); the two compose cleanly.
