### PR TITLE
Demote non-critical inductor warnings to info/debug level

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5714,8 +5714,8 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
         torch.testing.assert_close(carried_result, ordinary_result, atol=1.0, rtol=0.05)
         torch.testing.assert_close(carried_result, cpu_result, atol=1.0, rtol=0.05)
 
-    def test_carried_sum_hbm_fallback_is_correct_and_visible(self):
-        """Capacity spill keeps correct execution and emits a warning."""
+    def test_carried_sum_hbm_fallback_is_correct(self):
+        """Capacity spill keeps correct execution."""
 
         E, T, H = 2, 64, 64
         values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
@@ -5743,7 +5743,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
                     "dxp_lx_frac_avail": 1.0,
                 }
             ),
-            self.assertLogs("spyre.inductor.scheduler", level="WARNING") as logs,
         ):
             compare_with_cpu(
                 fn,
@@ -5754,7 +5753,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
                 atol=0.05,
                 rtol=0.05,
             )
-        self.assertTrue(any("remained in HBM" in line for line in logs.output))
 
     def test_carried_sum_requires_explicit_work_div(self):
         """Without row ownership, the existing reduction path is unchanged."""

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -947,21 +947,6 @@ def test_lx_relayout_keeps_source_lifetime_for_later_original_reader():
     _assert_live_buffers_do_not_share_addresses(graph, buffers, 384)
 
 
-@config.patch({"lx_planner_relayout": True})
-def test_lx_relayout_warns_for_unsupported_solver(caplog):
-    class UnsupportedSolver:
-        pass
-
-    allocator = ScratchpadAllocator(UnsupportedSolver, 256)
-    allocator._generate_buffers = lambda _graph: []
-    with caplog.at_level(logging.WARNING, logger="spyre.inductor.scratchpad.allocator"):
-        assert allocator._prepare_buffers(SimpleNamespace()) == []
-    assert any(
-        "LX relayout is not supported by UnsupportedSolver" in record.message
-        for record in caplog.records
-    )
-
-
 class _RelayoutNode:
     def __init__(self, name, reads=(), writes=(), layout=None):
         self.name = name

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -587,7 +587,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         peak = allocator.get_peak_usage()
         pool_extent = allocator.get_pool_end()
         if overflowed:
-            logger.warning(
+            logger.info(
                 "hbm_pool_planning: bundle=%s  %d intermediate(s) did not fit in "
                 "the %.2f GB pool budget and fell back to standalone HBM",
                 bundle_name,

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -645,7 +645,7 @@ def verify_carried_reduction_ownership(
                 f"non-device layout {type(layout).__name__}"
             )
         if "lx" not in layout.allocation:
-            logger.warning(
+            logger.info(
                 "carried reduction %s remained in HBM; execution is correct but "
                 "the persistent-LX performance contract was not realized",
                 record.accumulator_name,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -304,7 +304,7 @@ class ScratchpadAllocator:
                     "__name__",
                     type(self.layout_planning).__name__,
                 )
-                logger.warning(
+                logger.debug(
                     "LX relayout is not supported by %s; continuing without relayout",
                     solver_name,
                 )
@@ -2444,7 +2444,7 @@ def select_allocator() -> ScratchpadAllocator:
 
     if config.co_optimizing_lx_planning:
         if config.lx_planner_relayout:
-            logger.warning(
+            logger.debug(
                 "LX relayout is not supported by CoOptimizingAllocator; "
                 "continuing without relayout"
             )

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -659,7 +659,7 @@ def must_split_vars(
             best = best_within or best_above
 
             if best is None:
-                logger.warning(
+                logger.info(
                     f"No valid split combo found for tensor {td.dep.name} "
                     f"coord={coord} under accumulated_splits={accumulated_splits}. "
                     f"Skipping."

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -111,9 +111,7 @@ def _lone_sym(coord: sympy.Expr) -> sympy.Symbol | None:
 def _untracked_name(context: str, sym, size: int) -> str:
     name = f"_untracked_{size}"
     _named_dims.setdefault(name, size)
-    logger.warning(
-        f"{context}: loop var {sym} has no named dim mapping -- using {name}"
-    )
+    logger.debug(f"{context}: loop var {sym} has no named dim mapping -- using {name}")
     return name
 
 
@@ -137,7 +135,7 @@ def _consume_names(remaining: list[str], layout_size: int) -> list[str]:
         product *= _named_dims[name]
         if product == layout_size:
             return remaining[: i + 1]
-    logger.warning(
+    logger.debug(
         f"_consume_names: no prefix of {remaining} multiplies to {layout_size}"
     )
     return []


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Audit logger.warning calls and downgrade non-critial messages to either info or debug level.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
