### PR TITLE
fix(inductor): preserve offsets in coarse read copies

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -2789,6 +2789,46 @@ def test_view_unsqueeze_broadcast_A4_B4():
 # Parameterized helpers — tests specify sizes and tile counts directly.
 
 
+def test_sdpa_packed_qkv_input_offsets_h8():
+    """Read copies preserve offsets of QKV views repaired after pre-stickify.
+
+    Eight heads trigger SDPA's H coarse tiling.  K and V are non-contiguous
+    views into one packed allocation, with nonzero storage offsets.  Before
+    issue #4331's fix the generated per-tile read copies silently read Q's
+    slice for both tensors.
+    """
+    torch.manual_seed(0x4331)
+    B, H, L, D = 1, 8, 64, 64
+    packed = torch.randn(B, L, 3 * H * D, dtype=torch.float16)
+
+    def split_qkv(x):
+        return tuple(
+            part.reshape(B, L, H, D).transpose(1, 2) for part in x.chunk(3, dim=-1)
+        )
+
+    q_cpu, k_cpu, v_cpu = split_qkv(packed)
+    mask = torch.zeros(L, L, dtype=torch.float16).masked_fill(
+        ~torch.ones(L, L, dtype=torch.bool).tril(),
+        torch.finfo(torch.float16).min,
+    )[None, None]
+    expected = F.scaled_dot_product_attention(
+        q_cpu, k_cpu, v_cpu, attn_mask=mask, scale=D**-0.5
+    )
+
+    q, k, v = split_qkv(packed.to("spyre"))
+    assert (q.storage_offset(), k.storage_offset(), v.storage_offset()) == (
+        0,
+        H * D,
+        2 * H * D,
+    )
+    with fresh_cache():
+        actual = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=mask.to("spyre"), scale=D**-0.5
+        )
+
+    torch.testing.assert_close(actual.cpu(), expected, atol=0.01, rtol=0.1)
+
+
 def _flash_v1_inputs(B, H, Lq, Lk, D):
     """TensorSpec list for flash v1 (no mask)."""
     return [

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5830,6 +5830,48 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
         self.assertTrue(hasattr(copy_buf, "loop_info"))
         self.assertEqual(full_deps[0].name, entry.dep.name)
 
+    def test_read_copy_observes_late_source_layout_offset(self):
+        """A generated copy must not freeze the source's initial offset.
+
+        Eager graph-input view offsets are attached during layout propagation,
+        after pre-stickify coarse tiling inserts read copies.  Model that pass
+        ordering by changing the source layout offset after copy insertion and
+        verify the synthesized body reads from the repaired position.
+        """
+        from torch._inductor.ir import ComputedBuffer
+
+        from torch_spyre._inductor.pass_utils import invalidate_op_read_writes
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        tiled_op, _full_deps, operations = _make_full_buffer_read_fixture()
+        source_buf = operations[0]
+        source_buf.layout.offset = Integer(64)
+        invalidate_op_read_writes(tiled_op)
+        plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
+        entry = plans[(0,)].entries[0]
+
+        _insert_all_read_copy_ops(operations, plans)
+        copy_buf = next(
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer) and op.get_name() == entry.copy_name
+        )
+        source_buf.layout.offset = Integer(512)
+
+        class _Recorder(list):
+            def load(self, name, index):
+                self.append((name, index))
+                return 0.0
+
+        reads = _Recorder()
+        with V.set_ops_handler(reads):
+            copy_buf.data.inner_fn([Integer(2), Integer(3)])
+
+        self.assertEqual(reads, [(source_buf.get_name(), Integer(771))])
+
     def test_invariant_broadcast_copy_drops_absent_loop_dim(self):
         """A fixed [H] input read by an [E,H] loop is staged as [H], not
         materialized as the expanded [E,H] view."""

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3870,6 +3870,13 @@ def _insert_one_read_copy(
     if isinstance(full_buf, StorageBox):
         full_buf = full_buf.data
 
+    # Keep track of the offset already represented by dep.index.  Graph-input
+    # storage offsets are repaired later by propagate_spyre_tensor_layouts(),
+    # after this pre-stickify pass has created the copy.  Unlike an ordinary
+    # lowered op, the generated copy below starts from dep.index directly, so
+    # it must observe any layout-offset change that happens after this point.
+    initial_source_offset = full_buf.layout.offset
+
     # Derive copy buffer strides using compute_tile_stride.
     # dep.size is the full loop iteration space (output + reduction dims) and
     # may have higher rank than the tensor (e.g. for a Reduction reading
@@ -3954,6 +3961,8 @@ def _insert_one_read_copy(
         idx,
         _dep=dep,
         _full_name=full_buf.get_name(),
+        _full_buf=full_buf,
+        _initial_source_offset=initial_source_offset,
         _active_idx=active_idx,
         _compact=compact_invariant,
     ):
@@ -3965,6 +3974,7 @@ def _insert_one_read_copy(
             full_idx = idx
         subs = dict(zip(_dep.var_names, full_idx))
         flat_index = sympy_subs(_dep.index, subs)
+        flat_index += _full_buf.layout.offset - _initial_source_offset
         return V.ops.load(_full_name, flat_index)
 
     # Construct under sizing_op's origins so data.origins is non-empty —


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Preserves source layout-offset changes in read-copy operations synthesized by pre-stickify coarse tiling.

Graph-input storage offsets are repaired later by `propagate_spyre_tensor_layouts()`. The generated read-copy body previously froze the earlier zero-offset dependency index, so packed QKV views caused the K and V copies to read from the Q slice whenever SDPA genuinely tiled the head dimension.

The copy now records the source offset already represented in its dependency and applies only the subsequent offset delta when its body is traced. This also avoids double-applying offsets that were present before coarse tiling.

Adds:

- a focused IR test for late source-layout offset changes;
- an end-to-end H=8 SDPA regression using non-contiguous views into packed QKV storage.

#### Which issue(s) this PR is related to:

Follow-up to #4331 and #4299.

#### Special notes for your reviewer:

PR #4299 corrected the head tile-count conversion and fixes the reported H=4 reproducer because H=4 no longer enters head tiling. H=8 still enters the read-copy path and exposed this independent latent offset bug.

Before this change, the H=8 reproducer had max absolute error 2.44678 for packed non-contiguous inputs versus 0.00635 for contiguous inputs. After this change both paths have max absolute error 0.00635.

Validation:

- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 python -m pytest -q tests/inductor/test_coarse_tiling.py::TestInsertAllReadCopyOps::test_read_copy_observes_late_source_layout_offset tests/inductor/test_coarse_tile_e2e.py::test_sdpa_packed_qkv_input_offsets_h8` — 2 passed
- `python -m pytest -q tests/inductor/test_coarse_tiling.py::TestInsertAllReadCopyOps` — 9 passed
- pre-commit on all changed files — passed
- H=4 original reproducer — max absolute error 0.00293
- H=8 packed-QKV reproducer plus contiguous/mixed-contiguity variants — max absolute error 0.00635 throughout

#### Does this PR introduce a user-facing change?

Yes. SDPA remains numerically correct when coarse head tiling reads K/V from nonzero-offset views of packed QKV storage.

#### Additional note:

None.