### PR TITLE
fix(codegen): point maskingConstId_ at samv-maskvalue, not constant 0

### DIFF
--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -34,6 +34,7 @@ from torch_spyre._inductor.codegen.compute_ops import (
     _per_core_symbolic_dim_info,
     _symbolic_split_info,
     _tensor_has_symbolic_split,
+    generate_constant_info,
 )
 from torch_spyre._inductor.codegen.superdsc import (
     _align_pool_dim_labels,
@@ -765,3 +766,38 @@ class TestGenerateSdscSymbolicPerCoreAddresses(InductorTestCase):
         self.assertTrue(
             any(sk.is_derived_symbolic for sk in symbol_kinds[first_address:])
         )
+
+
+class TestMaskingConstId(InductorTestCase):
+    """maskingConstId_ must resolve to the samv-maskvalue constant.
+
+    Constant ids are positions in the constants dict, so an op that carries its
+    own constants shifts samv-maskvalue off id 0. Hardcoding 0 there made the
+    backend splat the padding lanes with scaling_factor instead of the mask
+    value, corrupting every non-stick-aligned mean reduction (#4390).
+    """
+
+    def _ids_to_names(self, constants):
+        info = generate_constant_info(DataFormats.SEN169_FP16, constants, 1)
+        return {cid: entry["name_"] for cid, entry in info.items()}
+
+    def test_constants_dict_preserves_insertion_order(self):
+        # The whole scheme rests on dict order being insertion order, not
+        # sorted: "samv-maskvalue" sorts before "scaling_factor" but must come
+        # second when inserted second.
+        constants = {"scaling_factor": 1.0 / 9, "samv-maskvalue": 0.0}
+        self.assertEqual(list(constants), ["scaling_factor", "samv-maskvalue"])
+        self.assertEqual(self._ids_to_names(constants)["1"], "samv-maskvalue")
+
+    def test_masking_const_id_follows_preceding_constants(self):
+        # A reduction carrying scaling_factor (mean) shifts the mask value to 1;
+        # one carrying nothing else (sum) leaves it at 0. In both cases the
+        # index recorded at insertion time must name samv-maskvalue.
+        for preceding, expected in (({}, "0"), ({"scaling_factor": 1.0 / 9}, "1")):
+            constants = dict(preceding)
+            recorded = len(constants)
+            constants["samv-maskvalue"] = 0.0
+            self.assertEqual(str(recorded), expected)
+            self.assertEqual(
+                self._ids_to_names(constants)[str(recorded)], "samv-maskvalue"
+            )

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -1391,9 +1391,7 @@ def generate_sdsc(
                                 str(dim): mask_range
                                 for dim, mask_range in sdsc_spec.coordinate_masking.items()
                             },
-                            "maskingConstId_": 0
-                            if sdsc_spec.coordinate_masking
-                            else -1,
+                            "maskingConstId_": sdsc_spec.masking_const_id,
                             # Emit dimToSymbolMapping_ only when there are symbolic dims;
                             # the runtime uses it to bind runtime shape values to symbols.
                             **(

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -136,6 +136,10 @@ class SDSCSpec:
     )
     indirect_access_indices: list[int] = dataclasses.field(default_factory=list)
     debug_handle: DebugHandle | None = None
+    # Index of "samv-maskvalue" in constants_. Constant ids are assigned by
+    # insertion order, so this is only 0 when the op carries no other constants;
+    # ops that do (mean/avgpool add scaling_factor first) shift it (see #4390).
+    masking_const_id: int = -1
     # Generic pool/window fields.  Neutral defaults mean generate_sdsc treats a
     # non-pool op exactly as before; parse_op_spec fills these for pool ops via
     # _avgpool_sdsc_fields, so compute_ops.py stays free of op-specific logic.
@@ -2237,7 +2241,11 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     coordinate_masking = _get_coordinate_mask(
         sdsc_iteration_space, args[-1], padding, op_spec.op
     )
+    masking_const_id = -1
     if coordinate_masking:
+        # Constant ids follow insertion order, so capture the index here rather
+        # than assuming 0 -- ops with their own constants shift it (see #4390).
+        masking_const_id = len(constants)
         constants["samv-maskvalue"] = _get_mask_value(op_spec.op)
 
     # Forward conv2d (#3284), like matmul, counts only the non-output args as
@@ -2385,6 +2393,7 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
             layouts=layouts,
             args=args,
             constants=constants,
+            masking_const_id=masking_const_id,
             conv_params=conv_params,
             coordinate_masking=coordinate_masking,
             symbolic_dims=symbolic_dims,


### PR DESCRIPTION
Fixes #4390.

The defect is in the SuperDSC frontend, not the native `mean` kernel — the backend honors `coordinateMasking_` for both `sum` and `mean`, but is told to mask with the wrong value.

`compute_ops.py` hardcoded `"maskingConstId_": 0`. Constant ids are positions in the `constants` dict, assigned by insertion order in `generate_constant_info`, and `superdsc.py` appends `samv-maskvalue` *after* any op-supplied constants. `sum` carries no others, so index 0 was correct by accident. `mean` inserts `scaling_factor` first, which shifts `samv-maskvalue` to index 1 while `maskingConstId_` stayed pinned at 0 — so the padding lanes were seeded with 1/N instead of the mask value, and that leaked into the reduction.

This also explains why the reported error was a fixed value rather than data-dependent noise: it is a deterministic constant, not uninitialized garbage. For the reported case (reduce 9 → 55 padding lanes holding 1/9, then scaled by 1/9) the predicted result is 0.678681 against 0.679688 observed, the difference being fp16 accumulation rounding.

## Fix

Record the index where `samv-maskvalue` is actually inserted and carry it on `SDSCSpec.masking_const_id`. `parse_op_spec` is the only place that inserts the constant and the only production `SDSCSpec` construction site.

## Verification

Reproducers written from scratch, run on hardware, `(3, 7, 9)` fp16, `dim=-1`:

| | before | after |
|---|---|---|
| `mean`, all-zeros control | 0.679688 ✗ | 0.0 ✓ |
| `mean` vs CPU eager (random) | 21/21 mismatched ✗ | pass ✓ |
| `sum`, both checks | pass | pass (unchanged) |

The all-zeros case is the decisive control: the correct answer is exactly 0 regardless of what sits in the padding lanes.

Reduction-size sweep (8, 9, 17, 31, 63, 64, 65, 127, 128) is clean; previously every non-multiple-of-64 leaked. `tests/inductor/` `test_codegen.py`, `test_coarse_tiling.py`, `test_provenance.py`: 440 passed.

`TestMaskingConstId` in `test_codegen.py` pins the id against the real `generate_constant_info`, and pins the assumption the scheme rests on — that `constants` iterates in insertion order, not sorted. Note `"samv-maskvalue"` sorts *before* `"scaling_factor"`, so a switch to sorted ordering would silently reintroduce this bug.
