### PR TITLE
Fix incorrect M-row stride for 3D unit-batch matmul with shared weight

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3654,9 +3654,13 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         args = [input_arg, kernel_arg, output_arg]
         op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 0}}
 
-        iteration_space = _preserve_shared_weight_unit_bmm_dim(
+        iteration_space, rewritten_arg_ids = _preserve_shared_weight_unit_bmm_dim(
             "batchmatmul", iteration_space, args, op_info
         )
+        self.assertEqual(
+            rewritten_arg_ids, frozenset({id(input_arg), id(output_arg)})
+        )
+        self.assertNotIn(id(kernel_arg), rewritten_arg_ids)
         sdsc_spec, _ = parse_op_spec(
             OpSpec(
                 op="batchmatmul",
@@ -3676,11 +3680,11 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         output_layout = sdsc_spec.layouts[sdsc_spec.args[-1].layout]
         self.assertEqual(
             [str(dim) for dim in input_layout["dim_order"]],
-            ["mb", "in", "x"],
+            ["in", "mb", "x"],
         )
         self.assertEqual(
             [str(dim) for dim in output_layout["dim_order"]],
-            ["mb", "out", "x"],
+            ["out", "mb", "x"],
         )
 
     def test_unit_bmm_preserve_skips_higher_rank_attention_layout(self):
@@ -3725,7 +3729,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         }
         op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 0}}
 
-        new_iteration_space = _preserve_shared_weight_unit_bmm_dim(
+        new_iteration_space, rewritten_arg_ids = _preserve_shared_weight_unit_bmm_dim(
             "batchmatmul",
             iteration_space,
             [input_arg, kernel_arg, output_arg],
@@ -3733,6 +3737,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         )
 
         self.assertIs(new_iteration_space, iteration_space)
+        self.assertEqual(rewritten_arg_ids, frozenset())
         self.assertNotIn("_spyre_bmm_unit", {str(dim) for dim in iteration_space})
         self.assertEqual(input_arg.device_size, [512, 32, 2, 1, 64])
         self.assertEqual(
@@ -3777,6 +3782,200 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
             SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
             bmm.meta.get("custom") or {},
         )
+
+    # -- Contract tests for _preserve_shared_weight_unit_bmm_dim's
+    # (it_space, rewritten_arg_ids) return value. Issue #4155.
+
+    def _make_valid_batchmatmul_case(self):
+        """Baseline Normal-branch case (#4155 shape M=256,K=1024,N=1024).
+        Guard-clause tests below start from a copy and break one precondition.
+        """
+        c0 = Symbol("c0")
+        c1 = Symbol("c1")
+        c2 = Symbol("c2")
+        input_arg = TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=[256, 16, 1, 64],
+            device_coordinates=[c0, floor(c2 / 64), Integer(0), Mod(c2, 64)],
+            allocation={"hbm": 0},
+        )
+        kernel_arg = TensorArg(
+            is_input=True,
+            arg_index=1,
+            device_dtype=_FP16,
+            device_size=[16, 1024, 64],
+            device_coordinates=[floor(c1 / 64), c2, Mod(c1, 64)],
+            allocation={"hbm": 0x400000000},
+        )
+        output_arg = TensorArg(
+            is_input=False,
+            arg_index=2,
+            device_dtype=_FP16,
+            device_size=[256, 16, 1, 64],
+            device_coordinates=[c0, floor(c1 / 64), Integer(0), Mod(c1, 64)],
+            allocation={"hbm": 0x800000000},
+        )
+        iteration_space = {
+            c0: (Integer(256), 4),
+            c1: (Integer(1024), 8),
+            c2: (Integer(1024), 1),
+        }
+        args = [input_arg, kernel_arg, output_arg]
+        op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 0}}
+        return args, iteration_space, op_info
+
+    @staticmethod
+    def _snapshot_args(args):
+        return [(list(a.device_size), list(a.device_coordinates)) for a in args]
+
+    def _assert_args_unchanged(self, args, snapshot):
+        for arg, (size_before, coords_before) in zip(args, snapshot):
+            self.assertEqual(arg.device_size, size_before)
+            self.assertEqual(arg.device_coordinates, coords_before)
+
+    def test_preserve_noop_when_op_is_not_batchmatmul(self):
+        args, it_space, op_info = self._make_valid_batchmatmul_case()
+        snapshot = self._snapshot_args(args)
+
+        new_it_space, rewritten = _preserve_shared_weight_unit_bmm_dim(
+            "add", it_space, args, op_info
+        )
+
+        self.assertEqual(rewritten, frozenset())
+        self.assertIs(new_it_space, it_space)
+        self._assert_args_unchanged(args, snapshot)
+
+    def test_preserve_noop_when_op_info_missing_marker(self):
+        args, it_space, _ = self._make_valid_batchmatmul_case()
+        snapshot = self._snapshot_args(args)
+
+        new_it_space, rewritten = _preserve_shared_weight_unit_bmm_dim(
+            "batchmatmul", it_space, args, {}
+        )
+
+        self.assertEqual(rewritten, frozenset())
+        self.assertIs(new_it_space, it_space)
+        self._assert_args_unchanged(args, snapshot)
+
+    def test_preserve_noop_when_iteration_space_wrong_length(self):
+        for bad_len in (2, 4):
+            with self.subTest(bad_len=bad_len):
+                args, it_space, op_info = self._make_valid_batchmatmul_case()
+                bad_it_space = dict(it_space)
+                if bad_len == 2:
+                    bad_it_space.pop(next(iter(bad_it_space)))
+                else:
+                    bad_it_space[Symbol("c3")] = (Integer(64), 1)
+                snapshot = self._snapshot_args(args)
+
+                new_it_space, rewritten = _preserve_shared_weight_unit_bmm_dim(
+                    "batchmatmul", bad_it_space, args, op_info
+                )
+
+                self.assertEqual(rewritten, frozenset())
+                self.assertIs(new_it_space, bad_it_space)
+                self._assert_args_unchanged(args, snapshot)
+
+    def test_preserve_noop_when_target_arg_rank_exceeds_four(self):
+        args, it_space, op_info = self._make_valid_batchmatmul_case()
+        input_arg = args[0]
+        # 5th physical axis, as SDPA attention heads would add.
+        input_arg.device_size.insert(0, 2)
+        input_arg.device_coordinates.insert(0, Symbol("z0"))
+        snapshot = self._snapshot_args(args)
+
+        new_it_space, rewritten = _preserve_shared_weight_unit_bmm_dim(
+            "batchmatmul", it_space, args, op_info
+        )
+
+        self.assertEqual(rewritten, frozenset())
+        self.assertIs(new_it_space, it_space)
+        self._assert_args_unchanged(args, snapshot)
+
+    def test_preserve_noop_when_batch_dim_is_not_zero(self):
+        args, it_space, _ = self._make_valid_batchmatmul_case()
+        op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 1}}
+        snapshot = self._snapshot_args(args)
+
+        new_it_space, rewritten = _preserve_shared_weight_unit_bmm_dim(
+            "batchmatmul", it_space, args, op_info
+        )
+
+        self.assertEqual(rewritten, frozenset())
+        self.assertIs(new_it_space, it_space)
+        self._assert_args_unchanged(args, snapshot)
+
+    def test_preserve_normal_branch_reports_exactly_input_and_output_args(self):
+        args, it_space, op_info = self._make_valid_batchmatmul_case()
+        input_arg, kernel_arg, output_arg = args
+
+        new_it_space, rewritten_arg_ids = _preserve_shared_weight_unit_bmm_dim(
+            "batchmatmul", it_space, args, op_info
+        )
+
+        self.assertEqual(
+            rewritten_arg_ids, frozenset({id(input_arg), id(output_arg)})
+        )
+        self.assertNotIn(id(kernel_arg), rewritten_arg_ids)
+        self.assertIn("_spyre_bmm_unit", {str(s) for s in new_it_space})
+        # Change A: reversed() bug would produce [1, 16, 256, 64] here.
+        self.assertEqual(input_arg.device_size, [1, 256, 16, 64])
+        self.assertEqual(output_arg.device_size, [1, 256, 16, 64])
+        self.assertEqual(kernel_arg.device_size, [16, 1024, 64])
+
+    def test_insert_branch_checks_both_targets_before_mutating_either(self):
+        """Pre-fix bug: the insert-branch loop could mutate args[0] before
+        discovering args[-1] fails its size guard, leaving args[0] mutated
+        with no signal. Constructs that exact scenario.
+        """
+        c0 = Symbol("c0")
+        c1 = Symbol("c1")
+        c2 = Symbol("c2")
+        # args[0]: no unit dim, len(device_size)==2 passes the guard alone.
+        input_arg = TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=[64, 64],
+            device_coordinates=[c0, Mod(c0, 64)],
+            allocation={"hbm": 0},
+        )
+        kernel_arg = TensorArg(
+            is_input=True,
+            arg_index=1,
+            device_dtype=_FP16,
+            device_size=[64, 64],
+            device_coordinates=[c1, Mod(c1, 64)],
+            allocation={"hbm": 0x400000000},
+        )
+        # args[-1]: len(device_size)==1 fails the guard.
+        output_arg = TensorArg(
+            is_input=False,
+            arg_index=2,
+            device_dtype=_FP16,
+            device_size=[64],
+            device_coordinates=[Mod(c2, 64)],
+            allocation={"hbm": 0x800000000},
+        )
+        args = [input_arg, kernel_arg, output_arg]
+        snapshot = self._snapshot_args(args)
+        iteration_space = {
+            c0: (Integer(64), 1),
+            c1: (Integer(64), 1),
+            c2: (Integer(64), 1),
+        }
+        op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 0}}
+
+        new_it_space, rewritten_arg_ids = _preserve_shared_weight_unit_bmm_dim(
+            "batchmatmul", iteration_space, args, op_info
+        )
+
+        self.assertEqual(rewritten_arg_ids, frozenset())
+        self.assertIs(new_it_space, iteration_space)
+        # Pre-fix, input_arg would have device_size == [64, 1, 64] here.
+        self._assert_args_unchanged(args, snapshot)
 
 
 # ===========================================================================

--- a/tests/inductor/test_inductor_matmul.py
+++ b/tests/inductor/test_inductor_matmul.py
@@ -65,31 +65,137 @@ class TestMatmulOps:
     # ── Scenario 3 — Identity matrix correctness [NEW] ───────────────────────
     # Upstream has this for CPU/CUDA but not via compare_with_cpu on a custom
     # backend. Tests Spyre tile engine with non-uniform stride inputs.
+    # bmm_unit_batch_* cases: issue #4155 regression (unit-batch, stick-
+    # aligned direct bmm -- sets SHARED_WEIGHT_UNIT_BMM_INFO_KEY).
     @pytest.mark.parametrize(
-        "fn,left,batched",
+        "fn,left,batch,size",
         [
-            (torch.mm, False, False),
-            (torch.mm, True, False),
-            (torch.bmm, False, True),
+            (torch.mm, False, 0, 8),
+            (torch.mm, True, 0, 8),
+            (torch.bmm, False, 4, 8),
+            (torch.bmm, False, 1, 1024),
+            (torch.bmm, False, 1, 2048),
         ],
-        ids=["mm_right", "mm_left", "bmm_batched"],
+        ids=[
+            "mm_right",
+            "mm_left",
+            "bmm_batched",
+            "bmm_unit_batch_1024",
+            "bmm_unit_batch_2048",
+        ],
     )
-    def test_identity(self, execution_mode, fn, left, batched):
+    def test_identity(self, execution_mode, fn, left, batch, size):
         torch.manual_seed(0)
         a = (
-            torch.randn(4, 8, 8, dtype=torch.float16)
-            if batched
-            else torch.randn(8, 8, dtype=torch.float16)
+            torch.randn(batch, size, size, dtype=torch.float16)
+            if batch
+            else torch.randn(size, size, dtype=torch.float16)
         )
         eye = (
-            torch.eye(8, dtype=torch.float16)
+            torch.eye(size, dtype=torch.float16)
             .unsqueeze(0)
-            .expand(4, -1, -1)
+            .expand(batch, -1, -1)
             .contiguous()
-            if batched
-            else torch.eye(8, dtype=torch.float16)
+            if batch
+            else torch.eye(size, dtype=torch.float16)
         )
         atol, rtol = _tol(torch.float16)
         _compare_modes(
             execution_mode, fn, *(eye, a) if left else (a, eye), atol=atol, rtol=rtol
         )
+
+    # ── Shared-weight unit-BMM regression [issue #4155] ──────────────────────
+    # reversed()->nonstick bug swapped M/K device axes for unit-batch matmul
+    # with a shared weight. Covers both trigger sites (view->mm->view via
+    # torch.matmul, direct aten.bmm via torch.bmm); the one-hot marker row
+    # makes a reintroduced swap fail under compare_with_cpu.
+    @pytest.mark.parametrize("site", ["view_mm_view", "direct_bmm"])
+    @pytest.mark.parametrize(
+        "M,K,N",
+        [
+            (256, 1024, 1024),
+            (512, 4096, 12800),
+        ],
+        ids=["issue_4155", "sendnn_like"],
+    )
+    def test_shared_weight_unit_bmm_marker_row(
+        self, execution_mode, M, K, N, site
+    ):
+        fn = torch.matmul if site == "view_mm_view" else torch.bmm
+        torch.manual_seed(hash((M, K, N, site)) & 0xFFFFFFFF)
+        row, col = M // 4, K // 2
+        x = torch.zeros(1, M, K, dtype=torch.float16)
+        x[0, row, col] = 1.0
+        w = (
+            torch.randn(1, K, N, dtype=torch.float16)
+            if site == "direct_bmm"
+            else torch.randn(K, N, dtype=torch.float16)
+        )
+        atol, rtol = _tol(torch.float16)
+        _compare_modes(execution_mode, fn, x, w, atol=atol, rtol=rtol)
+
+
+# ── Sanity-check safety net [issue #4155, Change B] ─────────────────────────
+# create_op_spec's post-_preserve sync only touches args reported as
+# rewritten; every other arg still hits the original strict check. These
+# corrupt a non-bmm op's coordinates without reporting it, proving the
+# check still fires outside the carve-out. "add"/"sum" hit create_op_spec's
+# two distinct call sites (pointwise vs. reduction).
+
+
+def _install_coordinate_corruption(monkeypatch, target_op):
+    """Corrupt args[0].device_coordinates for target_op without reporting
+    it as rewritten, simulating a bug elsewhere in the pipeline.
+    """
+    import torch_spyre._inductor.spyre_kernel as _sk
+
+    orig = _sk._preserve_shared_weight_unit_bmm_dim
+    state = {"corrupted": False}
+
+    def _corrupting(op, it_space, args, op_info):
+        it_space_out, rewritten = orig(op, it_space, args, op_info)
+        if not state["corrupted"] and op == target_op and args and not rewritten:
+            arg0 = args[0]
+            if arg0.device_coordinates:
+                arg0.device_coordinates[0] = arg0.device_coordinates[0] + 999999
+                state["corrupted"] = True
+        return it_space_out, rewritten
+
+    monkeypatch.setattr(_sk, "_preserve_shared_weight_unit_bmm_dim", _corrupting)
+    return state
+
+
+def _matmul_then_add(x, w):
+    return torch.matmul(x, w) + 1.0
+
+
+def _matmul_then_sum(x, w):
+    return torch.matmul(x, w).sum(dim=-1)
+
+
+@pytest.mark.parametrize(
+    "target_op,fn",
+    [
+        ("add", _matmul_then_add),
+        ("sum", _matmul_then_sum),
+    ],
+    ids=["add", "sum_reduction"],
+)
+def test_shared_weight_unit_bmm_sanity_check_fires_outside_carveout(
+    monkeypatch, target_op, fn
+):
+    state = _install_coordinate_corruption(monkeypatch, target_op)
+    torch.manual_seed(0)
+    x = torch.randn(1, 64, 128, dtype=torch.float16).to("spyre")
+    w = torch.randn(128, 128, dtype=torch.float16).to("spyre")
+
+    torch._dynamo.reset()
+    with pytest.raises(
+        RuntimeError, match="alignment input collection disagrees with tensor codegen"
+    ):
+        torch.compile(fn, dynamic=False)(x, w)
+
+    assert state["corrupted"], (
+        f"corruption hook never fired for op={target_op!r} -- this run "
+        "does not prove the safety net still works for it"
+    )

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -110,18 +110,21 @@ def _preserve_shared_weight_unit_bmm_dim(
     it_space: dict[sympy.Symbol, tuple[sympy.Expr, int]],
     args: Sequence[TensorArg],
     op_info: dict[str, Any],
-) -> dict[sympy.Symbol, tuple[sympy.Expr, int]]:
-    # TensorArg layout is normalized in-place below to match the surrounding
-    # OpSpec construction helpers.
+) -> tuple[dict[sympy.Symbol, tuple[sympy.Expr, int]], frozenset[int]]:
+    # OpSpec construction helpers. Returns (it_space, rewritten_arg_ids), where
+    # rewritten_arg_ids holds id(arg) for every TensorArg mutated in place, so
+    # callers can tell exactly which args' Python-side layout no longer
+    # matches whatever separate layout representation they built earlier.
+    no_rewrite: frozenset[int] = frozenset()
     if SHARED_WEIGHT_UNIT_BMM_INFO_KEY not in op_info:
-        return it_space
+        return it_space, no_rewrite
     if op not in [BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP]:
-        return it_space
+        return it_space, no_rewrite
     if len(it_space) != 3 or len(args) < 3:
-        return it_space
+        return it_space, no_rewrite
     info = op_info.get(SHARED_WEIGHT_UNIT_BMM_INFO_KEY)
     if not isinstance(info, dict) or info.get("batch_dim") != 0:
-        return it_space
+        return it_space, no_rewrite
 
     unit_sym = sympy.Symbol("_spyre_bmm_unit")
     suffix = 0
@@ -144,20 +147,22 @@ def _preserve_shared_weight_unit_bmm_dim(
     # as attention heads from SDPA, rewriting one axis into the BMM iteration
     # space can produce an illegal SDSC layout.
     if any(len(arg.device_size) > 4 for arg in target_args):
-        return it_space
+        return it_space, no_rewrite
     unit_idxs_by_arg = [_unit_indices(arg) for arg in target_args]
 
     if all(len(unit_idxs) == 0 for unit_idxs in unit_idxs_by_arg):
+        # Check both target_args before mutating either, so this bail-out
+        # can never leave one arg mutated without being reported below.
+        if any(len(arg.device_size) < 2 for arg in target_args):
+            return it_space, no_rewrite
         for arg in target_args:
-            if len(arg.device_size) < 2:
-                return it_space
             insert_at = len(arg.device_size) - 1
             arg.device_size.insert(insert_at, 1)
             arg.device_coordinates.insert(insert_at, sympy.S.Zero)
         unit_idxs_by_arg = [_unit_indices(arg) for arg in target_args]
 
     if not all(len(unit_idxs) == 1 for unit_idxs in unit_idxs_by_arg):
-        return it_space
+        return it_space, no_rewrite
 
     rewrite_targets = [
         (arg, unit_idxs[0]) for arg, unit_idxs in zip(target_args, unit_idxs_by_arg)
@@ -166,13 +171,14 @@ def _preserve_shared_weight_unit_bmm_dim(
     for arg, unit_idx in rewrite_targets:
         arg.device_coordinates[unit_idx] = unit_sym
         nonstick = list(range(len(arg.device_size) - 1))
-        order = [unit_idx] + [i for i in reversed(nonstick) if i != unit_idx]
+        order = [unit_idx] + [i for i in nonstick if i != unit_idx]
         order.append(len(arg.device_size) - 1)
         arg.device_size[:] = [arg.device_size[i] for i in order]
         arg.device_coordinates[:] = [arg.device_coordinates[i] for i in order]
 
     logger.info("Preserving shared-weight unit BMM dim %s", unit_sym)
-    return {unit_sym: (sympy.S.One, 1), **it_space}
+    rewritten_ids = frozenset(id(arg) for arg in target_args)
+    return {unit_sym: (sympy.S.One, 1), **it_space}, rewritten_ids
 
 
 @dataclass
@@ -901,8 +907,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space_extended = iteration_space_with_splits(
             ir_node, self.current_node.read_writes, it_space
         )
-        it_space_extended = _preserve_shared_weight_unit_bmm_dim(
-            op, it_space_extended, args, op_info
+        it_space_extended, unit_bmm_rewritten_arg_ids = (
+            _preserve_shared_weight_unit_bmm_dim(op, it_space_extended, args, op_info)
         )
         alignment_inputs = build_operation_alignment_inputs(
             it_space,
@@ -911,6 +917,22 @@ class SpyreKernel(Kernel[CSEVariable]):
             repeat_info=self._alignment_repeat_info,
             aligned_iteration_space=it_space_extended,
         )
+        # _preserve_shared_weight_unit_bmm_dim rewrites the Python-side
+        # device_size/device_coordinates of the matched TensorArgs in-place to
+        # hoist the synthetic _spyre_bmm_unit dim to the front, but the C++
+        # SpyreTensorLayout used by build_operation_alignment_inputs is a
+        # separate object that has no way to represent that synthetic symbol,
+        # so it is expected to disagree with the Python-side layout for
+        # exactly those args. Propagate the reordered layout back into
+        # alignment_inputs only for the args _preserve reported as rewritten,
+        # so align_tensors_pure (called from simplify_op_spec) starts from the
+        # correct physical ordering there. Every other arg and every op
+        # that never triggers this rewrite is left untouched, so the
+        # sanity check below stays a real check for them.
+        for arg, tensor in zip(args, alignment_inputs.tensors):
+            if id(arg) in unit_bmm_rewritten_arg_ids:
+                tensor["coordinates"] = list(arg.device_coordinates)
+                tensor["size"] = list(arg.device_size)
         for arg, tensor in zip(args, alignment_inputs.tensors):
             if list(arg.device_coordinates) != tensor["coordinates"]:
                 raise RuntimeError(


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Fixes a silent-wrong-values bug (crashes on current main) in torch.compile for torch.matmul/torch.bmm when the input is 3-D with batch size 1 and the weight is 2D (shared/static) (e.g. x=[1,256,1024] @ w=[1024,1024]).
_preserve_shared_weight_unit_bmm_dim built the reordered device_size/device_coordinates using reversed(nonstick), which swapped the M and K/64 device axes for unit-batch shared-weight BMM ops. Since _calculate_device_stride computes strides purely from position in this list, the swap produced a wrong M-row stride (one stick-width instead of a full row), causing hardware to re-read row 0 for every logical row. This produced physically wrong strides and incorrect matmul results for torch.matmul(x=[1,M,K], w=[K,N]) (and the direct torch.bmm path).

**Two changes:**
**Change A** (the actual fix): reversed(nonstick) → nonstick, so the unit dim moves to the front while M and K/64 keep their original relative order.

**Change B**: _preserve_shared_weight_unit_bmm_dim now returns (it_space, rewritten_arg_ids). create_op_spec's post-_preserve sanity check (added on main after this bug was originally reported, which is why it now crashes instead of silently corrupting) previously had to be synced unconditionally for all args to avoid a false-positive crash which made the check tautological for every op. It now syncs only the args _preserve actually reports as rewritten, so the check stays fully strict for every other argument and every op that doesn't trigger this rewrite. Also fixes a latent bug in the same function where the "insert unit dim" branch could mutate the first target arg and then bail on the second without reporting either mutation.

#### Which issue(s) this PR is related to:

<!--
Fixes #4155 
[<issue link>](https://github.com/torch-spyre/torch-spyre/issues/4155) 
-->

#### Special notes for your reviewer:

- Verified on real hardware across 4 shapes (including the original report shape and a sendnn-scale shape) via a marker-row test and an identity-weight control, plus the original reporter's repro (rel_err=0.0, cosine=1.0, was 1.41/0.002).
- Confirmed via guard-clause tracing (not just testing) that Change B cannot affect any op besides batchmatmul/batchmatmulfp8: SHARED_WEIGHT_UNIT_BMM_INFO_KEY can only ever be set for those two op targets, and _preserve independently guards on op type before any mutation is possible. Added tests that deliberately corrupt a non-BMM op's coordinates to confirm the sanity check still fires outside this carve-out.
- Investigated whether the batch/M/K physical layout here matches other matmul variants (2-D mm, regular B>1 bmm): it doesn't; each path uses an independently-chosen physical ordering. Not a correctness issue (each path only needs internal self-consistency, which this fix restores), but flagging as a possible follow-up if cross-path layout consistency matters going forward.
- Full regression suite re-run with this fix: test_coarse_tiling.py 363 passed/1 skipped (baseline exactly), test_inductor_matmul.py 35 passed, no new failures elsewhere.
- test_marked_squeezed_unit_bmm_recovers_sendnn_like_unit_layout previously asserted dim_order == ["mb","in","x"] / ["mb","out","x"] : this was documenting the buggy layout (K-tile stride computed as if it were the M-row stride). Updated to assert the physically correct ["in","mb","x"] / ["out","mb","x"], matching the working 2-D path's ["in","mb"] ordering.

#### Does this PR introduce a user-facing change?
Yes: torch.matmul/torch.bmm with a 3-D unit-batch input and a shared 2-D/static weight now produces numerically correct results instead of silently wrong output (or a crash, on current main).

#### Additional note:
None.