### PR TITLE
fix(inductor): preserve nested coarse-tile layouts

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -77,6 +77,7 @@ from torch_spyre._inductor.wsr.coarse_tile import (
     _REDUCTION_FREE_SYMS_KEY,
     _RetiledBufferInfo,
     _apply_plan,
+    _active_full_sizes_from_strides,
     _compute_fill_loop_info_planned,
     _compute_read_copy_strides,
     _consumer_own_dim_symbol,
@@ -913,6 +914,7 @@ class TestRetileLoadIndexFromStrides(unittest.TestCase):
             old_stride=(Integer(4096), Integer(1)),
             new_stride=(Integer(512), Integer(1)),
             old_size=(Integer(4), Integer(512)),
+            new_size=(Integer(4), Integer(512)),
         )
         result = _retile_load_index("buf", 4096 * c0 + c1, info)
 
@@ -926,6 +928,7 @@ class TestRetileLoadIndexFromStrides(unittest.TestCase):
             old_stride=(Integer(128), Integer(1)),
             new_stride=(Integer(64), Integer(1)),
             old_size=(Integer(2), Integer(128)),
+            new_size=(Integer(2), Integer(64)),
         )
         from torch_spyre._inductor.errors import Unsupported
 
@@ -943,6 +946,7 @@ class TestRetileLoadIndexFromStrides(unittest.TestCase):
             old_stride=(Integer(2), Integer(1)),
             new_stride=(Integer(1), Integer(1)),
             old_size=(Integer(2), Integer(2)),
+            new_size=(Integer(2), Integer(1)),
         )
         result = _retile_load_index("buf", 2 * c0 + c1, info)
 
@@ -956,6 +960,7 @@ class TestRetileLoadIndexFromStrides(unittest.TestCase):
             old_stride=(Integer(256), Integer(128)),
             new_stride=(Integer(64), Integer(32)),
             old_size=(Integer(2), Integer(4)),
+            new_size=(Integer(2), Integer(4)),
         )
         result_c0 = _retile_load_index("buf", 256 * c0, info)
         result_c1 = _retile_load_index("buf", 128 * c1, info)
@@ -978,6 +983,7 @@ class TestRetileLoadIndexFromStrides(unittest.TestCase):
             old_stride=(Integer(131072), Integer(4096), Integer(1)),
             new_stride=(Integer(4096), Integer(1024), Integer(1)),
             old_size=(Integer(2), Integer(32), Integer(4096)),
+            new_size=(Integer(2), Integer(4), Integer(1024)),
         )
         already_fresh_index = 4096 * d0 + 1024 * d1 + d2
 
@@ -994,12 +1000,126 @@ class TestRetileLoadIndexFromStrides(unittest.TestCase):
             old_stride=(Integer(131072), Integer(4096), Integer(1)),
             new_stride=(Integer(4096), Integer(1024), Integer(1)),
             old_size=(Integer(2), Integer(32), Integer(4096)),
+            new_size=(Integer(2), Integer(4), Integer(1024)),
         )
         stale_index = 131072 * d0 + 4096 * d1 + d2
 
         result = _retile_load_index("buf", stale_index, info)
 
         self.assertEqual(simplify(result - (4096 * d0 + 1024 * d1 + d2)), 0)
+
+    def test_nested_tile_fresh_index_ignores_final_zero_stride(self):
+        """A later squeezed axis contributes no atom to a fresh index.
+
+        The GQA head nest tiles ``[Hkv=8, group=4]`` to ``[4, 1]``.  By the
+        time a consumer is retraced, its Hkv coefficient is already the final
+        4096 stride and the squeezed group has no index term.  The zero group
+        stride must therefore not prevent detection of the fresh index.
+        """
+        hkv, row, column = sympy.symbols("hkv row column")
+        info = _RetiledBufferInfo(
+            old_stride=(
+                Integer(131072),
+                Integer(16384),
+                Integer(4096),
+                Integer(64),
+                Integer(1),
+            ),
+            new_stride=(
+                Integer(0),
+                Integer(4096),
+                Integer(0),
+                Integer(64),
+                Integer(1),
+            ),
+            old_size=(
+                Integer(1),
+                Integer(8),
+                Integer(4),
+                Integer(64),
+                Integer(64),
+            ),
+            new_size=(
+                Integer(1),
+                Integer(4),
+                Integer(1),
+                Integer(64),
+                Integer(64),
+            ),
+        )
+        already_fresh_index = 4096 * hkv + 64 * row + column
+
+        result = _retile_load_index("gqa_scores", already_fresh_index, info)
+
+        self.assertEqual(simplify(result - already_fresh_index), 0)
+
+    def test_tile_to_full_preserves_atom_already_using_full_stride(self):
+        """An outside view may already express one axis in the full layout."""
+        lq, head, dim = sympy.symbols("lq head dim")
+        info = _RetiledBufferInfo(
+            old_stride=(
+                Integer(0),
+                Integer(262144),
+                Integer(128),
+                Integer(1),
+            ),
+            new_stride=(
+                Integer(33554432),
+                Integer(1048576),
+                Integer(128),
+                Integer(1),
+            ),
+            old_size=(Integer(1), Integer(4), Integer(2048), Integer(128)),
+            new_size=(Integer(1), Integer(32), Integer(8192), Integer(128)),
+        )
+        index = 128 * lq + 1048576 * head + dim
+
+        result = _retile_load_index(
+            "sdpa_output",
+            index,
+            info,
+            preserve_target_stride_atoms=True,
+        )
+
+        self.assertEqual(simplify(result - index), 0)
+
+    def test_tile_to_full_retiles_source_stride_that_overlaps_target_stride(self):
+        """A source stride wins when its value is also another target stride."""
+        outer = sympy.symbols("outer")
+        info = _RetiledBufferInfo(
+            old_stride=(Integer(64), Integer(16), Integer(1)),
+            new_stride=(Integer(256), Integer(64), Integer(1)),
+            old_size=(Integer(4), Integer(4), Integer(16)),
+            new_size=(Integer(4), Integer(4), Integer(16)),
+        )
+
+        result = _retile_load_index(
+            "retiled",
+            64 * outer,
+            info,
+            preserve_target_stride_atoms=True,
+        )
+
+        self.assertEqual(simplify(result - 256 * outer), 0)
+
+    def test_tile_to_full_retiles_composite_view_step_equal_to_target_stride(self):
+        """A source-local view step is not evidence of target addressing."""
+        row, column = sympy.symbols("row column")
+        info = _RetiledBufferInfo(
+            old_stride=(Integer(64), Integer(1)),
+            new_stride=(Integer(256), Integer(1)),
+            old_size=(Integer(512), Integer(64)),
+            new_size=(Integer(512), Integer(256)),
+        )
+
+        result = _retile_load_index(
+            "retiled",
+            256 * row + column,
+            info,
+            preserve_target_stride_atoms=True,
+        )
+
+        self.assertEqual(simplify(result - (1024 * row + column)), 0)
 
 
 def _make_consumer_with_ranges(ranges):
@@ -1015,12 +1135,9 @@ def _make_consumer_with_ranges(ranges):
 class TestSqueezedRetileDims(unittest.TestCase):
     """Unit tests for which raw dims need a re-minted symbol on redirect.
 
-    See coarse_tile.py's module docstring / _squeezed_retile_dims's own
-    docstring for the two-bug history this guards: a dim only needs a
-    minted term when it was squeezed out of the *old* (tile-local) buffer's
-    layout (old_size[d] == 1, new_stride[d] != 0) AND the consumer's own
-    output for that same raw dim is non-unit (data.ranges[d] != 1) -- i.e a
-    real loop variable actually exists for it somewhere in the trace.
+    A dim only needs a minted term when it was squeezed out of the old
+    tile-local buffer and actually grows in the new full buffer. Positional
+    consumer symbols are used only when producer and consumer shapes align.
     """
 
     def test_squeezed_dim_with_nonunit_consumer_output_included(self):
@@ -1031,6 +1148,7 @@ class TestSqueezedRetileDims(unittest.TestCase):
             old_stride=(Integer(0), Integer(1)),
             new_stride=(Integer(256), Integer(1)),
             old_size=(Integer(1), Integer(256)),
+            new_size=(Integer(8), Integer(256)),
         )
         consumer = _make_consumer_with_ranges([8, 256])
 
@@ -1049,6 +1167,7 @@ class TestSqueezedRetileDims(unittest.TestCase):
             old_stride=(Integer(0), Integer(1)),
             new_stride=(Integer(256), Integer(1)),
             old_size=(Integer(1), Integer(256)),
+            new_size=(Integer(8), Integer(256)),
         )
         consumer = _make_consumer_with_ranges([1, 256])
 
@@ -1062,6 +1181,7 @@ class TestSqueezedRetileDims(unittest.TestCase):
             old_stride=(Integer(128), Integer(1)),
             new_stride=(Integer(64), Integer(1)),
             old_size=(Integer(2), Integer(256)),
+            new_size=(Integer(2), Integer(256)),
         )
         consumer = _make_consumer_with_ranges([2, 256])
 
@@ -1074,10 +1194,23 @@ class TestSqueezedRetileDims(unittest.TestCase):
             old_stride=(Integer(0), Integer(1)),
             new_stride=(Integer(0), Integer(1)),
             old_size=(Integer(1), Integer(256)),
+            new_size=(Integer(8), Integer(256)),
         )
         consumer = _make_consumer_with_ranges([8, 256])
 
         self.assertEqual(_squeezed_retile_dims(info, consumer), [])
+
+    def test_true_growth_through_rank_changing_consumer_is_rejected(self):
+        info = _RetiledBufferInfo(
+            old_stride=(Integer(512), Integer(128), Integer(0), Integer(1)),
+            new_stride=(Integer(4096), Integer(128), Integer(4096), Integer(1)),
+            old_size=(Integer(1), Integer(4), Integer(1), Integer(128)),
+            new_size=(Integer(1), Integer(32), Integer(8), Integer(128)),
+        )
+        consumer = _make_consumer_with_ranges([1, 1, 4096])
+
+        with self.assertRaisesRegex(Unsupported, "rank-changing consumer view"):
+            _squeezed_retile_dims(info, consumer)
 
 
 class TestIndexVarPrefix(unittest.TestCase):
@@ -1155,6 +1288,7 @@ class TestRetileLoadIndexWithConsumer(unittest.TestCase):
             old_stride=(Integer(0), Integer(1)),
             new_stride=(Integer(256), Integer(1)),
             old_size=(Integer(1), Integer(256)),
+            new_size=(Integer(4), Integer(256)),
         )
         q1 = sympy.Symbol("q1")
         consumer = _make_consumer_with_ranges([4, 256])
@@ -1172,9 +1306,10 @@ class TestRetileLoadIndexWithConsumer(unittest.TestCase):
         # silently corrupting it to 16384*d0 + 256*d0 instead of raising or
         # leaving 16384*d0 alone -- this is bug 2's exact regression.
         info = _RetiledBufferInfo(
-            old_stride=(Integer(0), Integer(1)),
-            new_stride=(Integer(256), Integer(1)),
-            old_size=(Integer(1), Integer(256)),
+            old_stride=(Integer(0), Integer(256), Integer(1)),
+            new_stride=(Integer(2048), Integer(256), Integer(1)),
+            old_size=(Integer(1), Integer(8), Integer(256)),
+            new_size=(Integer(8), Integer(8), Integer(256)),
         )
         d0 = sympy_index_symbol("d0")
         consumer = _make_consumer_with_ranges([1, 8, 256])
@@ -1192,12 +1327,118 @@ class TestRetileLoadIndexWithConsumer(unittest.TestCase):
             old_stride=(Integer(0), Integer(1)),
             new_stride=(Integer(256), Integer(1)),
             old_size=(Integer(1), Integer(256)),
+            new_size=(Integer(4), Integer(256)),
         )
         q1 = sympy.Symbol("q1")
 
         result = _retile_load_index("buf", q1, info)
 
         self.assertEqual(simplify(result - q1), 0)
+
+    def test_unit_bhld_axis_is_not_minted_into_flattened_projection(self):
+        """A persistent Lq=1 axis is not an extent lost to coarse tiling."""
+        info = _RetiledBufferInfo(
+            old_stride=(Integer(512), Integer(128), Integer(128), Integer(1)),
+            new_stride=(Integer(4096), Integer(128), Integer(4096), Integer(1)),
+            old_size=(Integer(1), Integer(4), Integer(1), Integer(128)),
+            new_size=(Integer(1), Integer(32), Integer(1), Integer(128)),
+        )
+        d1 = sympy_index_symbol("d1")
+        consumer = _make_consumer_with_ranges([1, 1, 4096])
+
+        result = _retile_load_index("buf", d1, info, consumer)
+
+        self.assertEqual(result, d1)
+
+    def test_dense_gqa_head_flatten_is_already_full_scale(self):
+        """A full GQA ``Hkv*group`` view must not be retiled a second time."""
+        info = _RetiledBufferInfo(
+            old_stride=(
+                Integer(0),
+                Integer(32768),
+                Integer(0),
+                Integer(128),
+                Integer(1),
+            ),
+            new_stride=(
+                Integer(2097152),
+                Integer(262144),
+                Integer(65536),
+                Integer(128),
+                Integer(1),
+            ),
+            old_size=(
+                Integer(1),
+                Integer(4),
+                Integer(1),
+                Integer(256),
+                Integer(128),
+            ),
+            new_size=(
+                Integer(1),
+                Integer(8),
+                Integer(4),
+                Integer(512),
+                Integer(128),
+            ),
+        )
+        consumer = _make_consumer_with_ranges([1, 512, 32, 128])
+
+        for symbols in (("d0", "d1", "d2"), ("_i1", "_i2", "_i3")):
+            lq, head, column = map(sympy_index_symbol, symbols)
+            index = 128 * lq + 65536 * head + column
+            result = _retile_load_index(
+                "gqa_output",
+                index,
+                info,
+                consumer,
+                preserve_target_stride_atoms=True,
+            )
+            self.assertEqual(result, index)
+
+    def test_dense_decode_gqa_flatten_in_matmul_reduction_is_full_scale(self):
+        info = _RetiledBufferInfo(
+            old_stride=(
+                Integer(0),
+                Integer(128),
+                Integer(0),
+                Integer(0),
+                Integer(1),
+            ),
+            new_stride=(
+                Integer(4096),
+                Integer(512),
+                Integer(128),
+                Integer(128),
+                Integer(1),
+            ),
+            old_size=(
+                Integer(1),
+                Integer(4),
+                Integer(1),
+                Integer(1),
+                Integer(128),
+            ),
+            new_size=(
+                Integer(1),
+                Integer(8),
+                Integer(4),
+                Integer(1),
+                Integer(128),
+            ),
+        )
+        consumer = _make_op(_make_reduction([1, 1, 4096], [4096]))
+        contraction = sympy_index_symbol("d1")
+
+        result = _retile_load_index(
+            "gqa_decode_output",
+            contraction,
+            info,
+            consumer,
+            preserve_target_stride_atoms=True,
+        )
+
+        self.assertEqual(result, contraction)
 
 
 class TestShouldPatchRetiledLoadIndexes(unittest.TestCase):
@@ -4798,6 +5039,129 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         self.assertNotIsInstance(final_op.layout, MutationLayoutSHOULDREMOVE)
         self.assertEqual(final_op.loop_info.output_tiled_dims, [])
 
+    def test_cross_group_read_copy_is_retargeted_to_full_copy_out(self):
+        """Pass 3 retargets Pass 1's reader without erasing its advances."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            MutationLayoutSHOULDREMOVE,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        from torch_spyre._inductor.loop_info import PropagationPlan
+        from torch_spyre._inductor.lowering import enable_spyre_lowerings
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+            _propagate_tiled_op,
+        )
+
+        fake_mode_ctx = V.set_fake_mode(FakeTensorMode())
+        fake_mode_ctx.__enter__()
+        self.addCleanup(fake_mode_ctx.__exit__, None, None, None)
+        lowerings_ctx = enable_spyre_lowerings()
+        lowerings_ctx.__enter__()
+        self.addCleanup(lowerings_ctx.__exit__, None, None, None)
+
+        producer = _make_real_pointwise_op(
+            ranges=[Integer(4), Integer(64)],
+            input_shapes_strides=[([32, 1024], [1024, 1])],
+            name="producer",
+        )
+        producer.loop_info = CoarseTileInfo(
+            loop_group_id=(0, 0),
+            loop_count=[Integer(8), Integer(16)],
+            loop_tiled_dims=[[0], [1]],
+        )
+
+        producer_box = TensorBox(StorageBox(producer))
+
+        def consumer_inner_fn(index):
+            return producer_box.make_loader()(index[1:])
+
+        consumer_pw = Pointwise.create(
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            inner_fn=consumer_inner_fn,
+            ranges=[Integer(1), Integer(4), Integer(64)],
+        )
+        consumer = ComputedBuffer(
+            name="consumer",
+            layout=FixedLayout(
+                torch.device("cpu"),
+                torch.float32,
+                [Integer(1), Integer(4), Integer(64)],
+                None,
+            ),
+            data=consumer_pw.data.data,
+        )
+        consumer.operation_name = "consumer"
+        consumer.origins = OrderedSet()
+        consumer.loop_info = CoarseTileInfo(
+            loop_group_id=(1, 0),
+            loop_count=[Integer(8), Integer(16)],
+            loop_tiled_dims=[[1], [2]],
+        )
+        V.graph.name_to_buffer["consumer"] = consumer
+
+        operations = V.graph.buffers
+        operations.extend([producer, consumer])
+
+        read_copy_plans = _plan_read_copies(operations, [((1,), [consumer], {})])
+        _insert_all_read_copy_ops(operations, read_copy_plans)
+        read_copy = next(
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer)
+            and op.get_name().startswith("coarse_tile_read_copy_")
+        )
+        self.assertEqual(
+            {dep.name for dep in read_copy.get_read_writes().reads}, {"producer"}
+        )
+        expected_read_advances = [
+            [[(0, Integer(4))], [(1, Integer(64))]],
+        ]
+        self.assertEqual(list(read_copy.data.ranges), [Integer(4), Integer(64)])
+        self.assertEqual(read_copy.loop_info.loop_tiled_dims, [[0], [1]])
+        self.assertEqual(
+            read_copy.loop_info.tiled_dims_per_read, expected_read_advances
+        )
+
+        propagation = PropagationPlan(
+            kind="copy_out",
+            full_ranges=[Integer(32), Integer(1024)],
+            full_strides=(Integer(1024), Integer(1)),
+            outside_consumer_names=("consumer",),
+            is_graph_output=False,
+        )
+        _propagate_tiled_op(producer, propagation, operations)
+
+        write_copy = next(
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer)
+            and op.get_name().startswith("coarse_tile_copy_")
+        )
+        self.assertIsInstance(write_copy.layout, MutationLayoutSHOULDREMOVE)
+        full_buf = write_copy.layout.get_buffer()
+
+        # _patch_consumers reconstructs the read-copy, so resolve its live
+        # replacement before checking the actual IR dependency.
+        live_read_copy = V.graph.name_to_buffer[read_copy.get_name()]
+        self.assertEqual(
+            {dep.name for dep in live_read_copy.get_read_writes().reads},
+            {full_buf.get_name()},
+        )
+        self.assertEqual(
+            live_read_copy.loop_info.tiled_dims_per_read, expected_read_advances
+        )
+        self.assertNotIn(
+            "producer", {dep.name for dep in live_read_copy.get_read_writes().reads}
+        )
+
 
 class TestPlanTilingPropagation(unittest.TestCase):
     """Cross-check: _plan_tiling_propagation's kind decision must match what
@@ -7917,6 +8281,28 @@ class TestCoeffThroughFloor(unittest.TestCase):
 
 class TestTileHelpers(unittest.TestCase):
     """Tests for tile.py."""
+
+    def test_active_full_sizes_padded_prefix_view(self):
+        # The logical prefix excludes the final 256 rows, but retains the
+        # 8448-row backing stride.  numel // head_stride would incorrectly
+        # report seven heads; the raw head dimension still has extent eight.
+        sizes = _active_full_sizes_from_strides(
+            [1, 8, 8192, 128],
+            [8650752, 1081344, 128, 1],
+            [1081344, 128, 1],
+        )
+        self.assertEqual(sizes, [8, 8448, 128])
+        self.assertEqual(
+            compute_tile_stride(sizes, [1081344, 128, 1], [4, 256, 128]),
+            [32768, 128, 1],
+        )
+
+    def test_active_full_sizes_reshaped_coordinate_fallback(self):
+        # A viewed coordinate stride need not appear in the raw 1-D layout.
+        self.assertEqual(
+            _active_full_sizes_from_strides([8192], [1], [128, 1]),
+            [64, 128],
+        )
 
     def test_compute_tile_stride_1d(self):
         self.assertEqual(compute_tile_stride([1024], [1], [256]), [1])

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -40,6 +40,7 @@ from torch_spyre._inductor.codegen.superdsc import (
     _align_pool_dim_labels,
     _resolve_sdsc_size,
     compile_op_spec,
+    parse_op_spec,
 )
 from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
@@ -483,6 +484,70 @@ class TestSdscJsonSymbolicDimSmoke(InductorTestCase):
         for stage in ("ss_", "el_"):
             sym_info = dsc["dataStageParam_"]["0"][stage]["symbolicDimInfo_"]
             self.assertEqual(sym_info, {"mb": {"maxSize_": 512, "granularity_": 64}})
+
+
+class TestTiledAwayPhysicalAxis(InductorTestCase):
+    def test_nonstick_role_uses_coordinate_axis_across_tiled_away_axis(self):
+        """A constant GQA group slot must not collapse the Hkv stride."""
+        d0, d1, d2, d3 = sympy.symbols("d0:4")
+        iteration_space = {
+            d0: (sympy.Integer(2), 1),
+            d1: (sympy.Integer(8), 1),
+            d2: (sympy.Integer(64), 32),
+            d3: (sympy.Integer(128), 1),
+        }
+        spec = OpSpec(
+            op="identity",
+            is_reduction=False,
+            iteration_space=iteration_space,
+            core_id_to_work_slice={dim: sympy.S.Zero for dim in iteration_space},
+            args=[
+                TensorArg(
+                    is_input=True,
+                    arg_index=0,
+                    device_dtype=DataFormats.SEN169_FP16,
+                    # [Hkv, tiled-away G, M, D/64, B, D%64]
+                    device_size=[32, 4, 64, 2, 2, 64],
+                    device_coordinates=[
+                        d1,
+                        sympy.S.Zero,
+                        d2,
+                        sympy.floor(d3 / 64),
+                        d0,
+                        sympy.Mod(d3, 64),
+                    ],
+                    allocation={"hbm": 0},
+                    device_tile_advance_expr=16_384 * sympy.Symbol("tile_group"),
+                ),
+                TensorArg(
+                    is_input=False,
+                    arg_index=1,
+                    device_dtype=DataFormats.SEN169_FP16,
+                    device_size=[1, 8, 64, 2, 2, 64],
+                    device_coordinates=[
+                        sympy.S.Zero,
+                        d1,
+                        d2,
+                        sympy.floor(d3 / 64),
+                        d0,
+                        sympy.Mod(d3, 64),
+                    ],
+                    allocation={"lx": 0},
+                ),
+            ],
+            op_info={},
+            tiled_symbols=[[sympy.Symbol("tile_group")]],
+            tiled_symbol_trip_counts={sympy.Symbol("tile_group"): 4},
+        )
+
+        sdsc_spec, _ = parse_op_spec(spec)
+        source = sdsc_spec.args[0]
+
+        self.assertEqual(
+            {str(dim): gap for dim, gap in source.backGap.items()},
+            {"y": 192, "x": 24},
+        )
+        self.assertEqual(int(source.strides[sympy.Symbol("x")]), 524_288)
 
 
 class TestSymbolKindKernelDerivedSymbolic(InductorTestCase):

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -299,6 +299,27 @@ def _calculate_device_stride(dev_dim_idx: int, device_size: list) -> int:
     return math.prod(device_size[-dev_dim_idx - 2 :])
 
 
+def _unambiguous_physical_axis(
+    arg: TensorArg, dim: Symbol, symbol_mapping: dict
+) -> int | None:
+    """Return the sole physical axis carrying ``dim``, if there is one.
+
+    Coarse tiling can leave a constant physical axis in ``device_size`` after
+    its loop role has moved to a ``LoopSpec``. Positional alignment between
+    the remaining logical dimensions and physical axes is then invalid. A
+    non-stick dimension with one coordinate dependency still has an
+    unambiguous physical axis, which is authoritative for its extent and
+    stride. Factorized dimensions intentionally return ``None`` here and keep
+    the established positional handling.
+    """
+    positions = [
+        index
+        for index, coordinate in enumerate(arg.device_coordinates[:-1])
+        if dim in coordinate.subs(symbol_mapping).free_symbols
+    ]
+    return positions[0] if len(positions) == 1 else None
+
+
 # SDSC dim labels for the conv2d padding (output-spatial) and window (kernel)
 # axes. These labels are owned by codegen -- see the note on CONV2D_DIM_LABELS in
 # constants.py -- so they are defined here rather than plumbed down from
@@ -1217,6 +1238,7 @@ def _create_sdsc_tensors(
         # tile_size; the full extent is that tile_size times every level's
         # supertile_count for that dim.
         sdsc_dim_advance: dict[Symbol, tuple[int, int]] = {}
+        tiled_constant_axes: set[int] = set()
         if arg.device_tile_advance_expr is not None:
             arg_elem_bytes = num_bytes(arg.device_dtype)
             for level_syms in op_spec.tiled_symbols:
@@ -1230,6 +1252,32 @@ def _create_sdsc_tensors(
                     trip_count = op_spec.tiled_symbol_trip_counts.get(sym, 1)
                     sdsc_sym = symbol_mapping[sym]
                     sdsc_dim_advance[sdsc_sym] = (tile_size, trip_count)
+                    element_advance = int(coeff)
+                    candidates = [
+                        axis
+                        for axis, coordinate in enumerate(arg.device_coordinates[:-1])
+                        if int(arg.device_size[axis]) > 1
+                        and not coordinate.subs(symbol_mapping).free_symbols
+                        and math.prod(arg.device_size[axis + 1 :]) == element_advance
+                    ]
+                    if len(candidates) == 1:
+                        tiled_constant_axes.add(candidates[0])
+
+        # A loop dimension tiled down to one disappears from the op's
+        # iteration space but may remain as a non-unit constant axis in the
+        # backing device layout. Fold that axis into the next inner logical
+        # dimension so SDSC emits the required gap between repetitions of the
+        # next outer role. The tile-advance coefficient identifies precisely
+        # which constant axis belongs to the surrounding LoopSpec.
+        gap_factor_by_inner_axis: dict[int, int] = {}
+        for tiled_axis in tiled_constant_axes:
+            for inner_axis in range(tiled_axis + 1, len(arg.device_coordinates) - 1):
+                coordinate = arg.device_coordinates[inner_axis].subs(symbol_mapping)
+                if coordinate.free_symbols:
+                    gap_factor_by_inner_axis[inner_axis] = gap_factor_by_inner_axis.get(
+                        inner_axis, 1
+                    ) * int(arg.device_size[tiled_axis])
+                    break
 
         scales: dict = {}
         strides: dict = {}
@@ -1298,6 +1346,14 @@ def _create_sdsc_tensors(
 
         for dim in dim_order:
             stride_idx = stride_dim_order.index(dim)
+            if dim is not stick_dim:
+                # A tiled-away loop role may survive as a constant physical
+                # axis. Locate every other role by coordinate identity so the
+                # constant slot cannot shift an outer role onto the wrong
+                # device extent (notably Hkv in native GQA with D=128).
+                physical_axis = _unambiguous_physical_axis(arg, dim, symbol_mapping)
+            else:
+                physical_axis = None
 
             if has_indirect_access and (
                 i in index_tensor_indices or is_indirect_value_tensor(arg)
@@ -1310,17 +1366,28 @@ def _create_sdsc_tensors(
             else:
                 scales[dim] = 1
 
+            if physical_axis is not None:
+                # Coarse-tiled layouts may contain constant physical axes that
+                # have no live loop role. Use the role's actual coordinate
+                # position so those axes contribute to its physical stride
+                # without being mistaken for a neighboring logical role.
+                physical_gap_factor = gap_factor_by_inner_axis.get(physical_axis, 1)
+                strides[dim] = (
+                    math.prod(arg.device_size[physical_axis:]) * physical_gap_factor
+                )
+                dim_device_stride = math.prod(arg.device_size[physical_axis + 1 :])
             # Injected stick dims don't exist in device_size; use stride=1.
-            if (
+            elif (
                 has_indirect_access
                 and i in index_tensor_indices
                 and dim in (index_stick_syms.values() if index_stick_syms else [])
             ):
                 strides[dim] = 1
+                dim_device_stride = 1
             else:
                 strides[dim] = _calculate_device_stride(stride_idx, arg.device_size)
+                dim_device_stride = math.prod(arg.device_size[-stride_idx - 1 :])
             offsets[dim] = 0
-            dim_device_stride = math.prod(arg.device_size[-stride_idx - 1 :])
 
             if dim is stick_dim and dim in sdsc_dim_advance:
                 # Authoritative fact from coarse_tile.py: the stick dim's
@@ -1353,7 +1420,11 @@ def _create_sdsc_tensors(
                 # enough unit dims are squeezed out; fall back to the iteration
                 # extent, which skips the padding corrections below.
                 size_idx = -stride_idx - 2
-                if -size_idx > len(arg.device_size):
+                if physical_axis is not None:
+                    dev_dim_size = arg.device_size[
+                        physical_axis
+                    ] * gap_factor_by_inner_axis.get(physical_axis, 1)
+                elif -size_idx > len(arg.device_size):
                     dev_dim_size = iteration_space[dim]
                 else:
                     dev_dim_size = arg.device_size[size_idx]
@@ -1382,10 +1453,13 @@ def _create_sdsc_tensors(
             # Same out-of-range case as the device_size lookup above: such a dim
             # has no device coordinate either, and this subscript would raise
             # before the size comparison below could skip it.
-            coord_idx = -stride_idx - 2
+            coord_idx = physical_axis if physical_axis is not None else -stride_idx - 2
             dim_coord = (
                 arg.device_coordinates[coord_idx]
-                if -coord_idx <= len(arg.device_coordinates)
+                if (
+                    physical_axis is not None
+                    or -coord_idx <= len(arg.device_coordinates)
+                )
                 else None
             )
             if (

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3856,6 +3856,10 @@ def _active_full_sizes_from_strides(
                 )
             result[k] = matching_sizes[0]
         else:
+            # No raw-layout stride survives in this coordinate space, so
+            # there is no authoritative padded backing extent to prefer.
+            # This is the dense-reshape fallback: recover the outer extent
+            # from the buffer's logical numel and the view stride.
             result[k] = sympy.prod(buffer_sizes) // active_strides[k]
     return result
 
@@ -5936,6 +5940,10 @@ def _is_dense_full_buffer_view(
     against the tile-local Hkv stride corrupts it.  We can recognize the safe
     case without view metadata when both layouts are dense and the affine
     index is a complete, bijective permutation/reshape of the new buffer.
+
+    A missed recognition is safe but conservative: ``False`` keeps the
+    caller on the general retile/``Unsupported`` path rather than accepting
+    an unproven full-buffer mapping.
     """
 
     def _equal(lhs: Expr, rhs: Expr) -> bool:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -130,11 +130,12 @@ logger = get_inductor_logger("coarse_tile")
 
 
 class _RetiledBufferInfo(NamedTuple):
-    """Host strides before and after a buffer is resized for a coarse tile."""
+    """Host shape/strides before and after a coarse-tile resize."""
 
     old_stride: tuple[Expr, ...]
     new_stride: tuple[Expr, ...]
     old_size: tuple[Expr, ...]
+    new_size: tuple[Expr, ...]
 
 
 class _ReadCopyHoistDecision(enum.Enum):
@@ -2128,7 +2129,7 @@ def _divide_ranges(
     _clear_cache(layout, _LAYOUT_FREE_SYMS_KEY)
     _clear_cache(op, _COMPUTED_BUF_FREE_SYMS_KEY)
     retiled_info = (
-        _RetiledBufferInfo(old_stride, tuple(layout.stride), old_size)
+        _RetiledBufferInfo(old_stride, tuple(layout.stride), old_size, tuple(new_size))
         if tiled_dims and old_stride != tuple(layout.stride)
         else None
     )
@@ -2280,7 +2281,10 @@ def _apply_plan(
                 prior = retiled_infos.get(name)
                 retiled_infos[name] = (
                     _RetiledBufferInfo(
-                        prior.old_stride, retiled_info.new_stride, prior.old_size
+                        prior.old_stride,
+                        retiled_info.new_stride,
+                        prior.old_size,
+                        retiled_info.new_size,
                     )
                     if prior is not None
                     else retiled_info
@@ -3029,7 +3033,10 @@ def _propagate_tiled_op(
     # Patch outside consumers and graph outputs to read full_buf.
     full_name = full_buf.get_name()
     retile_info = _RetiledBufferInfo(
-        old_stride, tuple(full_buf.layout.stride), old_size
+        old_stride,
+        tuple(full_buf.layout.stride),
+        old_size,
+        tuple(full_buf.layout.size),
     )
     _patch_consumers(
         outside_consumers, read_lookup_name, full_name, operations, retile_info
@@ -3808,6 +3815,51 @@ def _propagate_read_copy_named_dims(copy_buf: ComputedBuffer, dep: MemoryDep) ->
     )
 
 
+def _active_full_sizes_from_strides(
+    buffer_sizes: list[Expr],
+    buffer_strides: list[Expr],
+    active_strides: list[Expr],
+) -> list[Expr]:
+    """Recover physical extents for a read's active coordinate dimensions.
+
+    Adjacent active strides determine every inner extent.  The outermost
+    extent normally comes from ``numel / stride`` when the read is through a
+    reshape whose coordinate strides do not occur in the raw buffer layout.
+    That quotient is invalid for a prefix view of padded storage, however: a
+    ``[8, 8192, 128]`` cache may retain the backing allocation's
+    ``[1081344, 128, 1]`` strides (8448 rows per head), making the quotient
+    floor to seven.  When the outer active stride is present in the buffer's
+    own layout, its corresponding logical size is authoritative.
+    """
+    if not active_strides:
+        return []
+
+    order = sorted(range(len(active_strides)), key=lambda k: active_strides[k])
+    result: list[Expr] = [sympy.Integer(0)] * len(active_strides)
+    for pos, k in enumerate(order):
+        if pos + 1 < len(order):
+            result[k] = active_strides[order[pos + 1]] // active_strides[k]
+            continue
+
+        matching_sizes = [
+            size
+            for size, stride in zip(buffer_sizes, buffer_strides, strict=True)
+            if size != 1 and sympy.simplify(stride - active_strides[k]) == 0
+        ]
+        if matching_sizes:
+            # Non-overlapping layouts have at most one non-unit dimension at
+            # a given stride.  Unit dimensions were intentionally ignored.
+            if any(size != matching_sizes[0] for size in matching_sizes[1:]):
+                raise Unsupported(
+                    "cannot infer an unambiguous outer extent for active "
+                    f"stride {active_strides[k]} from sizes {matching_sizes}"
+                )
+            result[k] = matching_sizes[0]
+        else:
+            result[k] = sympy.prod(buffer_sizes) // active_strides[k]
+    return result
+
+
 def _insert_one_read_copy(
     sizing_op: ComputedBuffer,
     dep: MemoryDep,
@@ -3918,24 +3970,18 @@ def _insert_one_read_copy(
         # [Lq, D] before being read -- full_buf stays 1D/stride=[1] forever,
         # so no stride in its layout equals the viewed coordinate space's
         # per-dim strides). Derive full sizes purely from the active
-        # strides themselves instead: in a dense coordinate space, each
-        # dim's full size is (stride of the next-larger active dim) /
-        # (this dim's own stride), and the outermost active dim's full size
-        # is full_buf's total element count / its own stride -- true
-        # regardless of any reshape, since numel is view-invariant.
+        # strides themselves instead: each inner dim's physical extent is
+        # (stride of the next-larger active dim) / (this dim's own stride).
+        # The helper below resolves the outermost extent from an exact raw
+        # layout-stride match when possible, falling back to numel/stride for
+        # dense reshaped coordinate spaces.  The exact match matters for a
+        # prefix view of padded storage, whose numel excludes the padding.
         active_full_strides = [full_coeff[i] for i in active_idx]
-        order = sorted(range(len(active_idx)), key=lambda k: active_full_strides[k])
-        total_elems = sympy.prod(full_buf.get_size())
-        active_full_sizes: list[Expr] = [sympy.Integer(0)] * len(active_idx)
-        for pos, k in enumerate(order):
-            next_stride = (
-                active_full_strides[order[pos + 1]] if pos + 1 < len(order) else None
-            )
-            active_full_sizes[k] = (
-                total_elems // active_full_strides[k]
-                if next_stride is None
-                else next_stride // active_full_strides[k]
-            )
+        active_full_sizes = _active_full_sizes_from_strides(
+            list(full_buf.get_size()),
+            list(full_buf.get_stride()),
+            active_full_strides,
+        )
         active_tile_ranges = [dep.size[i] for i in active_idx]
         active_tile_strides = _compute_read_copy_strides(
             active_full_sizes, active_full_strides, active_tile_ranges
@@ -5633,6 +5679,7 @@ def _propagate_tiled_reduction_op(
         tuple(op.layout.stride),
         tuple(accum_full.layout.stride),
         op_size,
+        tuple(accum_full.layout.size),
     )
     _patch_consumers(all_consumers, buf_name, accum_name, operations, retile_info)
     if is_graph_output:
@@ -5757,6 +5804,19 @@ def _patch_consumers(
         if not hasattr(new_consumer, "loop_info"):
             continue
         new_loop_info = new_consumer.loop_info  # type: ignore[attr-defined]
+
+        # A Pass-1 read-copy is different from the original logical
+        # consumers covered below.  _insert_one_read_copy already builds its
+        # tiled_dims_per_read (and squeezed_advance_per_read) as an advancing
+        # read of the full logical source; Pass 3 is only making that source
+        # concrete by renaming the tile-local producer to its full copy-out.
+        # Keep that metadata verbatim.  Recomputing it from the copy op's own
+        # ranges is also structurally invalid when its dependency iteration
+        # space is squeezed relative to the sizing op whose raw dim numbers
+        # loop_tiled_dims retains (for example [[1], [2]] with a rank-2 copy).
+        if new_consumer.get_name().startswith("coarse_tile_read_copy_"):
+            continue
+
         new_reads = [
             r for r in new_consumer.get_read_writes().reads if isinstance(r, MemoryDep)
         ]
@@ -5812,30 +5872,182 @@ def _squeezed_retile_dims(
     derived against this buffer's (by-then tile-local, size-1) layout, so
     ``compute_tile_index``/``_retile_load_index`` has no atom to rescale for
     that dim: rescaling can only touch coefficients already present in the
-    incoming index (see ``_retile_load_index``'s docstring). Restricted to
-    dims where ``new_stride[d] != 0`` -- a dim that stays size-1 (or
-    genuinely strideless) in the new buffer too contributes nothing and
-    needs no term.
+    incoming index (see ``_retile_load_index``'s docstring).
 
-    Also restricted to dims where the *consumer's own* output is non-unit
-    for that raw dim (``consumer.data.ranges[d] != 1``). When the consumer's
-    own output dim is unit-size too (e.g. a coarse-tiled dim of extent 1,
-    such as B=1 when only H is tiled), there is no real loop variable for it
-    anywhere in this trace -- the consumer's own write index squeezes it out
-    exactly like the read did, so its only valid coordinate is the constant
-    0, not a symbol. Minting one anyway causes a name collision with an
-    unrelated, already-present symbol in the same dense numbering scheme
-    (both derived independently, so nothing stops them picking the same
-    name for two different logical slots), silently corrupting that other
-    symbol's coefficient instead of erroring.
+    A nonzero stride does *not* prove that a dimension became real: ordinary
+    contiguous tensors retain nonzero strides on size-one dimensions.  Add a
+    term only for an actual extent transition from one in the tile-local
+    buffer to non-one in the full buffer.  In particular, decode attention's
+    ``[B,H,Lq,D]`` output has ``Lq == 1`` in both buffers; treating its Lq
+    stride as evidence of growth aliases the flattened projection's output-N
+    loop onto Lq and turns a 4K read into a bogus 16M read.
+
+    Re-minting uses a raw producer dimension as a positional consumer output
+    dimension.  That mapping is valid only when the complete shapes agree.
+    Rank-changing or shape-changing views need semantic view metadata to
+    recover a missing coordinate; guessing positionally would silently read
+    the wrong dimension, so reject such a true-growth case explicitly.
     """
-    return [
+    grown_dims = [
         d
         for d in range(len(info.old_size))
         if info.old_size[d] == 1
+        and info.new_size[d] != 1
         and info.new_stride[d] != sympy.S.Zero
-        and int(consumer.data.ranges[d]) != 1
     ]
+    if not grown_dims:
+        return []
+
+    consumer_ranges = tuple(consumer.data.ranges)
+    if len(consumer_ranges) < len(info.new_size):
+        raise Unsupported(
+            "coarse_tile: cannot restore dimensions squeezed from a retiled "
+            "producer through a rank-changing consumer view; "
+            f"producer old_size={info.old_size}, new_size={info.new_size}, "
+            f"consumer ranges={consumer_ranges}, grown_dims={grown_dims}"
+        )
+
+    # A unit consumer axis selects coordinate zero and needs no symbol.  For
+    # every axis that does need a symbol, require the complete output shape to
+    # match the producer shape before treating raw positions as identities.
+    result = [d for d in grown_dims if int(consumer_ranges[d]) != 1]
+    if result and any(
+        sympy.simplify(actual - expected) != 0
+        for actual, expected in zip(consumer_ranges, info.new_size)
+    ):
+        raise Unsupported(
+            "coarse_tile: cannot restore dimensions squeezed from a retiled "
+            "producer through a shape-changing consumer view; "
+            f"producer old_size={info.old_size}, new_size={info.new_size}, "
+            f"consumer ranges={consumer_ranges}, grown_dims={grown_dims}"
+        )
+    return result
+
+
+def _is_dense_full_buffer_view(
+    index: Expr, info: _RetiledBufferInfo, consumer: ComputedBuffer
+) -> bool:
+    """Whether ``index`` already densely addresses the complete new buffer.
+
+    A rank-changing view can flatten a dimension that was unit-sized in the
+    tile but is real in the full buffer.  For example, GQA flattens
+    ``[Hkv=8, group=4]`` into ``[heads=32]``.  Its flattened coefficient is
+    already the full buffer's group stride, so decomposing that coefficient
+    against the tile-local Hkv stride corrupts it.  We can recognize the safe
+    case without view metadata when both layouts are dense and the affine
+    index is a complete, bijective permutation/reshape of the new buffer.
+    """
+
+    def _equal(lhs: Expr, rhs: Expr) -> bool:
+        return sympy.simplify(lhs - rhs) == 0
+
+    target_dims = [
+        (stride, size)
+        for size, stride in zip(info.new_size, info.new_stride, strict=True)
+        if size != 1
+    ]
+    if any(stride == sympy.S.Zero for stride, _ in target_dims):
+        return False
+    target_dims.sort(key=lambda pair: pair[0])
+    running = sympy.Integer(1)
+    for stride, size in target_dims:
+        if not _equal(stride, running):
+            return False
+        running *= size
+    target_numel = running
+
+    consumer_ranges = tuple(consumer.data.ranges)
+    reduction_ranges = tuple(getattr(consumer.data, "reduction_ranges", None) or ())
+
+    try:
+        atoms, offset = decompose_index_for_tiling(
+            index, {sym: 1 for sym in index.free_symbols}
+        )
+    except Unsupported:
+        return False
+    if offset != 0 or len(atoms) != len(index.free_symbols):
+        return False
+
+    symbol_numbers: dict[sympy.Symbol, int] = {}
+    for _coefficient, symbol in atoms:
+        name = symbol.name
+        split = len(name)
+        while split > 0 and name[split - 1].isdigit():
+            split -= 1
+        if split == len(name):
+            return False
+        symbol_numbers[symbol] = int(name[split:])
+
+    nonunit_ranges = [size for size in consumer_ranges if size != 1]
+    all_ranges = [*consumer_ranges, *reduction_ranges]
+    nonunit_all_ranges = [size for size in all_ranges if size != 1]
+    nonunit_reduction_ranges = [size for size in reduction_ranges if size != 1]
+    extent_maps: list[dict[sympy.Symbol, Expr]] = []
+    # Some retraces preserve raw dimension numbers (_i1/_i2/_i3 when raw dim
+    # 0 is unit), while extract_read_writes renumbers them densely (d0/d1/d2).
+    if all(number < len(consumer_ranges) for number in symbol_numbers.values()):
+        extent_maps.append(
+            {
+                symbol: consumer_ranges[number]
+                for symbol, number in symbol_numbers.items()
+            }
+        )
+    if all(number < len(nonunit_ranges) for number in symbol_numbers.values()):
+        extent_maps.append(
+            {
+                symbol: nonunit_ranges[number]
+                for symbol, number in symbol_numbers.items()
+            }
+        )
+    if all(number < len(all_ranges) for number in symbol_numbers.values()):
+        extent_maps.append(
+            {symbol: all_ranges[number] for symbol, number in symbol_numbers.items()}
+        )
+    if all(number < len(nonunit_all_ranges) for number in symbol_numbers.values()):
+        extent_maps.append(
+            {
+                symbol: nonunit_all_ranges[number]
+                for symbol, number in symbol_numbers.items()
+            }
+        )
+    # Some inner_fn traces use an independent r0/r1/... namespace for
+    # reduction indices rather than continuing the d-numbering after outputs.
+    if all(
+        symbol.name.lstrip("_").startswith("r") and number < len(reduction_ranges)
+        for symbol, number in symbol_numbers.items()
+    ):
+        extent_maps.append(
+            {
+                symbol: reduction_ranges[number]
+                for symbol, number in symbol_numbers.items()
+            }
+        )
+    if all(
+        symbol.name.lstrip("_").startswith("r")
+        and number < len(nonunit_reduction_ranges)
+        for symbol, number in symbol_numbers.items()
+    ):
+        extent_maps.append(
+            {
+                symbol: nonunit_reduction_ranges[number]
+                for symbol, number in symbol_numbers.items()
+            }
+        )
+
+    for extent_map in extent_maps:
+        indexed_dims = sorted(
+            ((coefficient, extent_map[symbol]) for coefficient, symbol in atoms),
+            key=lambda pair: pair[0],
+        )
+        running = sympy.Integer(1)
+        for coefficient, extent in indexed_dims:
+            if not _equal(coefficient, running):
+                break
+            running *= extent
+        else:
+            if _equal(running, target_numel):
+                return True
+    return False
 
 
 def _index_var_prefix(free_symbols: "OrderedSet[Expr] | set[Expr]") -> str:
@@ -5939,7 +6151,13 @@ def _index_already_at_new_scale(
         if s != 1 and t != 0
     ]
     old_set = {info.old_stride[d] for d in dims}
-    new_set = {info.new_stride[d] for d in dims}
+    # A dimension that a later nested tiling level squeezes to one has a zero
+    # final stride.  It cannot contribute an atom to an already-retiled load,
+    # so including that zero in ``new_set`` makes the equality test fail and
+    # causes the fresh index to be rewritten a second time.  In GQA this
+    # misidentifies the surviving Hkv coefficient as the now-squeezed group
+    # coefficient and drops Hkv from every downstream read.
+    new_set = {info.new_stride[d] for d in dims if info.new_stride[d] != sympy.S.Zero}
     return coeffs == new_set and coeffs != old_set
 
 
@@ -5948,13 +6166,22 @@ def _retile_load_index(
     index: Expr,
     info: _RetiledBufferInfo,
     consumer: "ComputedBuffer | None" = None,
+    preserve_target_stride_atoms: bool = False,
 ) -> Expr:
     """Rewrite a load index using compute_tile_index.  Raises Unsupported if
     the index cannot be decomposed (non-affine, or stride not in info.old_stride).
 
     Used by _RetileLoadIndexHandler and _NameAndIndexSwapHandler during real
-    codegen.  In both cases the incoming index has coefficients equal to
-    info.old_stride and the call rewrites them to info.new_stride.
+    codegen.  Most incoming index coefficients are expressed in
+    ``info.old_stride`` and are rewritten to ``info.new_stride``.  An outside
+    view can, however, derive some coefficients from the full destination
+    layout before its producer is redirected.  In the tile-to-full direction,
+    ``preserve_target_stride_atoms`` keeps an atom whose coefficient exactly
+    matches an unambiguous regular ``new_stride`` entry and exceeds the source
+    tile's maximum physical offset (proving that it cannot be source-local).
+    Remaining atoms still use ``compute_tile_index`` so view-combined
+    tile-local coefficients retain the general decomposition supported by that
+    helper.
 
     When ``consumer`` is given AND has no loop_info of its own (i.e. it is an
     "outside" consumer with no enclosing coarse-tile loop nest), any dim
@@ -5992,9 +6219,18 @@ def _retile_load_index(
     """
 
     loop_syms = index.free_symbols
-    if not loop_syms:
+    dense_full_view = (
+        consumer is not None
+        and preserve_target_stride_atoms
+        and _is_dense_full_buffer_view(index, info, consumer)
+    )
+    if dense_full_view:
         new_index = index
-    elif _index_already_at_new_scale(index, loop_syms, info):
+    elif not loop_syms:
+        new_index = index
+    elif not preserve_target_stride_atoms and _index_already_at_new_scale(
+        index, loop_syms, info
+    ):
         # This consumer's index was traced *after* the producer's layout was
         # already mutated to new_stride (e.g. built/retraced during Pass
         # 1/2/3, from a same-name replacement object resynced into group_ops
@@ -6005,15 +6241,51 @@ def _retile_load_index(
         # issue found via test_copy_running_max_4d_H4_Lq4.
         new_index = index
     else:
+        index_to_retile = index
+        preserved_index = sympy.S.Zero
+        if preserve_target_stride_atoms:
+            source_max_offset = sympy.simplify(
+                sum(
+                    (old_size - 1) * old_stride
+                    for old_size, old_stride in zip(info.old_size, info.old_stride)
+                    if old_size != 1 and old_stride != sympy.S.Zero
+                )
+            )
+            regular_source_strides = {
+                sympy.simplify(old_stride)
+                for old_size, old_stride in zip(info.old_size, info.old_stride)
+                if old_size != 1 and old_stride != sympy.S.Zero
+            }
+            regular_target_strides = {
+                sympy.simplify(new_stride)
+                for new_size, new_stride in zip(info.new_size, info.new_stride)
+                if new_size != 1
+                and new_stride != sympy.S.Zero
+                and sympy.simplify(new_stride) not in regular_source_strides
+            }
+            for term in index.as_ordered_terms():
+                term_syms = term.free_symbols & loop_syms
+                if len(term_syms) != 1:
+                    continue
+                sym = next(iter(term_syms))
+                coeff = sympy.simplify(term.coeff(sym))
+                exceeds_source_span = sympy.simplify(
+                    coeff - source_max_offset
+                ).is_positive
+                if coeff in regular_target_strides and exceeds_source_span is True:
+                    preserved_index += term
+            index_to_retile = sympy.expand(index - preserved_index)
+
         new_index = compute_tile_index(
-            index,
+            index_to_retile,
             {sym: 1 for sym in loop_syms},
             info.old_size,
             info.old_stride,
             info.new_stride,
         )
+        new_index += preserved_index
 
-    if consumer is not None:
+    if consumer is not None and not dense_full_view:
         for d in _squeezed_retile_dims(info, consumer):
             # A consumer read by multiple _patch_consumers redirects (e.g.
             # buf24 reading both a _divide_ranges-mutated buffer and a
@@ -6041,10 +6313,15 @@ def _retile_load_index(
                 new_index += sym * info.new_stride[d]
 
     logger.debug(
-        "coarse_tile: retiled load index for %s: %s -> %s",
+        "coarse_tile: retiled load index for %s: %s -> %s "
+        "(old_size=%s old_stride=%s new_size=%s new_stride=%s)",
         buf_name,
         index,
         new_index,
+        info.old_size,
+        info.old_stride,
+        info.new_size,
+        info.new_stride,
     )
     return new_index
 
@@ -6089,7 +6366,11 @@ class _NameAndIndexSwapHandler(WrapperHandler):
     def load(self, name, index):
         if name in self._infos_by_old_name:
             index = _retile_load_index(
-                name, index, self._infos_by_old_name[name], self._consumer
+                name,
+                index,
+                self._infos_by_old_name[name],
+                self._consumer,
+                preserve_target_stride_atoms=True,
             )
         return super().load(self._name_map.get(name, name), index)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes coarse-tiling and SuperDSC handling for nested tiles whose logical axes are reshaped, squeezed, flattened, or backed by padded physical storage.

- Carries both the pre-tile and full destination shapes when retiled producers are patched into consumers.
- Preserves already-full dense view indices and target-stride atoms instead of applying a second, lossy retile.
- Rejects ambiguous positional reconstruction through rank- or shape-changing consumers.
- Keeps Pass-1 read-copy tiling metadata intact when its source is later redirected to a full copy-out.
- Recovers read-copy extents from physical strides, including prefix views of padded storage.
- Makes SuperDSC map non-stick logical roles to their physical coordinate axes when a tiled-away constant axis remains in the layout.
- Keeps factorized stick dimensions on the established positional path.

This is the infrastructure dependency for native GQA PR #4277, but the fixes and regression coverage are independent of GQA.

#### Special notes for your reviewer:

The SuperDSC mapping is deliberately restricted to non-stick roles. During validation, applying it to a factorized stick dimension treated floor(D/64) as the whole D axis and inflated a 64-element stride to 65,536; the existing 1D sub-dimension end-to-end test caught that regression.

The new rank/shape-changing rejection is a forward safety guard discovered while developing #4277. No known non-GQA production graph currently reaches it. The rejection is covered directly with a synthetic unit test; supported reshape and transpose paths are covered by compiled end-to-end tests.

Focused validation:

- 411 coarse-tiling/codegen tests passed.
- The original full PR matrix passed all 150 applicable checks with 2 skips.
- A one-off DXP “Incorrect chunk size” error passed on isolated rerun and did not reproduce in the full matrix.
- 7 view/transpose coarse-tile end-to-end tests passed.
- Pre-commit, ruff, and mypy passed.

#### Does this PR introduce a user-facing change?

No.