### PR TITLE
Fix stream-context re-entrancy leak in torch_spyre.Stream

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -160,6 +160,61 @@ class TestSpyreStream(TestCase):
         self.assertTrue(stream2.query())
         self.assertEqual(c.shape, (3, 3))
 
+    def test_reentrant_same_stream_context(self):
+        """Re-entering the *same* Stream instance must not clobber the
+        state needed to restore the stream that was active before the
+        outermost `with` block.
+
+        Regression test: __enter__ used to save the previous stream into a
+        single `_prev_stream` attribute, so nesting the same instance (e.g.
+        via `with s: with s: ...`, or the aliasing `torch_spyre.stream(s)`
+        helper) overwrote the outer value and left the wrong stream current
+        after the outer block exited.
+        """
+        outer_stream = torch.spyre.current_stream()
+        # s = torch.Stream(self.device)
+        s = torch.spyre.Stream(self.device)
+
+        print(f"outer_stream: {outer_stream}", flush=True)
+        print(f"s: {s}", flush=True)
+        # print(outer_stream, flush=True)
+        # print(s, flush=True)
+
+        with s:
+            with s:
+                torch.randn(3, 3, device="spyre")
+
+                print(
+                    f"torch.spyre.current_stream(): {torch.spyre.current_stream()}",
+                    flush=True,
+                )
+                # print(torch.spyre.current_stream(), flush=True)
+
+            print(
+                f"torch.spyre.current_stream(): {torch.spyre.current_stream()}",
+                flush=True,
+            )
+            # print(torch.spyre.current_stream(), flush=True)
+
+            # The inner __exit__ must restore `s`, not the stream that was
+            # current before the outer __enter__.
+            self.assertEqual(torch.spyre.current_stream(), s)
+
+        self.assertEqual(torch.spyre.current_stream(), outer_stream)
+
+    def test_stream_context_restores_on_exception(self):
+        """The displaced stream must be restored even if the `with` body
+        raises."""
+        outer_stream = torch.spyre.current_stream()
+        # s = torch.Stream(self.device)
+        s = torch.spyre.Stream(self.device)
+
+        with self.assertRaises(ValueError):
+            with s:
+                raise ValueError("boom")
+
+        self.assertEqual(torch.spyre.current_stream(), outer_stream)
+
     def test_stream_priority_levels(self):
         """Test creating streams with different priority levels."""
         high_priority = torch.Stream(self.device, priority=-1)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -175,31 +175,15 @@ class TestSpyreStream(TestCase):
         # s = torch.Stream(self.device)
         s = torch.spyre.Stream(self.device)
 
-        print(f"outer_stream: {outer_stream}", flush=True)
-        print(f"s: {s}", flush=True)
-        # print(outer_stream, flush=True)
-        # print(s, flush=True)
-
         with s:
             with s:
                 torch.randn(3, 3, device="spyre")
-
-                print(
-                    f"torch.spyre.current_stream(): {torch.spyre.current_stream()}",
-                    flush=True,
-                )
-                # print(torch.spyre.current_stream(), flush=True)
-
-            print(
-                f"torch.spyre.current_stream(): {torch.spyre.current_stream()}",
-                flush=True,
-            )
-            # print(torch.spyre.current_stream(), flush=True)
 
             # The inner __exit__ must restore `s`, not the stream that was
             # current before the outer __enter__.
             self.assertEqual(torch.spyre.current_stream(), s)
 
+        # use proper comparisonn
         self.assertEqual(torch.spyre.current_stream(), outer_stream)
 
     def test_stream_context_restores_on_exception(self):

--- a/torch_spyre/streams.py
+++ b/torch_spyre/streams.py
@@ -47,19 +47,36 @@ class Stream:
 
         # Get stream from pool via C++ binding
         self._cdata = _C.get_stream_from_pool(device, priority)
+        # Stack of streams displaced by __enter__, restored in __exit__.
+        # A stack (rather than a single slot) makes the context manager safe
+        # to re-enter with the same Stream instance, e.g. via
+        # `with s: with s: ...` or `torch_spyre.stream(s)`, which hands back
+        # the same object rather than a fresh context manager.
+        self._prev_streams: list[_C._SpyreStreamBase] = []
+
+    @classmethod
+    def _from_cdata(cls, cdata) -> "Stream":
+        """Wrap an existing C++ stream handle without going through
+        __init__ (which would allocate a new stream from the pool)."""
+        stream_obj = cls.__new__(cls)
+        stream_obj._cdata = cdata
+        stream_obj._prev_streams = []
+        return stream_obj
 
     def __enter__(self):
         """Enter stream context - set as current stream"""
         # Save previous stream
-        self._prev_stream = _C.current_stream(self.device())
+        self._prev_streams.append(_C.current_stream(self.device()))
         # Set this stream as current
         _C.set_current_stream(self._cdata)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit stream context - restore previous stream"""
+        if not self._prev_streams:
+            raise RuntimeError("Stream.__exit__ called without a matching __enter__")
         # Restore previous stream
-        _C.set_current_stream(self._prev_stream)
+        _C.set_current_stream(self._prev_streams.pop())
         return False
 
     def synchronize(self):
@@ -136,9 +153,7 @@ def current_stream(device: Optional[torch.device] = None) -> Stream:
     cdata = _C.current_stream(device)
 
     # Wrap in Python Stream object
-    stream_obj = Stream.__new__(Stream)
-    stream_obj._cdata = cdata
-    return stream_obj
+    return Stream._from_cdata(cdata)
 
 
 def default_stream(device: Optional[torch.device] = None) -> Stream:
@@ -158,9 +173,7 @@ def default_stream(device: Optional[torch.device] = None) -> Stream:
 
     cdata = _C.default_stream(device)
 
-    stream_obj = Stream.__new__(Stream)
-    stream_obj._cdata = cdata
-    return stream_obj
+    return Stream._from_cdata(cdata)
 
 
 def synchronize(device: Optional[torch.device] = None):


### PR DESCRIPTION

#### What type of PR is this?

- [x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### Bug Symptom 
 `__enter__` saved the displaced stream in one attribute (`_prev_stream`), so re-entering the same `Stream` object overwrote it before it was restored, leaving the wrong stream current after the exit of the outer `with` context.

#### Fix
replaced that single slot with a `_prev_streams` stack, pushed on enter and popped on exit, so each nesting level restores correctly.