### PR TITLE
fix attention view error

### DIFF
--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -483,6 +483,7 @@ def spyre__sdpa_overrideable(
     # instead normalized PER BLOCK inside the loop (keys_T's .contiguous() and
     # the per-block v_blk.contiguous()), each a bounded [B, H, kv_block_size, D]
     # copy (kv_block_size <= 2048, see below), never the full [B, H, S_kv, D].
+    original_query_strides = query.stride()
     query = query.contiguous()
 
     expansion = num_heads // num_kvheads
@@ -712,7 +713,7 @@ def spyre__sdpa_overrideable(
     # (physical [B, S, H, D]) it is the swapped-dim layout. Reproduce the meta's
     # dim-order permutation so both cases match exactly.
     dim_order = sorted(
-        range(query.dim()), key=lambda i: query.stride()[i], reverse=True
+        range(query.dim()), key=lambda i: original_query_strides[i], reverse=True
     )
     permuted = output.permute(dim_order).contiguous()
     inverse_permute = [dim_order.index(i) for i in range(len(dim_order))]


### PR DESCRIPTION

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes attention stride issue. The error observed is 
```
ValueError: Cannot view a tensor with shape torch.Size([4, 64, 32, 128]) and strides (262144, 128, 8192, 1) as a tensor with shape (4, 64, 4096)!
```

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:
Blocks granite FMS run in perf suite

#### Does this PR introduce a user-facing change?


#### Additional note:
