### PR TITLE
Improve SWA graph reuse, generic masks, and kernel robustness

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_sliding_window_attention_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_sliding_window_attention_config.yaml
@@ -3,3 +3,5 @@ test_suite_config:
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_sliding_window_attention.py
       unlisted_test_mode: mandatory_success
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_pass_utils.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_kv_window.py
+++ b/tests/inductor/test_kv_window.py
@@ -45,9 +45,6 @@ import torch
 from torch_spyre._inductor.sliding_window_plan import (
     STICK,
     SlidingWindowPlan,
-    band_batch,
-    band_valid_start,
-    check_valid_start,
     check_window_read,
     default_buffer_origin,
     plan_sliding_window,
@@ -792,29 +789,14 @@ def _device_cache(differentiation, seqlen_kv=256, kvheads=HEADS):
 
 
 def _call_op(cache, plan, block_index, which, value_cache=None):
-    """which: 0 -> k_win, 1 -> v_win, 2 -> band.
+    """which: 0 -> k_win, 1 -> v_win.
 
     value_cache defaults to cache: most callers only inspect k_win or the
-    band, where key and value being the same tensor is harmless. A test that
-    inspects v_win must pass a value_cache that actually differs from cache,
-    or a v_win sourced from the wrong tensor would pass unnoticed.
-
-    The window and the band are separate ops -- they share no arguments -- so
-    2 dispatches to the mask rather than indexing a third return value.
+    key window, where key and value being the same tensor is harmless. A test
+    that inspects v_win must pass a value_cache that actually differs from
+    cache, or a v_win sourced from the wrong tensor would pass unnoticed.
     """
     value_cache = cache if value_cache is None else value_cache
-    q_start, _ = plan.block_q_range(block_index)
-    if which == 2:
-        return torch.ops.spyre.window_band_mask(
-            plan.read_start(block_index),
-            plan.q_block,
-            plan.buffer_width,
-            plan.q_kv_offset + q_start,
-            plan.window_size,
-            plan.is_causal,
-            cache.dtype,
-            cache.device,
-        )
     return torch.ops.spyre.kv_window(
         cache,
         value_cache,
@@ -846,10 +828,10 @@ class TestKVWindowOp:
     does it.
     """
 
-    def test_window_and_band(self):
-        # All three outputs of one call, per block, so a failure names both which
-        # output was wrong and which block. Not cat-ed across blocks: that is the
-        # defect the class docstring describes, and nothing on this path does it.
+    def test_key_and_value_windows(self):
+        # Both outputs of one call, per block, so a failure names both which output
+        # was wrong and which block. Not cat-ed across blocks: that is the defect
+        # the class docstring describes, and nothing on this path does it.
         plan = _plan(256, 256, 64)
 
         def fn(k, v):
@@ -857,13 +839,12 @@ class TestKVWindowOp:
             if k.device.type == "spyre":
                 return tuple(
                     _call_op(k, plan, n, which, value_cache=v)
-                    for which in (0, 1, 2)
+                    for which in (0, 1)
                     for n in blocks
                 )
             return tuple(
                 [_reference_window(k, plan, n, transpose=True) for n in blocks]
                 + [_reference_window(v, plan, n) for n in blocks]
-                + [_reference_band(plan, n) for n in blocks]
             )
 
         compare_with_cpu(fn, _device_cache(1), _device_cache(2), run_eager=False)
@@ -897,53 +878,6 @@ class TestKVWindowOp:
             return _reference_window(k, plan, 0, transpose=True)
 
         compare_with_cpu(fn, cache, cache, run_eager=False)
-
-    def test_decode_band_is_all_zeros(self):
-        # What the body relies on to skip the band add entirely.
-        plan = _plan(1, 4096, 64, q_block=1)
-        cache = _device_cache(3, seqlen_kv=4096)
-        assert torch.equal(
-            _reference_band(plan, 0), torch.zeros((1, 1, 1, 64), dtype=torch.float16)
-        )
-
-        def fn(k, v):
-            if k.device.type == "spyre":
-                return _call_op(k, plan, 0, 2)
-            return _reference_band(plan, 0)
-
-        compare_with_cpu(fn, cache, cache, run_eager=False)
-
-
-class TestValidStart:
-    """The three torch-free helpers behind the valid_start band."""
-
-    def test_none_and_all_zero_mask_nothing(self):
-        # A caller with no padding must not pay for a per-batch band.
-        assert band_valid_start(None) is None
-        assert band_valid_start([]) is None
-        assert band_valid_start([0, 0]) is None
-        assert band_batch([0, 0]) == 1
-
-    def test_uniform_nonzero_stays_broadcast(self):
-        # Same threshold for every sequence: one row of band, broadcast over batch.
-        assert band_valid_start([40, 40]) == [40, 40]
-        assert band_batch([40, 40]) == 1
-
-    def test_ragged_widens_to_batch(self):
-        assert band_batch([0, 40]) == 2
-        assert band_batch([40, 40, 7]) == 3
-
-    def test_check_rejects_wrong_length(self):
-        assert "2 entries" in check_valid_start([0, 40], 3, 1088)
-
-    def test_check_rejects_out_of_range(self):
-        assert "outside" in check_valid_start([-1], 1, 1088)
-        assert "outside" in check_valid_start([1089], 1, 1088)
-
-    def test_check_accepts_valid(self):
-        assert check_valid_start(None, 4, 1088) is None
-        assert check_valid_start([0, 40], 2, 1088) is None
-        assert check_valid_start([1088], 1, 1088) is None
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_pass_utils.py
+++ b/tests/inductor/test_pass_utils.py
@@ -1,0 +1,62 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+import sympy
+from torch._inductor.dependencies import WeakDep
+
+import torch_spyre._inductor.pass_utils as pass_utils
+
+
+def test_reduction_iteration_space_ignores_weak_dependencies(monkeypatch):
+    """Mutation ordering edges describe no loop dimensions."""
+
+    class FakeReduction:
+        pass
+
+    output_dim = sympy.Symbol("d0")
+    reduction_dim = sympy.Symbol("r0")
+    write = types.SimpleNamespace(ranges={output_dim: 4})
+    read = types.SimpleNamespace(ranges={output_dim: 4, reduction_dim: 8})
+    node = types.SimpleNamespace(
+        node=types.SimpleNamespace(data=FakeReduction()),
+        read_writes=types.SimpleNamespace(
+            writes=[write],
+            reads=[WeakDep("mutation", "buffer"), read],
+        ),
+    )
+    monkeypatch.setattr(pass_utils, "Reduction", FakeReduction)
+
+    assert pass_utils.iteration_space(node) == {output_dim: 4, reduction_dim: 8}
+
+
+def test_late_operation_registration_does_not_reuse_a_removed_slot():
+    """Late graph edits must not derive names from the shortened op list."""
+
+    old_ops = [types.SimpleNamespace(operation_name=f"op{i}") for i in range(4)]
+    graph = types.SimpleNamespace(
+        # Model a pass that removed op1 but retained its name registry entry.
+        operations=[old_ops[0], old_ops[2], old_ops[3]],
+        name_to_op={op.operation_name: op for op in old_ops},
+        qualify_name=lambda name: name,
+    )
+    inserted = types.SimpleNamespace(operation_name=None)
+
+    name = pass_utils.register_operation_after_graph_edit(graph, inserted)
+
+    assert name == "op4"
+    assert graph.operations[-1] is inserted
+    assert graph.name_to_op["op3"] is old_ops[3]
+    assert graph.name_to_op["op4"] is inserted

--- a/tests/inductor/test_sliding_window_attention.py
+++ b/tests/inductor/test_sliding_window_attention.py
@@ -66,11 +66,11 @@ def _attention_mask(
     return mask.unsqueeze(1)
 
 
-def _attention(q, k, v, attention_mask, window_size, scale=None):
+def _attention(q, k, v, attention_mask, window_size, scale=None, is_causal=True):
     """Dispatch: the runtime-mask op on Spyre, masked SDPA on CPU."""
     if q.device.type == "spyre":
         return torch.ops.spyre.sliding_window_attention(
-            q, k, v, attention_mask, window_size, scale
+            q, k, v, attention_mask, window_size, is_causal, scale
         )
     return F.scaled_dot_product_attention(
         q,
@@ -358,6 +358,28 @@ class TestSlidingWindowAttention(unittest.TestCase):
         query = cached_randn((1, 4, 128, 256), differentiation=1, dtype=torch.float16)
         _compare_attention(query, key, value, 128, query_end=128, valid_start=[17])
 
+    def test_non_causal_prefill_reads_future_keys_outside_the_causal_plan(self):
+        # A bidirectional vision block can make an early query attend a much
+        # later key. The causal plan for block 0 reads only rows [0, 128), so
+        # allowing row 255 proves the generic path scans the complete cache.
+        query, key, value = _inputs(1, 8, 2, 256, 256)
+        mask = _attention_mask(1, 256, 256, 64)
+        mask[0, 0, 0, 255] = 0
+        expected = _attention(query, key, value, mask, 64, None, False)
+
+        compiled = torch.compile(_attention, backend="inductor")
+        actual = compiled(
+            query.to("spyre"),
+            key.to("spyre"),
+            value.to("spyre"),
+            mask.to("spyre"),
+            64,
+            None,
+            False,
+        ).cpu()
+
+        torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.1)
+
 
 class TestCompactCache(unittest.TestCase):
     """Runtime masks over compact caches with changing logical positions."""
@@ -529,6 +551,37 @@ class TestCompactCache(unittest.TestCase):
         device_args = [tensor.to("spyre") for tensor in (query, key, value)]
         actual = [
             compiled(*device_args, mask.to("spyre"), window).cpu() for mask in masks
+        ]
+
+        assert torch._dynamo.utils.counters["stats"]["unique_graphs"] == 1
+        for got, want in zip(actual, expected):
+            torch.testing.assert_close(got, want, atol=0.1, rtol=0.1)
+
+    def test_non_causal_prefill_mask_reuses_one_graph_as_values_change(self):
+        """Different bidirectional regions remain runtime tensor data."""
+        batch, heads, kvheads, seqlen, window = 1, 8, 2, 256, 64
+        query, key, value = _inputs(batch, heads, kvheads, seqlen, seqlen)
+        masks = []
+        for future_key in (191, 255):
+            mask = _attention_mask(batch, seqlen, seqlen, window)
+            mask[0, 0, 0, future_key] = 0
+            masks.append(mask)
+        expected = [
+            _attention(query, key, value, mask, window, None, False) for mask in masks
+        ]
+
+        torch._dynamo.utils.counters.clear()
+        compiled = torch.compile(_attention, backend="inductor")
+        device_args = [tensor.to("spyre") for tensor in (query, key, value)]
+        actual = [
+            compiled(
+                *device_args,
+                mask.to("spyre"),
+                window,
+                None,
+                False,
+            ).cpu()
+            for mask in masks
         ]
 
         assert torch._dynamo.utils.counters["stats"]["unique_graphs"] == 1

--- a/tests/inductor/test_sliding_window_attention.py
+++ b/tests/inductor/test_sliding_window_attention.py
@@ -35,26 +35,50 @@ import torch.nn.functional as F
 from utils_inductor import cached_randn, compare_with_cpu
 
 
-def _band_mask(
-    seqlen_q: int, seqlen_kv: int, window_size: int, dtype=torch.float16
-) -> torch.Tensor:
-    """Full [1, 1, Lq, Lkv] causal sliding-window mask -- the definition."""
-    q_pos = torch.arange(seqlen_kv - seqlen_q, seqlen_kv).unsqueeze(-1)
-    k_pos = torch.arange(seqlen_kv).unsqueeze(0)
-    delta = q_pos - k_pos
-    allowed = (delta >= 0) & (delta < window_size)
-    mask = torch.zeros(seqlen_q, seqlen_kv, dtype=dtype)
+def _attention_mask(
+    batch,
+    seqlen_q,
+    capacity,
+    window_size,
+    *,
+    query_end=None,
+    buffer_origin=0,
+    valid_start=None,
+    dtype=torch.float16,
+):
+    """Runtime causal-window mask in physical cache coordinates."""
+    query_end = capacity if query_end is None else query_end
+    q_pos = torch.arange(query_end - seqlen_q, query_end).view(1, seqlen_q, 1)
+    k_pos = torch.arange(capacity).view(1, 1, capacity) + buffer_origin
+    allowed = (q_pos >= k_pos) & (q_pos - k_pos < window_size)
+    if valid_start is not None:
+        starts = torch.tensor(valid_start).view(batch, 1, 1)
+        allowed = allowed & (k_pos >= starts)
+    allowed = allowed.expand(batch, -1, -1)
+
+    # Padding rows can have no legal key. Their outputs are discarded, but the
+    # kernel still needs a defined softmax so they cannot poison later layers.
+    has_attendable_key = allowed.any(dim=-1, keepdim=True)
+    first_column = torch.arange(capacity).view(1, 1, capacity) == 0
+    allowed = allowed | (~has_attendable_key & first_column)
+    mask = torch.zeros((batch, seqlen_q, capacity), dtype=dtype)
     mask.masked_fill_(~allowed, float("-inf"))
-    return mask.unsqueeze(0).unsqueeze(0)
+    return mask.unsqueeze(1)
 
 
-def _attention(q, k, v, window_size):
-    """Dispatch: the op on spyre, the masked reference on CPU."""
+def _attention(q, k, v, attention_mask, window_size, scale=None):
+    """Dispatch: the runtime-mask op on Spyre, masked SDPA on CPU."""
     if q.device.type == "spyre":
-        return torch.ops.spyre.sliding_window_attention(q, k, v, window_size, True)
-    mask = _band_mask(q.size(2), k.size(2), window_size)
+        return torch.ops.spyre.sliding_window_attention(
+            q, k, v, attention_mask, window_size, scale
+        )
     return F.scaled_dot_product_attention(
-        q, k, v, mask, enable_gqa=q.size(1) != k.size(1)
+        q,
+        k,
+        v,
+        attention_mask,
+        scale=scale,
+        enable_gqa=q.size(1) != k.size(1),
     )
 
 
@@ -136,87 +160,6 @@ def _compact_kv_at(batch, kvheads, capacity, buffer_origin, cache_seqlen, head_d
     return key, value
 
 
-def _rolled_reference(query, key, value, window_size, cache_seqlen, buffer_origin=None):
-    """CPU reference for a compact cache: key/value are ``[B, Hkv, capacity,
-    E]``, not the full-length cache ``_band_mask`` assumes.
-
-    Physical row ``j`` holds logical position ``buffer_origin + j``
-    (``buffer_origin = max(0, cache_seqlen - capacity)``), per
-    ``spyre::kv_window``'s row-order precondition -- the band is built
-    directly in that coordinate space.
-
-    The ``k_pos < cache_seqlen`` term is redundant with the causal one here,
-    and kept deliberately: ``spyre::window_band_mask`` drops it on the
-    argument that the two can never disagree, so stating it independently
-    means a regression in the production causal band shows up as a
-    disagreement rather than a shared mistake.
-    """
-    capacity = key.size(2)
-    seqlen_q = query.size(2)
-    if buffer_origin is None:
-        buffer_origin = max(0, cache_seqlen - capacity)
-    q_pos = torch.arange(cache_seqlen - seqlen_q, cache_seqlen).unsqueeze(-1)
-    k_pos = torch.arange(capacity, dtype=torch.int64) + buffer_origin
-    delta = q_pos - k_pos.unsqueeze(0)
-    allowed = (delta >= 0) & (delta < window_size) & (k_pos.unsqueeze(0) < cache_seqlen)
-    mask = torch.zeros(seqlen_q, capacity, dtype=torch.float16)
-    mask.masked_fill_(~allowed, float("-inf"))
-    mask = mask.unsqueeze(0).unsqueeze(0)
-    return F.scaled_dot_product_attention(
-        query, key, value, mask, enable_gqa=query.size(1) != key.size(1)
-    )
-
-
-def _reference_with_valid_start(
-    query, key, value, window_size, valid_start, cache_seqlen=None
-):
-    """``_rolled_reference`` for an exactly-full buffer, additionally excluding
-    physical rows below ``valid_start`` -- the left-padding an offset-and-length
-    window cannot express.
-
-    One threshold per batch entry, so ``valid_start`` is a list even when uniform.
-    """
-    seqlen_q, capacity = query.size(2), key.size(2)
-    cache_seqlen = capacity if cache_seqlen is None else cache_seqlen
-    rows = torch.arange(seqlen_q) + (cache_seqlen - seqlen_q)
-    columns = torch.arange(capacity)
-    delta = rows.unsqueeze(-1) - columns.unsqueeze(0)
-    allowed = ((delta >= 0) & (delta < window_size)).unsqueeze(0)
-    starts = torch.tensor(valid_start).view(-1, 1, 1)
-    row_grid = rows.view(1, -1, 1)
-    column_grid = columns.view(1, 1, -1)
-    allowed = (allowed & (column_grid >= starts)) | (
-        (row_grid < starts) & (column_grid == row_grid)
-    )
-    mask = torch.zeros(allowed.shape, dtype=query.dtype)
-    mask.masked_fill_(~allowed, float("-inf"))
-    return F.scaled_dot_product_attention(
-        query, key, value, attn_mask=mask.unsqueeze(1)
-    )
-
-
-def _valid_start_attention(q, k, v, window_size, valid_start, cache_seqlen=None):
-    """The op with an explicit valid_start on spyre, the reference on CPU."""
-    cache_seqlen = k.size(2) if cache_seqlen is None else cache_seqlen
-    if q.device.type == "spyre":
-        return torch.ops.spyre.sliding_window_attention(
-            q, k, v, window_size, True, None, cache_seqlen, 0, valid_start
-        )
-    return _reference_with_valid_start(q, k, v, window_size, valid_start, cache_seqlen)
-
-
-def _rolled_attention(q, k, v, window_size, cache_seqlen, buffer_origin=None):
-    """Dispatch for a compact cache: the op on spyre with an explicit
-    ``cache_seqlen`` (it cannot default to ``k.size(2)`` here -- that IS the
-    distinction under test), the compact reference on CPU.
-    """
-    if q.device.type == "spyre":
-        return torch.ops.spyre.sliding_window_attention(
-            q, k, v, window_size, True, None, cache_seqlen, buffer_origin
-        )
-    return _rolled_reference(q, k, v, window_size, cache_seqlen, buffer_origin)
-
-
 def _decode_mask(batch, capacity, write_row, window_size, valid_start, dtype):
     """Fixed-shape runtime mask over physical rows of an anchored cache."""
     columns = torch.arange(capacity).view(1, 1, 1, capacity)
@@ -231,22 +174,40 @@ def _decode_mask(batch, capacity, write_row, window_size, valid_start, dtype):
 
 
 def _runtime_mask_attention(q, k, v, window_size, scale, decode_mask):
-    """Dispatch the tensor-mask API on Spyre and masked SDPA on CPU."""
-    if q.device.type == "spyre":
-        return torch.ops.spyre.sliding_window_attention(
-            q,
-            k,
-            v,
-            window_size,
-            True,
-            scale,
-            None,
-            None,
-            None,
-            decode_mask,
-        )
-    return F.scaled_dot_product_attention(
-        q, k, v, attn_mask=decode_mask, scale=scale, enable_gqa=q.size(1) != k.size(1)
+    """Compatibility wrapper with scalar arguments after tensor inputs."""
+    return _attention(q, k, v, decode_mask, window_size, scale)
+
+
+def _compare_attention(
+    query,
+    key,
+    value,
+    window_size,
+    *,
+    query_end=None,
+    buffer_origin=0,
+    valid_start=None,
+    scale=None,
+):
+    mask = _attention_mask(
+        query.size(0),
+        query.size(2),
+        key.size(2),
+        window_size,
+        query_end=query_end,
+        buffer_origin=buffer_origin,
+        valid_start=valid_start,
+        dtype=query.dtype,
+    )
+    compare_with_cpu(
+        _attention,
+        query,
+        key,
+        value,
+        mask,
+        window_size,
+        scale,
+        run_eager=False,
     )
 
 
@@ -259,17 +220,17 @@ class TestSlidingWindowAttention(unittest.TestCase):
     def test_prefill_mha(self):
         # 4 blocks of 64, a 128-row window each.
         query, key, value = _inputs(1, 8, 8, 256, 256)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_prefill_mha_wider_window(self):
         # W=128 -> a 192-row window.
         query, key, value = _inputs(1, 8, 8, 256, 256)
-        compare_with_cpu(_attention, query, key, value, 128, run_eager=False)
+        _compare_attention(query, key, value, 128)
 
     def test_prefill_gqa(self):
         # 8 query heads from 2 kv heads; the expand is inside the op.
         query, key, value = _inputs(1, 8, 2, 256, 256)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_prefill_transposed_query_view(self):
         # Q projections arrive physically as [B, Lq, H, D] and are viewed as
@@ -278,97 +239,80 @@ class TestSlidingWindowAttention(unittest.TestCase):
             (1, 256, 8, 64), differentiation=1, dtype=torch.float16
         ).transpose(1, 2)
         _, key, value = _inputs(1, 8, 8, 256, 256)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_prefill_batch(self):
         query, key, value = _inputs(2, 4, 4, 256, 256)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_prefill_head_dim_128(self):
         # Two sticks per row where 64 is one; the placement is in rows.
         query, key, value = _inputs(1, 8, 8, 256, 256, head_dim=128)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_prefill_long(self):
         # 32 blocks — a long unrolled loop rather than a handful.
         query, key, value = _inputs(1, 8, 8, 2048, 2048)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_decode(self):
         # One block reading exactly W rows: 64 of 4096.
         query, key, value = _inputs(1, 8, 8, 1, 4096)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_decode_gqa(self):
         query, key, value = _inputs(1, 8, 2, 1, 512)
-        compare_with_cpu(_attention, query, key, value, 128, run_eager=False)
+        _compare_attention(query, key, value, 128)
 
     def test_decode_long_cache(self):
         query, key, value = _inputs(1, 8, 8, 1, 8192)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_chunked_prefill(self):
         # Lq < Lkv: prefill continuing a warm cache.
         query, key, value = _inputs(1, 8, 8, 128, 512)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_query_length_not_a_multiple_of_the_block(self):
         # Lq=100 padded to 128 at the front. Back-padding would shift every
         # real row 28 positions and this would catch it.
         query, key, value = _inputs(1, 8, 8, 100, 256)
-        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 64)
 
     def test_decode_window_not_a_multiple_of_the_stick(self):
         # The only decode case where the band add is emitted: W=64/128 mask
         # nothing and skip it.
         query, key, value = _inputs(1, 8, 8, 1, 4096)
-        compare_with_cpu(_attention, query, key, value, 100, run_eager=False)
+        _compare_attention(query, key, value, 100)
 
     def test_window_not_a_multiple_of_the_stick(self):
         # W=100: buffer rounds up to a stick, band masks by the true window.
         query, key, value = _inputs(1, 8, 8, 256, 256)
-        compare_with_cpu(_attention, query, key, value, 100, run_eager=False)
+        _compare_attention(query, key, value, 100)
 
     def test_window_covering_the_whole_cache(self):
         # buffer_width == seqlen_kv: degenerate, not a separate code path.
         query, key, value = _inputs(1, 8, 8, 128, 128)
-        compare_with_cpu(_attention, query, key, value, 128, run_eager=False)
-
-    def test_explicit_cache_seqlen_matches_the_default(self):
-        # cache_seqlen defaults to the cache's allocated rows, so passing that
-        # same number explicitly must not move a single window.
-        query, key, value = _inputs(1, 8, 8, 128, 512)
-
-        def attention(q, k, v, window_size):
-            if q.device.type == "spyre":
-                return torch.ops.spyre.sliding_window_attention(
-                    q, k, v, window_size, True, None, k.size(2)
-                )
-            mask = _band_mask(q.size(2), k.size(2), window_size)
-            return F.scaled_dot_product_attention(q, k, v, mask)
-
-        compare_with_cpu(attention, query, key, value, 64, run_eager=False)
+        _compare_attention(query, key, value, 128)
 
     def test_ragged_query_and_window_together(self):
         # An off-by-one in the pad arithmetic can survive either alone.
         query, key, value = _inputs(1, 8, 2, 100, 512)
-        compare_with_cpu(_attention, query, key, value, 100, run_eager=False)
+        _compare_attention(query, key, value, 100)
 
     def test_prefill_head_dim_256_gqa(self):
         # Gemma 4's sliding layers: 16 query heads from 8 KV heads, head_dim 256,
         # W=1024. head_dim 256 is four sticks per row where the rest of this file
         # uses one or two, and kv_window hands back a transposed slice.
         query, key, value = _inputs(1, 16, 8, 512, 512, head_dim=256)
-        compare_with_cpu(_attention, query, key, value, 1024, run_eager=False)
+        _compare_attention(query, key, value, 1024)
 
     def test_prefill_reads_a_prefix_of_a_larger_cache(self):
         # A short prefill can use the compact decode allocation already. Its KV
         # slice has a larger backing stride than its 64-row logical width.
         key, value = _compact_kv(1, 2, 1088, 64, head_dim=256)
         query = cached_randn((1, 4, 64, 256), differentiation=1, dtype=torch.float16)
-        compare_with_cpu(
-            _rolled_attention, query, key, value, 1024, 64, 0, run_eager=False
-        )
+        _compare_attention(query, key, value, 1024, query_end=64)
 
     def test_prefill_from_pinned_larger_cache_with_left_padding(self):
         # Model caches pin the sequence dimension outermost for indirect writes.
@@ -376,15 +320,15 @@ class TestSlidingWindowAttention(unittest.TestCase):
         # and a load-bearing left-padding band at head_dim=256.
         key, value = _compact_kv(1, 4, 256, 128, head_dim=256)
         query = cached_randn((1, 4, 128, 256), differentiation=1, dtype=torch.float16)
-        expected = _valid_start_attention(query, key, value, 128, [17], 128)
+        mask = _attention_mask(1, 128, 256, 128, query_end=128, valid_start=[17])
+        expected = _attention(query, key, value, mask, 128)
 
-        compiled = torch.compile(_valid_start_attention, backend="inductor")
+        compiled = torch.compile(_attention, backend="inductor")
         actual = compiled(
             query.to("spyre"),
             _to_cache_position_first(key),
             _to_cache_position_first(value),
-            128,
-            [17],
+            mask.to("spyre"),
             128,
         ).cpu()
 
@@ -394,16 +338,16 @@ class TestSlidingWindowAttention(unittest.TestCase):
         """Separate pinned-cache layout from the load-bearing padding band."""
         key, value = _compact_kv(1, 4, 256, 128, head_dim=256)
         query = cached_randn((1, 4, 128, 256), differentiation=1, dtype=torch.float16)
-        expected = _rolled_attention(query, key, value, 128, 128, 0)
+        mask = _attention_mask(1, 128, 256, 128, query_end=128)
+        expected = _attention(query, key, value, mask, 128)
 
-        compiled = torch.compile(_rolled_attention, backend="inductor")
+        compiled = torch.compile(_attention, backend="inductor")
         actual = compiled(
             query.to("spyre"),
             _to_cache_position_first(key),
             _to_cache_position_first(value),
+            mask.to("spyre"),
             128,
-            128,
-            0,
         ).cpu()
 
         torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.1)
@@ -412,26 +356,11 @@ class TestSlidingWindowAttention(unittest.TestCase):
         """Separate the load-bearing padding band from the pinned-cache layout."""
         key, value = _compact_kv(1, 4, 256, 128, head_dim=256)
         query = cached_randn((1, 4, 128, 256), differentiation=1, dtype=torch.float16)
-        compare_with_cpu(
-            _valid_start_attention,
-            query,
-            key,
-            value,
-            128,
-            [17],
-            128,
-            run_eager=False,
-        )
+        _compare_attention(query, key, value, 128, query_end=128, valid_start=[17])
 
 
 class TestCompactCache(unittest.TestCase):
-    """cache_seqlen != key.size(2): a compact cache, rolled or still filling.
-
-    These check end-to-end numeric correctness of placement + masking +
-    attention against a compact (not full-length) cache. They do NOT isolate
-    the unwritten-tail question: an overshooting buffer is excluded by the
-    causal term alone, since window_band_mask carries no cache_seqlen term.
-    """
+    """Runtime masks over compact caches with changing logical positions."""
 
     def setUp(self):
         torch._dynamo.reset()
@@ -447,8 +376,13 @@ class TestCompactCache(unittest.TestCase):
         query = cached_randn(
             (batch, heads, 1, 64), differentiation=1, dtype=torch.float16
         )
-        compare_with_cpu(
-            _rolled_attention, query, key, value, window, cache_seqlen, run_eager=False
+        _compare_attention(
+            query,
+            key,
+            value,
+            window,
+            query_end=cache_seqlen,
+            buffer_origin=cache_seqlen - capacity,
         )
 
     def test_warmup_cache_at_a_non_aligned_seqlen(self):
@@ -462,9 +396,7 @@ class TestCompactCache(unittest.TestCase):
         query = cached_randn(
             (batch, heads, 1, 64), differentiation=1, dtype=torch.float16
         )
-        compare_with_cpu(
-            _rolled_attention, query, key, value, window, cache_seqlen, run_eager=False
-        )
+        _compare_attention(query, key, value, window, query_end=cache_seqlen)
 
     def test_capacity_equals_window_decode(self):
         # HF's StaticSlidingWindowLayer geometry: exactly window_size rows for
@@ -477,8 +409,13 @@ class TestCompactCache(unittest.TestCase):
         query = cached_randn(
             (batch, heads, 1, 64), differentiation=1, dtype=torch.float16
         )
-        compare_with_cpu(
-            _rolled_attention, query, key, value, window, cache_seqlen, run_eager=False
+        _compare_attention(
+            query,
+            key,
+            value,
+            window,
+            query_end=cache_seqlen,
+            buffer_origin=cache_seqlen - capacity,
         )
 
     def test_block_granular_eviction_with_an_explicit_buffer_origin(self):
@@ -496,15 +433,13 @@ class TestCompactCache(unittest.TestCase):
         query = cached_randn(
             (batch, heads, 1, 64), differentiation=1, dtype=torch.float16
         )
-        compare_with_cpu(
-            _rolled_attention,
+        _compare_attention(
             query,
             key,
             value,
             window,
-            cache_seqlen,
-            buffer_origin,
-            run_eager=False,
+            query_end=cache_seqlen,
+            buffer_origin=buffer_origin,
         )
 
     def test_multiblock_rolled_prefill_with_distinct_read_starts(self):
@@ -519,8 +454,13 @@ class TestCompactCache(unittest.TestCase):
         query = cached_randn(
             (batch, heads, seqlen_q, 64), differentiation=1, dtype=torch.float16
         )
-        compare_with_cpu(
-            _rolled_attention, query, key, value, window, cache_seqlen, run_eager=False
+        _compare_attention(
+            query,
+            key,
+            value,
+            window,
+            query_end=cache_seqlen,
+            buffer_origin=cache_seqlen - capacity,
         )
 
     def test_anchored_decode_gemma4(self):
@@ -532,9 +472,7 @@ class TestCompactCache(unittest.TestCase):
         # the integration to work at all.
         key, value = _compact_kv(1, 8, 1088, 1088, head_dim=256)
         query = cached_randn((1, 16, 1, 256), differentiation=1, dtype=torch.float16)
-        compare_with_cpu(
-            _rolled_attention, query, key, value, 1024, 1088, run_eager=False
-        )
+        _compare_attention(query, key, value, 1024, query_end=1088)
 
     def test_runtime_decode_mask_reuses_one_graph_as_values_change(self):
         """Position and padding travel as tensor data, never Python guards."""
@@ -562,53 +500,87 @@ class TestCompactCache(unittest.TestCase):
         for got, want in zip(actual, expected):
             torch.testing.assert_close(got, want, atol=0.1, rtol=0.1)
 
-    def test_valid_start_excludes_padded_columns(self):
-        # 17 rows of left padding inside the window: without valid_start they are
-        # attended, and the reference proves the difference is visible.
+    def test_runtime_prefill_mask_reuses_one_graph_as_values_change(self):
+        """Chunk origin and per-sequence padding stay out of Python guards."""
+        batch, heads, kvheads, seqlen_q, capacity, window = 2, 8, 2, 64, 128, 64
+        query, key, value = _inputs(batch, heads, kvheads, seqlen_q, capacity)
+        masks = [
+            _attention_mask(
+                batch,
+                seqlen_q,
+                capacity,
+                window,
+                query_end=64,
+                valid_start=[0, 17],
+            ),
+            _attention_mask(
+                batch,
+                seqlen_q,
+                capacity,
+                window,
+                query_end=128,
+                valid_start=[0, 3],
+            ),
+        ]
+        expected = [_attention(query, key, value, mask, window) for mask in masks]
+
+        torch._dynamo.utils.counters.clear()
+        compiled = torch.compile(_attention, backend="inductor")
+        device_args = [tensor.to("spyre") for tensor in (query, key, value)]
+        actual = [
+            compiled(*device_args, mask.to("spyre"), window).cpu() for mask in masks
+        ]
+
+        assert torch._dynamo.utils.counters["stats"]["unique_graphs"] == 1
+        for got, want in zip(actual, expected):
+            torch.testing.assert_close(got, want, atol=0.1, rtol=0.1)
+
+    def test_runtime_mask_skips_fully_masked_leading_chunks(self):
+        # A late chunked-prefill block can have no valid key in the first 512-row
+        # KV chunk. The online softmax must carry zero weight across that chunk,
+        # not form -inf - -inf and poison the later live window with NaNs.
+        batch, heads, kvheads, seqlen_q, capacity, window = 1, 8, 2, 64, 1024, 64
+        query, key, value = _inputs(batch, heads, kvheads, seqlen_q, capacity)
+        mask = _attention_mask(
+            batch,
+            seqlen_q,
+            capacity,
+            window,
+            query_end=capacity,
+        )
+        expected = _attention(query, key, value, mask, window)
+
+        compiled = torch.compile(_attention, backend="inductor")
+        actual = compiled(
+            query.to("spyre"),
+            key.to("spyre"),
+            value.to("spyre"),
+            mask.to("spyre"),
+            window,
+        ).cpu()
+
+        assert torch.isfinite(actual).all()
+        torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.1)
+
+    def test_runtime_mask_excludes_padded_columns(self):
+        # Position and left padding are both runtime tensor data.
         key, value = _compact_kv(1, 8, 1088, 1088)
         query = cached_randn((1, 8, 64, 64), differentiation=1, dtype=torch.float16)
-        compare_with_cpu(
-            _valid_start_attention, query, key, value, 1024, [17], run_eager=False
-        )
+        _compare_attention(query, key, value, 1024, valid_start=[17])
 
-    def test_valid_start_prefill_padding_rows_stay_finite(self):
+    def test_runtime_mask_prefill_padding_rows_stay_finite(self):
         # The first 17 query rows are left padding. Each receives a harmless
         # diagonal rather than an all--inf band, so it cannot poison later layers
         # with NaN K/V values; callers discard or zero these query outputs.
         key, value = _compact_kv(1, 8, 1088, 64)
         query = cached_randn((1, 8, 64, 64), differentiation=1, dtype=torch.float16)
-        compare_with_cpu(
-            _valid_start_attention,
-            query,
-            key,
-            value,
-            1024,
-            [17],
-            64,
-            run_eager=False,
-        )
+        _compare_attention(query, key, value, 1024, query_end=64, valid_start=[17])
 
-    def test_valid_start_per_sequence(self):
-        # Ragged batch: the band widens to [B, 1, q, W'] only for this case.
+    def test_runtime_mask_per_sequence_padding(self):
+        # Each batch entry carries its own padding threshold in tensor data.
         key, value = _compact_kv(2, 8, 1088, 1088)
         query = cached_randn((2, 8, 64, 64), differentiation=1, dtype=torch.float16)
-        compare_with_cpu(
-            _valid_start_attention, query, key, value, 1024, [0, 40], run_eager=False
-        )
-
-    def test_all_zero_valid_start_matches_no_valid_start(self):
-        # The fast path must be numerically identical to passing nothing.
-        key, value = _compact_kv(1, 8, 1088, 1088)
-        query = cached_randn((1, 8, 64, 64), differentiation=1, dtype=torch.float16)
-
-        def attention(q, k, v, window_size):
-            if q.device.type == "spyre":
-                return torch.ops.spyre.sliding_window_attention(
-                    q, k, v, window_size, True, None, k.size(2), 0, [0]
-                )
-            return _rolled_reference(q, k, v, window_size, k.size(2))
-
-        compare_with_cpu(attention, query, key, value, 1024, run_eager=False)
+        _compare_attention(query, key, value, 1024, valid_start=[0, 40])
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_sliding_window_attention.py
+++ b/tests/inductor/test_sliding_window_attention.py
@@ -97,6 +97,26 @@ def _compact_kv(batch, kvheads, capacity, cache_seqlen, head_dim=64):
     return key, value
 
 
+def _to_cache_position_first(tensor):
+    """Move a KV cache with the device layout used by model cache updates."""
+    from torch_spyre._C import SpyreTensorLayout, get_device_dtype
+
+    batch, kvheads, capacity, head_dim = tensor.shape
+    eps = SpyreTensorLayout(list(tensor.shape), tensor.dtype).elems_per_stick()
+    layout = SpyreTensorLayout(
+        device_size=[capacity, kvheads, (head_dim + eps - 1) // eps, batch, eps],
+        stride_map=[
+            head_dim,
+            capacity * head_dim,
+            eps,
+            kvheads * capacity * head_dim,
+            1,
+        ],
+        device_dtype=get_device_dtype(tensor.dtype),
+    )
+    return tensor.to("spyre", device_layout=layout)
+
+
 def _compact_kv_at(batch, kvheads, capacity, buffer_origin, cache_seqlen, head_dim=64):
     """Like ``_compact_kv`` but for a buffer whose physical row 0 holds
     ``buffer_origin`` rather than the exactly-full ``cache_seqlen -
@@ -197,6 +217,39 @@ def _rolled_attention(q, k, v, window_size, cache_seqlen, buffer_origin=None):
     return _rolled_reference(q, k, v, window_size, cache_seqlen, buffer_origin)
 
 
+def _decode_mask(batch, capacity, write_row, window_size, valid_start, dtype):
+    """Fixed-shape runtime mask over physical rows of an anchored cache."""
+    columns = torch.arange(capacity).view(1, 1, 1, capacity)
+    starts = torch.tensor(valid_start).view(batch, 1, 1, 1)
+    allowed = (
+        (columns <= write_row)
+        & (columns > write_row - window_size)
+        & (columns >= starts)
+    )
+    mask = torch.zeros((batch, 1, 1, capacity), dtype=dtype)
+    return mask.masked_fill(~allowed, float("-inf"))
+
+
+def _runtime_mask_attention(q, k, v, window_size, scale, decode_mask):
+    """Dispatch the tensor-mask API on Spyre and masked SDPA on CPU."""
+    if q.device.type == "spyre":
+        return torch.ops.spyre.sliding_window_attention(
+            q,
+            k,
+            v,
+            window_size,
+            True,
+            scale,
+            None,
+            None,
+            None,
+            decode_mask,
+        )
+    return F.scaled_dot_product_attention(
+        q, k, v, attn_mask=decode_mask, scale=scale, enable_gqa=q.size(1) != k.size(1)
+    )
+
+
 class TestSlidingWindowAttention(unittest.TestCase):
     """Shapes the op supports, against the masked reference."""
 
@@ -216,6 +269,15 @@ class TestSlidingWindowAttention(unittest.TestCase):
     def test_prefill_gqa(self):
         # 8 query heads from 2 kv heads; the expand is inside the op.
         query, key, value = _inputs(1, 8, 2, 256, 256)
+        compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
+
+    def test_prefill_transposed_query_view(self):
+        # Q projections arrive physically as [B, Lq, H, D] and are viewed as
+        # [B, H, Lq, D]. The tiled window must follow logical, not stride, axes.
+        query = cached_randn(
+            (1, 256, 8, 64), differentiation=1, dtype=torch.float16
+        ).transpose(1, 2)
+        _, key, value = _inputs(1, 8, 8, 256, 256)
         compare_with_cpu(_attention, query, key, value, 64, run_eager=False)
 
     def test_prefill_batch(self):
@@ -298,6 +360,68 @@ class TestSlidingWindowAttention(unittest.TestCase):
         # uses one or two, and kv_window hands back a transposed slice.
         query, key, value = _inputs(1, 16, 8, 512, 512, head_dim=256)
         compare_with_cpu(_attention, query, key, value, 1024, run_eager=False)
+
+    def test_prefill_reads_a_prefix_of_a_larger_cache(self):
+        # A short prefill can use the compact decode allocation already. Its KV
+        # slice has a larger backing stride than its 64-row logical width.
+        key, value = _compact_kv(1, 2, 1088, 64, head_dim=256)
+        query = cached_randn((1, 4, 64, 256), differentiation=1, dtype=torch.float16)
+        compare_with_cpu(
+            _rolled_attention, query, key, value, 1024, 64, 0, run_eager=False
+        )
+
+    def test_prefill_from_pinned_larger_cache_with_left_padding(self):
+        # Model caches pin the sequence dimension outermost for indirect writes.
+        # Exercise the fused recurrence with both the model's pinned cache layout
+        # and a load-bearing left-padding band at head_dim=256.
+        key, value = _compact_kv(1, 4, 256, 128, head_dim=256)
+        query = cached_randn((1, 4, 128, 256), differentiation=1, dtype=torch.float16)
+        expected = _valid_start_attention(query, key, value, 128, [17], 128)
+
+        compiled = torch.compile(_valid_start_attention, backend="inductor")
+        actual = compiled(
+            query.to("spyre"),
+            _to_cache_position_first(key),
+            _to_cache_position_first(value),
+            128,
+            [17],
+            128,
+        ).cpu()
+
+        torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.1)
+
+    def test_prefill_from_pinned_larger_cache_without_left_padding(self):
+        """Separate pinned-cache layout from the load-bearing padding band."""
+        key, value = _compact_kv(1, 4, 256, 128, head_dim=256)
+        query = cached_randn((1, 4, 128, 256), differentiation=1, dtype=torch.float16)
+        expected = _rolled_attention(query, key, value, 128, 128, 0)
+
+        compiled = torch.compile(_rolled_attention, backend="inductor")
+        actual = compiled(
+            query.to("spyre"),
+            _to_cache_position_first(key),
+            _to_cache_position_first(value),
+            128,
+            128,
+            0,
+        ).cpu()
+
+        torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.1)
+
+    def test_prefill_left_padding_head_dim_256(self):
+        """Separate the load-bearing padding band from the pinned-cache layout."""
+        key, value = _compact_kv(1, 4, 256, 128, head_dim=256)
+        query = cached_randn((1, 4, 128, 256), differentiation=1, dtype=torch.float16)
+        compare_with_cpu(
+            _valid_start_attention,
+            query,
+            key,
+            value,
+            128,
+            [17],
+            128,
+            run_eager=False,
+        )
 
 
 class TestCompactCache(unittest.TestCase):
@@ -411,6 +535,32 @@ class TestCompactCache(unittest.TestCase):
         compare_with_cpu(
             _rolled_attention, query, key, value, 1024, 1088, run_eager=False
         )
+
+    def test_runtime_decode_mask_reuses_one_graph_as_values_change(self):
+        """Position and padding travel as tensor data, never Python guards."""
+        batch, heads, kvheads, capacity, window = 2, 8, 2, 256, 128
+        query, key, value = _inputs(batch, heads, kvheads, 1, capacity)
+        masks = [
+            _decode_mask(batch, capacity, 128, window, [0, 17], query.dtype),
+            _decode_mask(batch, capacity, 191, window, [0, 3], query.dtype),
+            _decode_mask(batch, capacity, 255, window, [0, 0], query.dtype),
+        ]
+        expected = [
+            _runtime_mask_attention(query, key, value, window, 1.0, mask)
+            for mask in masks
+        ]
+
+        torch._dynamo.utils.counters.clear()
+        compiled = torch.compile(_runtime_mask_attention, backend="inductor")
+        device_args = [tensor.to("spyre") for tensor in (query, key, value)]
+        actual = [
+            compiled(*device_args, window, 1.0, mask.to("spyre")).cpu()
+            for mask in masks
+        ]
+
+        assert torch._dynamo.utils.counters["stats"]["unique_graphs"] == 1
+        for got, want in zip(actual, expected):
+            torch.testing.assert_close(got, want, atol=0.1, rtol=0.1)
 
     def test_valid_start_excludes_padded_columns(self):
         # 17 rows of left padding inside the window: without valid_start they are

--- a/tests/inductor/test_sliding_window_attention.py
+++ b/tests/inductor/test_sliding_window_attention.py
@@ -147,7 +147,9 @@ def _rolled_reference(query, key, value, window_size, cache_seqlen, buffer_origi
     )
 
 
-def _reference_with_valid_start(query, key, value, window_size, valid_start):
+def _reference_with_valid_start(
+    query, key, value, window_size, valid_start, cache_seqlen=None
+):
     """``_rolled_reference`` for an exactly-full buffer, additionally excluding
     physical rows below ``valid_start`` -- the left-padding an offset-and-length
     window cannot express.
@@ -155,12 +157,17 @@ def _reference_with_valid_start(query, key, value, window_size, valid_start):
     One threshold per batch entry, so ``valid_start`` is a list even when uniform.
     """
     seqlen_q, capacity = query.size(2), key.size(2)
-    rows = torch.arange(seqlen_q) + (capacity - seqlen_q)
+    cache_seqlen = capacity if cache_seqlen is None else cache_seqlen
+    rows = torch.arange(seqlen_q) + (cache_seqlen - seqlen_q)
     columns = torch.arange(capacity)
     delta = rows.unsqueeze(-1) - columns.unsqueeze(0)
-    allowed = (delta >= 0) & (delta < window_size)
+    allowed = ((delta >= 0) & (delta < window_size)).unsqueeze(0)
     starts = torch.tensor(valid_start).view(-1, 1, 1)
-    allowed = allowed.unsqueeze(0) & (columns.view(1, 1, -1) >= starts)
+    row_grid = rows.view(1, -1, 1)
+    column_grid = columns.view(1, 1, -1)
+    allowed = (allowed & (column_grid >= starts)) | (
+        (row_grid < starts) & (column_grid == row_grid)
+    )
     mask = torch.zeros(allowed.shape, dtype=query.dtype)
     mask.masked_fill_(~allowed, float("-inf"))
     return F.scaled_dot_product_attention(
@@ -168,13 +175,14 @@ def _reference_with_valid_start(query, key, value, window_size, valid_start):
     )
 
 
-def _valid_start_attention(q, k, v, window_size, valid_start):
+def _valid_start_attention(q, k, v, window_size, valid_start, cache_seqlen=None):
     """The op with an explicit valid_start on spyre, the reference on CPU."""
+    cache_seqlen = k.size(2) if cache_seqlen is None else cache_seqlen
     if q.device.type == "spyre":
         return torch.ops.spyre.sliding_window_attention(
-            q, k, v, window_size, True, None, k.size(2), 0, valid_start
+            q, k, v, window_size, True, None, cache_seqlen, 0, valid_start
         )
-    return _reference_with_valid_start(q, k, v, window_size, valid_start)
+    return _reference_with_valid_start(q, k, v, window_size, valid_start, cache_seqlen)
 
 
 def _rolled_attention(q, k, v, window_size, cache_seqlen, buffer_origin=None):
@@ -411,6 +419,23 @@ class TestCompactCache(unittest.TestCase):
         query = cached_randn((1, 8, 64, 64), differentiation=1, dtype=torch.float16)
         compare_with_cpu(
             _valid_start_attention, query, key, value, 1024, [17], run_eager=False
+        )
+
+    def test_valid_start_prefill_padding_rows_stay_finite(self):
+        # The first 17 query rows are left padding. Each receives a harmless
+        # diagonal rather than an all--inf band, so it cannot poison later layers
+        # with NaN K/V values; callers discard or zero these query outputs.
+        key, value = _compact_kv(1, 8, 1088, 64)
+        query = cached_randn((1, 8, 64, 64), differentiation=1, dtype=torch.float16)
+        compare_with_cpu(
+            _valid_start_attention,
+            query,
+            key,
+            value,
+            1024,
+            [17],
+            64,
+            run_eager=False,
         )
 
     def test_valid_start_per_sequence(self):

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -1065,18 +1065,25 @@ def sliding_window_attention(  # type: ignore[empty-body]
     MUST pass its true origin, or every read lands past the data, in bounds
     and unmasked. See ``SlidingWindowPlan`` for both.
 
-    ``valid_start`` is one **logical** column coordinate per batch entry;
-    columns strictly below it are never attended, whatever the window says. It
-    exists for left-padded prompts, whose pad columns sit inside the window and
+    ``valid_start`` is one **logical** column coordinate per batch entry; valid
+    query rows never attend columns strictly below it, whatever the window says.
+    It exists for left-padded prompts, whose pad columns sit inside the window and
     which an offset-and-length window cannot otherwise exclude. ``None`` or
     all-zero costs nothing; a uniform threshold keeps the band broadcast over
     batch; only a ragged one widens it. Coordinates are logical, matching
     ``cache_seqlen``, so a caller passing ``buffer_origin=0`` passes physical
-    row indices.
+    row indices. Query rows below ``valid_start`` are padding; the implementation
+    gives each such row its diagonal to avoid an all-masked softmax. Compiler-added
+    front-padding rows whose logical coordinate predates the cache instead retain
+    the first resident column. These outputs are unspecified and callers discard
+    or zero them.
 
-    Allocation contract: ``Lk >= round_up_to_64(window_size + Lq - 1)`` for
-    the ``Lq`` of this call, so prefill long sequences in chunks;
-    ``rejection_reason`` names the required row count when ``Lk`` is short.
+    Allocation contract: each internally tiled query block needs
+    ``round_up_to_64(window_size + q_block - 1)`` rows (``q_block=64`` for
+    prefill and 1 for decode), and the allocation/origin pair must also contain
+    the logical rows through ``cache_seqlen - 1``. Long prefills are tiled by the
+    decomposition rather than requiring ``window_size + Lq`` physical rows;
+    ``rejection_reason`` names the exact failure when the cache is too short.
     Zero-fill the allocation -- a buffer may overshoot the written prefix,
     and though causal masking discards those scores the multiply still
     happens, and an additive ``-inf`` cannot rescue a ``NaN``.
@@ -1146,7 +1153,12 @@ def window_band_mask(
     today, would need one.
 
     ``valid_start``, if given, additionally excludes columns strictly below
-    its per-batch-entry threshold -- see ``sliding_window_attention``.
+    its per-batch-entry threshold -- see ``sliding_window_attention``. Query
+    rows below the same threshold are padding themselves; each keeps only its
+    causal diagonal so the softmax remains defined. Any compiler-added front-pad
+    row whose diagonal predates the resident buffer keeps its first column instead.
+    Callers discard or zero these query rows, but no row receives an all-``-inf``
+    score band.
 
     Built entirely on CPU so the in-place ops stay opaque to torch.compile,
     matching spyre.causal_mask's rationale.
@@ -1159,14 +1171,27 @@ def window_band_mask(
     else:
         allowed = delta.abs() < window_size
     effective = band_valid_start(valid_start)
-    if effective is None:
-        allowed = allowed.unsqueeze(0)
-    elif min(effective) == max(effective):
-        # Uniform threshold: still one broadcast row, not one per sequence.
-        allowed = (allowed & (column.unsqueeze(0) >= effective[0])).unsqueeze(0)
-    else:
-        starts = torch.tensor(effective, device="cpu").view(-1, 1, 1)
-        allowed = allowed.unsqueeze(0) & (column.view(1, 1, -1) >= starts)
+    allowed = allowed.unsqueeze(0)
+    if effective is not None:
+        # A uniform threshold remains one broadcast row. For a padded query row,
+        # retain its diagonal solely to avoid an undefined all-masked softmax;
+        # valid rows still exclude every column below valid_start.
+        starts = torch.tensor(
+            [effective[0]] if min(effective) == max(effective) else effective,
+            device="cpu",
+        ).view(-1, 1, 1)
+        rows = row.view(1, -1, 1)
+        columns = column.view(1, 1, -1)
+        allowed = (allowed & (columns >= starts)) | (
+            (rows < starts) & (columns == rows)
+        )
+    # A ragged query is front-padded to q_block by the decomposition. Its synthetic
+    # leading coordinates can predate physical row 0, so even the diagonal rule
+    # above has no matching column. Those outputs are sliced away, but keeping one
+    # zero-filled resident column avoids manufacturing NaNs inside the graph.
+    has_attendable_key = allowed.any(dim=-1, keepdim=True)
+    first_column = torch.arange(buffer_width, device="cpu").view(1, 1, -1) == 0
+    allowed = allowed | (~has_attendable_key & first_column)
     mask_cpu = torch.zeros(allowed.shape, dtype=dtype, device="cpu")
     mask_cpu.masked_fill_(~allowed, float("-inf"))
     return mask_cpu.unsqueeze(1).to(device=device)

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -1042,6 +1042,7 @@ def sliding_window_attention(  # type: ignore[empty-body]
     value: torch.Tensor,
     attention_mask: torch.Tensor,
     window_size: int,
+    is_causal: bool,
     scale: Optional[float] = None,
 ) -> torch.Tensor:
     """
@@ -1054,16 +1055,20 @@ def sliding_window_attention(  # type: ignore[empty-body]
     unwritten cache rows, and left padding. Keeping that state in a tensor means
     changing a decode position does not specialize the compiled graph.
 
-    ``window_size`` and ``scale`` are static model configuration. For square
-    prefill, ``window_size`` lets the implementation read only each query
-    block's physical KV window. Other shapes, including anchored single-token
-    decode and chunked prefill, consume the fixed-shape mask over the complete
-    cache allocation in bounded chunks. Use a compact cache for decode so this
-    remains proportional to the sliding window rather than the model context.
+    ``window_size``, ``is_causal``, and ``scale`` are static model
+    configuration. ``is_causal=True`` promises that the mask never allows a
+    future key, which lets square prefill read only each query block's physical
+    causal window. ``is_causal=False`` makes no causal-layout assumption and
+    reads the complete physical cache in bounded chunks; this supports masks
+    with bidirectional regions such as Gemma 4's vision blocks. Other shapes,
+    including anchored single-token decode and chunked prefill, also consume the
+    complete fixed-shape cache because their position is runtime mask data. Use
+    a compact cache for decode so that work remains proportional to the sliding
+    window rather than the model context.
 
-    The operation is causal-only by contract; callers express the exact causal
-    boundary in ``attention_mask``. Zero-fill unwritten cache rows: masked scores
-    are still computed, and adding a mask cannot rescue a NaN.
+    The tensor mask always defines the exact attention semantics. Zero-fill
+    unwritten cache rows: masked scores are still computed, and adding a mask
+    cannot rescue a NaN.
 
     MUST be called under torch.compile(backend="inductor") on the spyre
     device; the real lowering is in decompositions.py. This eager body is
@@ -1079,6 +1084,7 @@ def _(
     value: torch.Tensor,
     attention_mask: torch.Tensor,
     window_size: int,
+    is_causal: bool,
     scale: Optional[float] = None,
 ) -> torch.Tensor:
     return query.new_empty(query.size())

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -25,7 +25,6 @@ from torch_spyre.ops.fallbacks import warn_fallback
 from .constants import FP8_E4M3FN_MAX
 from .errors import Unsupported
 from .scratchpad.lx_context_switching import mark_lx_safe
-from .sliding_window_plan import band_batch, band_valid_start
 
 aten = torch.ops.aten
 
@@ -1041,64 +1040,30 @@ def sliding_window_attention(  # type: ignore[empty-body]
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
+    attention_mask: torch.Tensor,
     window_size: int,
-    is_causal: bool = True,
     scale: Optional[float] = None,
-    cache_seqlen: Optional[int] = None,
-    buffer_origin: Optional[int] = None,
-    valid_start: Optional[list[int]] = None,
-    decode_mask: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Sliding-window attention entry point.
 
-    query: [B, Hq, Lq, D]; key/value: [B, Hkv, Lk, D], GQA expanded
-    internally. Query row i, at cache coordinate ``cache_seqlen - Lq + i``,
-    attends column c iff ``0 <= coordinate - c < window_size``.
-    ``is_causal=False`` raises Unsupported.
+    ``query`` is ``[B, Hq, Lq, D]`` and ``key``/``value`` are
+    ``[B, Hkv, Lk, D]``; GQA is expanded internally. ``attention_mask`` is a
+    runtime additive mask with shape ``[B, 1, Lq, Lk]``. It is the sole source
+    of position-dependent state: it carries causality, the sliding window,
+    unwritten cache rows, and left padding. Keeping that state in a tensor means
+    changing a decode position does not specialize the compiled graph.
 
-    ``cache_seqlen`` is how many tokens the cache has seen, as distinct from
-    ``Lk``, the rows it allocates. Defaults to ``Lk``; need not be a multiple
-    of 64. ``buffer_origin`` is the logical position held by physical row 0,
-    defaulting to ``max(0, cache_seqlen - Lk)`` -- correct only for a buffer
-    that is exactly full, holding precisely the most recent ``Lk`` positions.
-    A caller evicting at coarser granularity holds fewer live positions and
-    MUST pass its true origin, or every read lands past the data, in bounds
-    and unmasked. See ``SlidingWindowPlan`` for both.
+    ``window_size`` and ``scale`` are static model configuration. For square
+    prefill, ``window_size`` lets the implementation read only each query
+    block's physical KV window. Other shapes, including anchored single-token
+    decode and chunked prefill, consume the fixed-shape mask over the complete
+    cache allocation in bounded chunks. Use a compact cache for decode so this
+    remains proportional to the sliding window rather than the model context.
 
-    ``valid_start`` is one **logical** column coordinate per batch entry; valid
-    query rows never attend columns strictly below it, whatever the window says.
-    It exists for left-padded prompts, whose pad columns sit inside the window and
-    which an offset-and-length window cannot otherwise exclude. ``None`` or
-    all-zero costs nothing; a uniform threshold keeps the band broadcast over
-    batch; only a ragged one widens it. Coordinates are logical, matching
-    ``cache_seqlen``, so a caller passing ``buffer_origin=0`` passes physical
-    row indices. Query rows below ``valid_start`` are padding; the implementation
-    gives each such row its diagonal to avoid an all-masked softmax. Compiler-added
-    front-padding rows whose logical coordinate predates the cache instead retain
-    the first resident column. These outputs are unspecified and callers discard
-    or zero them.
-
-    ``decode_mask`` is a runtime additive mask for anchored single-token decode.
-    Its fixed shape is ``[B, 1, 1, Lk]`` and it must share query's dtype and
-    device; zero keeps a physical cache column and a sufficiently negative
-    additive value excludes it. When it is present, the mask itself describes
-    the current write row, sliding window, unwritten rows, and left padding.
-    ``cache_seqlen``, ``buffer_origin``, and ``valid_start`` must therefore be
-    omitted. Unlike those Python geometry arguments, changing a tensor's contents
-    does not specialize the compiled graph, so every anchored decode position
-    reuses one SWA binary over the compact cache. Prefill should omit
-    ``decode_mask`` and uses the planned per-block window path.
-
-    Allocation contract: each internally tiled query block needs
-    ``round_up_to_64(window_size + q_block - 1)`` rows (``q_block=64`` for
-    prefill and 1 for decode), and the allocation/origin pair must also contain
-    the logical rows through ``cache_seqlen - 1``. Long prefills are tiled by the
-    decomposition rather than requiring ``window_size + Lq`` physical rows;
-    ``rejection_reason`` names the exact failure when the cache is too short.
-    Zero-fill the allocation -- a buffer may overshoot the written prefix,
-    and though causal masking discards those scores the multiply still
-    happens, and an additive ``-inf`` cannot rescue a ``NaN``.
+    The operation is causal-only by contract; callers express the exact causal
+    boundary in ``attention_mask``. Zero-fill unwritten cache rows: masked scores
+    are still computed, and adding a mask cannot rescue a NaN.
 
     MUST be called under torch.compile(backend="inductor") on the spyre
     device; the real lowering is in decompositions.py. This eager body is
@@ -1112,119 +1077,11 @@ def _(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
+    attention_mask: torch.Tensor,
     window_size: int,
-    is_causal: bool = True,
     scale: Optional[float] = None,
-    cache_seqlen: Optional[int] = None,
-    buffer_origin: Optional[int] = None,
-    valid_start: Optional[list[int]] = None,
-    decode_mask: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return query.new_empty(query.size())
-
-
-@torch.library.custom_op(
-    "spyre::window_band_mask", mutates_args=(), device_types="spyre"
-)
-def window_band_mask(
-    read_start: int,
-    q_block: int,
-    buffer_width: int,
-    q_row_origin: int,
-    window_size: int,
-    is_causal: bool,
-    dtype: torch.dtype,
-    device: torch.device,
-    valid_start: Optional[list[int]] = None,
-) -> torch.Tensor:
-    """
-    Additive band over one Q block's KV window.
-
-    Shape: [1, 1, q_block, buffer_width] normally; the leading axis is 1
-    unless ``valid_start`` differs across the batch, in which case it is B.
-    0.0 = keep, -inf = masked. The head axis stays size 1 and broadcasts,
-    which keeps this at q_block x buffer_width elements per batch row rather
-    than one copy per head.
-
-    Query row ``q_row_origin + i`` (an absolute KV-cache coordinate: row 0 of
-    this block sits at ``seqlen_kv - seqlen_q + q_block*n``) may attend column
-    ``read_start + j`` iff, with ``delta`` the difference of those two absolute
-    coordinates:
-      - causal:        0 <= delta < window_size
-      - bidirectional: abs(delta) < window_size
-
-    The band removes what the buffer over-covers: the stagger between rows
-    inside the block, and the columns a shifted ragged window drags in.
-
-    ``read_start`` here is **logical** (``read_start_logical``), not
-    buffer-relative, since ``q_row_origin`` is logical and ``delta`` subtracts
-    the two.
-
-    No ``cache_seqlen`` term, deliberately: rows satisfy ``row < cache_seqlen``
-    by construction, so causal ``delta >= 0`` already forces
-    ``column < cache_seqlen``. Only a bidirectional window, which raises
-    today, would need one.
-
-    ``valid_start``, if given, additionally excludes columns strictly below
-    its per-batch-entry threshold -- see ``sliding_window_attention``. Query
-    rows below the same threshold are padding themselves; each keeps only its
-    causal diagonal so the softmax remains defined. Any compiler-added front-pad
-    row whose diagonal predates the resident buffer keeps its first column instead.
-    Callers discard or zero these query rows, but no row receives an all-``-inf``
-    score band.
-
-    Built entirely on CPU so the in-place ops stay opaque to torch.compile,
-    matching spyre.causal_mask's rationale.
-    """
-    row = torch.arange(q_block, device="cpu") + q_row_origin
-    column = torch.arange(buffer_width, device="cpu") + read_start
-    delta = row.unsqueeze(-1) - column.unsqueeze(0)
-    if is_causal:
-        allowed = (delta >= 0) & (delta < window_size)
-    else:
-        allowed = delta.abs() < window_size
-    effective = band_valid_start(valid_start)
-    allowed = allowed.unsqueeze(0)
-    if effective is not None:
-        # A uniform threshold remains one broadcast row. For a padded query row,
-        # retain its diagonal solely to avoid an undefined all-masked softmax;
-        # valid rows still exclude every column below valid_start.
-        starts = torch.tensor(
-            [effective[0]] if min(effective) == max(effective) else effective,
-            device="cpu",
-        ).view(-1, 1, 1)
-        rows = row.view(1, -1, 1)
-        columns = column.view(1, 1, -1)
-        allowed = (allowed & (columns >= starts)) | (
-            (rows < starts) & (columns == rows)
-        )
-    # A ragged query is front-padded to q_block by the decomposition. Its synthetic
-    # leading coordinates can predate physical row 0, so even the diagonal rule
-    # above has no matching column. Those outputs are sliced away, but keeping one
-    # zero-filled resident column avoids manufacturing NaNs inside the graph.
-    has_attendable_key = allowed.any(dim=-1, keepdim=True)
-    first_column = torch.arange(buffer_width, device="cpu").view(1, 1, -1) == 0
-    allowed = allowed | (~has_attendable_key & first_column)
-    mask_cpu = torch.zeros(allowed.shape, dtype=dtype, device="cpu")
-    mask_cpu.masked_fill_(~allowed, float("-inf"))
-    return mask_cpu.unsqueeze(1).to(device=device)
-
-
-@window_band_mask.register_fake
-def _(
-    read_start: int,
-    q_block: int,
-    buffer_width: int,
-    q_row_origin: int,
-    window_size: int,
-    is_causal: bool,
-    dtype: torch.dtype,
-    device: torch.device,
-    valid_start: Optional[list[int]] = None,
-) -> torch.Tensor:
-    return torch.empty(
-        band_batch(valid_start), 1, q_block, buffer_width, dtype=dtype, device=device
-    )
 
 
 @torch.library.custom_op("spyre::kv_window", mutates_args=(), device_types="spyre")

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -1047,6 +1047,7 @@ def sliding_window_attention(  # type: ignore[empty-body]
     cache_seqlen: Optional[int] = None,
     buffer_origin: Optional[int] = None,
     valid_start: Optional[list[int]] = None,
+    decode_mask: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Sliding-window attention entry point.
@@ -1078,6 +1079,17 @@ def sliding_window_attention(  # type: ignore[empty-body]
     the first resident column. These outputs are unspecified and callers discard
     or zero them.
 
+    ``decode_mask`` is a runtime additive mask for anchored single-token decode.
+    Its fixed shape is ``[B, 1, 1, Lk]`` and it must share query's dtype and
+    device; zero keeps a physical cache column and a sufficiently negative
+    additive value excludes it. When it is present, the mask itself describes
+    the current write row, sliding window, unwritten rows, and left padding.
+    ``cache_seqlen``, ``buffer_origin``, and ``valid_start`` must therefore be
+    omitted. Unlike those Python geometry arguments, changing a tensor's contents
+    does not specialize the compiled graph, so every anchored decode position
+    reuses one SWA binary over the compact cache. Prefill should omit
+    ``decode_mask`` and uses the planned per-block window path.
+
     Allocation contract: each internally tiled query block needs
     ``round_up_to_64(window_size + q_block - 1)`` rows (``q_block=64`` for
     prefill and 1 for decode), and the allocation/origin pair must also contain
@@ -1106,6 +1118,7 @@ def _(
     cache_seqlen: Optional[int] = None,
     buffer_origin: Optional[int] = None,
     valid_start: Optional[list[int]] = None,
+    decode_mask: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return query.new_empty(query.size())
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -37,8 +37,6 @@ from .constants import DEVICE_NAME, FP8_E4M3FN_MAX, FP8_E4M3FN_MIN
 from .errors import Unsupported
 from .sliding_window_plan import (
     SlidingWindowPlan,
-    band_valid_start,
-    check_valid_start,
     check_window_read,
     plan_sliding_window,
     query_blocking,
@@ -784,11 +782,11 @@ def _windowed_attention(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
+    attention_mask: torch.Tensor,
     plan: SlidingWindowPlan,
     scaling_factor: float,
     num_heads: int,
-    valid_start: list[int] | None = None,
-    runtime_mask: torch.Tensor | None = None,
+    full_cache: bool,
 ) -> torch.Tensor:
     """Blocked online attention over each query block's physical KV window.
 
@@ -798,15 +796,12 @@ def _windowed_attention(
     a mutation-based ``copy_forced`` carry is not tile-safe when the output row
     spans multiple sticks (Gemma's head_dim=256).
     """
-    batch_size = query.size(0)
-    head_dim = query.size(3)
     q_block = plan.q_block
-    # A runtime decode mask describes an anchored compact cache whose write
-    # cursor moves within the final stick. Read the complete compact allocation
-    # in that mode: the tensor mask selects the live W rows without turning its
-    # position into Python specialization state. Planned prefill still reads the
-    # smaller per-block slice.
-    buffer_width = key.size(2) if runtime_mask is not None else plan.buffer_width
+    # Runtime-positioned queries (decode and chunked prefill) read the complete
+    # compact allocation; their tensor mask is the only source of geometry.
+    # Square prefill has position fixed by shape, so it retains the cheaper
+    # per-block physical window.
+    buffer_width = key.size(2) if full_cache else plan.buffer_width
 
     # Bound each explicit KV block to the proven SDPA tile size. Unlike a coarse
     # tile over the reduction dimension, explicit blocks make online-softmax
@@ -814,6 +809,13 @@ def _windowed_attention(
     # there is no need for full SDPA's additional approximately four-way split.
     kv_block_size = min(_SDPA_MAX_SEQUENCE_TILE_SIZE, buffer_width)
     num_kv_blocks = (buffer_width + kv_block_size - 1) // kv_block_size
+    # Spyre stores fp16 and bf16 tensors in its 16-bit floating-point format.
+    # Use values representable in that storage rather than bf16's wider range.
+    storage_dtype = (
+        torch.float16 if query.dtype in (torch.float16, torch.bfloat16) else query.dtype
+    )
+    finite_min = torch.finfo(storage_dtype).min
+    positive_min = torch.finfo(storage_dtype).tiny
 
     out_blocks = []
     for block_index in range(plan.num_q_blocks):
@@ -824,36 +826,8 @@ def _windowed_attention(
             "should have rejected a query length that does not divide"
         )
 
-        read_start = 0 if runtime_mask is not None else plan.read_start(block_index)
-        # A valid_start that masks anything makes the band load-bearing even for a
-        # block the window alone fully covers.
-        if runtime_mask is not None:
-            band = runtime_mask
-        else:
-            fully_attended = (
-                plan.block_is_fully_attended(block_index)
-                and band_valid_start(valid_start) is None
-            )
-            band = (
-                None
-                if fully_attended
-                else torch.ops.spyre.window_band_mask(
-                    # Logical, not read_start: the row side of this op
-                    # (q_row_origin) is a logical coordinate, and delta = row -
-                    # column only means anything if both sides agree. Identical
-                    # to read_start while buffer_origin is 0 -- a still-filling
-                    # or exactly-full cache -- and diverges for a rolled buffer.
-                    plan.read_start_logical(block_index),
-                    q_block,
-                    buffer_width,
-                    plan.q_kv_offset + q_start,
-                    plan.window_size,
-                    plan.is_causal,
-                    query.dtype,
-                    query.device,
-                    valid_start,
-                )
-            )
+        read_start = 0 if full_cache else plan.read_start(block_index)
+        mask_rows = attention_mask[:, :, q_start:q_end, :]
 
         # Keep the multi-output custom reads outside the coarse-tile scope.
         # FallbackKernel/MultiOutput nodes do not carry named dimensions; putting
@@ -878,34 +852,6 @@ def _windowed_attention(
         with spyre_hint(named_dims=["_b", "num_heads", "q_block", "head_dim"]):
             q_scaled = q_rows * scaling_factor
 
-        if num_kv_blocks > 1:
-            # SDPA's sparse-via-reduction construction. Single-chunk windows do
-            # not need synthetic state; omitting it also avoids dead hinted ops
-            # retaining scheduler dependencies after DCE.
-            m_reduced = torch.full(
-                (batch_size, num_heads, q_block, 64),
-                float("-inf"),
-                device=query.device,
-                dtype=query.dtype,
-            )
-            with spyre_hint(named_dims=["_b", "num_heads", "q_block"]):
-                running_max = m_reduced.amax(dim=-1)
-
-            denominator_reduced = torch.zeros(
-                (batch_size, num_heads, q_block, 64),
-                device=query.device,
-                dtype=query.dtype,
-            )
-            with spyre_hint(named_dims=["_b", "num_heads", "q_block"]):
-                denominator = denominator_reduced.amax(dim=-1)
-
-            with spyre_hint(named_dims=["_b", "num_heads", "q_block", "head_dim"]):
-                output = torch.zeros(
-                    (batch_size, num_heads, q_block, head_dim),
-                    device=query.device,
-                    dtype=query.dtype,
-                )
-
         # Do not create a one-tile hint group. Besides doing no useful work, that
         # group can make post-layout restickify producers appear after their
         # consumers for small batched MHA graphs.
@@ -915,6 +861,9 @@ def _windowed_attention(
             if num_head_tiles > 1
             else nullcontext()
         ):
+            running_max = None
+            denominator = None
+            output = None
             for kv_block, (start, end, k_blk, v_blk) in enumerate(window_chunks):
                 # k_blk is already transposed to [B, Hq, D, block_width].
                 with spyre_hint(named_dims=["_b", "num_heads", "q_block", "kv_block"]):
@@ -922,10 +871,17 @@ def _windowed_attention(
                         q_scaled, k_blk * scaling_factor
                     )  # batch, num_heads, q_block, block_width
 
-                if band is not None:
-                    scores = scores + band[..., start:end]
+                scores = scores + mask_rows[..., read_start + start : read_start + end]
 
                 block_max = torch.amax(scores, dim=-1)
+                # A standard additive mask may make an entire KV chunk -inf.
+                # Clamp that reduction to a finite value before subtracting it:
+                # -inf - -inf is NaN and would otherwise poison all later chunks,
+                # including a later chunk that contains attendable keys.
+                block_max = torch.maximum(
+                    block_max,
+                    torch.full_like(block_max, finite_min),
+                )
                 if kv_block == 0:
                     # Seed from real scores. Besides avoiding dead arithmetic,
                     # this keeps the single-chunk decode case as the direct
@@ -935,6 +891,9 @@ def _windowed_attention(
                     exp_scores = torch.exp(scores - new_max.unsqueeze(-1))
                     new_denominator = exp_scores.sum(dim=-1)
                 else:
+                    assert running_max is not None
+                    assert denominator is not None
+                    assert output is not None
                     new_max = torch.maximum(running_max, block_max)
                     exp_scores = torch.exp(scores - new_max.unsqueeze(-1))
                     correction = torch.exp(running_max - new_max)
@@ -959,7 +918,9 @@ def _windowed_attention(
                             "head_dim",
                         ]
                     ):
-                        output = new_output / new_denominator.unsqueeze(-1)
+                        output = new_output / torch.clamp_min(
+                            new_denominator, positive_min
+                        ).unsqueeze(-1)
                 else:
                     running_max = new_max
                     denominator = new_denominator
@@ -975,25 +936,15 @@ def spyre_sliding_window_attention(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
+    attention_mask: torch.Tensor,
     window_size: int,
-    is_causal: bool = True,
     scale: float | None = None,
-    cache_seqlen: int | None = None,
-    buffer_origin: int | None = None,
-    valid_start: list[int] | None = None,
-    decode_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Sliding-window attention: each Q block attends only its own KV slice.
+    """Sliding-window attention with all runtime geometry in a tensor mask.
 
-    Rather than scoring the full cache behind a band mask, each block of
-    q_block query rows reads buffer_width rows -- a constant that does not
-    grow with the cache -- and attends against those. See
-    ``plan_sliding_window`` for the placement.
-
-    A ragged query length is padded up rather than refused. Shapes the
-    placement cannot express raise: there is no slower-but-correct fallback,
-    since a band mask over full attention is itself wrong for an unaligned KV
-    length.
+    Square prefill uses static per-block KV windows. Every other shape reads the
+    complete cache allocation in bounded chunks, so changing mask contents never
+    changes the graph. A ragged query length is padded up rather than refused.
     """
     num_heads = query.size(1)
     head_dim = query.size(3)
@@ -1002,60 +953,31 @@ def spyre_sliding_window_attention(
     cache_capacity = key.size(2)
 
     if scale is not None and scale < 0:
-        # math.sqrt would otherwise raise a bare ValueError in the planned path;
-        # keep the runtime-mask path on the same public contract.
+        # math.sqrt would otherwise raise a bare ValueError.
         raise Unsupported(
             f"sliding_window_attention: scale={scale} must be non-negative"
-        )
-    if not is_causal:
-        raise Unsupported(
-            "sliding_window_attention: bidirectional windows are not implemented, "
-            "only causal ones"
         )
     if window_size <= 0:
         raise Unsupported(
             f"sliding_window_attention: window_size={window_size} must be positive"
         )
 
-    if decode_mask is not None:
-        # This path deliberately has no Python position argument: the fixed-shape
-        # tensor carries all position-dependent state at runtime, which lets every
-        # anchored decode step reuse one graph.
-        if seqlen_q != 1:
-            raise Unsupported(
-                "sliding_window_attention: decode_mask requires a single query row"
-            )
-        if (
-            cache_seqlen is not None
-            or buffer_origin is not None
-            or valid_start is not None
-        ):
-            raise Unsupported(
-                "sliding_window_attention: decode_mask cannot be combined with "
-                "cache_seqlen, buffer_origin, or valid_start"
-            )
-        expected_shape = (batch_size, 1, 1, cache_capacity)
-        if tuple(decode_mask.shape) != expected_shape:
-            raise Unsupported(
-                "sliding_window_attention: decode_mask shape "
-                f"{tuple(decode_mask.shape)} must be {expected_shape}"
-            )
-        if decode_mask.dtype != query.dtype:
-            raise Unsupported(
-                "sliding_window_attention: decode_mask dtype "
-                f"{decode_mask.dtype} must match query dtype {query.dtype}"
-            )
-        if decode_mask.device != query.device:
-            raise Unsupported(
-                "sliding_window_attention: decode_mask device "
-                f"{decode_mask.device} must match query device {query.device}"
-            )
-
-        # Use fixed trace-time geometry for the anchored compact allocation.
-        # The runtime mask is consumed by the SWA recurrence below and carries
-        # the moving write position, padding boundary, and unwritten tail.
-        cache_seqlen = cache_capacity
-        buffer_origin = 0
+    expected_mask_shape = (batch_size, 1, seqlen_q, cache_capacity)
+    if tuple(attention_mask.shape) != expected_mask_shape:
+        raise Unsupported(
+            "sliding_window_attention: attention_mask shape "
+            f"{tuple(attention_mask.shape)} must be {expected_mask_shape}"
+        )
+    if attention_mask.dtype != query.dtype:
+        raise Unsupported(
+            "sliding_window_attention: attention_mask dtype "
+            f"{attention_mask.dtype} must match query dtype {query.dtype}"
+        )
+    if attention_mask.device != query.device:
+        raise Unsupported(
+            "sliding_window_attention: attention_mask device "
+            f"{attention_mask.device} must match query device {query.device}"
+        )
 
     # Split across query and key, not applied once to their product: keeps the
     # intermediate in float16 range.
@@ -1064,43 +986,35 @@ def spyre_sliding_window_attention(
     else:
         scaling_factor = math.sqrt(scale)
 
-    # The cache's position, not its allocation. None means "exactly full",
-    # which is what reading key.size(2) as a position silently assumed.
-    # Degenerate values (<= 0, either of them) need no check here:
-    # rejection_reason below rejects them, and it is the single source of
-    # truth for which geometries can be planned.
-    if cache_seqlen is None:
-        cache_seqlen = cache_capacity
-
-    reason = check_valid_start(valid_start, batch_size, cache_seqlen)
-    if reason is not None:
-        raise Unsupported(f"sliding_window_attention: {reason}")
-
-    # Pad at the FRONT: row i sits at coordinate seqlen_kv - seqlen_q + i, so
-    # once seqlen_q is the padded length the two shifts cancel and every real
-    # row keeps its coordinate. Back-padding would move all of them.
+    # Pad at the front so real rows keep their relative order. Synthetic rows
+    # receive an all-zero mask and are sliced from the result; this guarantees a
+    # finite softmax without imposing semantics on discarded outputs.
     q_block, padded_seqlen_q = query_blocking(seqlen_q)
     pad_rows = padded_seqlen_q - seqlen_q
+
+    # Only square prefill has position fully determined by tensor shapes. All
+    # other calls may carry a changing query origin in attention_mask and must
+    # therefore read the complete allocation rather than specialize on a Python
+    # offset. A compact decode allocation keeps this bounded by the window.
+    full_cache = seqlen_q != cache_capacity
     plan = plan_sliding_window(
         padded_seqlen_q,
-        cache_seqlen,
+        cache_capacity,
         window_size,
-        is_causal=is_causal,
+        is_causal=True,
         q_block=q_block,
         cache_capacity=cache_capacity,
-        buffer_origin=buffer_origin,
     )
     if plan is None:
         # Never None when the plan is, but the type says otherwise.
         reason = (
             rejection_reason(
                 padded_seqlen_q,
-                cache_seqlen,
+                cache_capacity,
                 window_size,
-                is_causal,
+                True,
                 q_block,
                 cache_capacity,
-                buffer_origin,
             )
             or "the window placement cannot express this shape"
         )
@@ -1118,16 +1032,27 @@ def spyre_sliding_window_attention(
             ],
             dim=2,
         )
+        attention_mask = torch.cat(
+            [
+                torch.zeros(
+                    (batch_size, 1, pad_rows, cache_capacity),
+                    device=attention_mask.device,
+                    dtype=attention_mask.dtype,
+                ),
+                attention_mask,
+            ],
+            dim=2,
+        )
 
     output = _windowed_attention(
         query,
         key,
         value,
+        attention_mask,
         plan,
         scaling_factor,
         num_heads,
-        valid_start,
-        decode_mask,
+        full_cache,
     )
     return output[:, :, pad_rows:, :] if pad_rows else output
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -27,6 +27,7 @@ registry; Spyre never mutates the global table.
 
 import math
 import threading
+from contextlib import nullcontext
 from typing import Any, Callable, Optional, Sequence, Union
 
 import torch
@@ -772,6 +773,15 @@ def spyre_kv_window(
     k_win = key[:, :, read_start : read_start + buffer_width, :].transpose(-1, -2)
     v_win = value[:, :, read_start : read_start + buffer_width, :]
 
+    # A four-stick head dimension (Gemma 4 uses D=256) needs a materialized
+    # bounded window before the tiled matmuls. Keeping the source-cache strides
+    # there makes the layout solver bind a multi-stick head row as though it were
+    # the window axis. One- and two-stick rows retain the zero-copy view: forcing
+    # those through this clone currently regresses offset decode reads.
+    if key.size(3) > 128:
+        k_win = k_win.contiguous()
+        v_win = v_win.contiguous()
+
     expansion = num_heads // key.size(1)
     if expansion != 1:
         k_win = k_win.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
@@ -787,18 +797,39 @@ def _windowed_attention(
     scaling_factor: float,
     num_heads: int,
     valid_start: list[int] | None = None,
+    runtime_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """spyre__sdpa_overrideable's body, tiled over buffer_width not max_seqlen_kv.
+    """Blocked online attention over each query block's physical KV window.
 
-    The Python loop is unrolled at trace time, so every read offset is a
-    constant. Blocks share no softmax state; the accumulators are per
-    iteration and exist because the window_size hint may tile buffer_width
-    into partial softmaxes.
+    Both loops are unrolled at trace time, so every cache read is a bounded,
+    constant slice. Query blocks share no softmax state. Within one query block,
+    KV chunks use functional SSA carries, matching ``spyre__sdpa_overrideable``;
+    a mutation-based ``copy_forced`` carry is not tile-safe when the output row
+    spans multiple sticks (Gemma's head_dim=256).
     """
     batch_size = query.size(0)
     head_dim = query.size(3)
     q_block = plan.q_block
-    buffer_width = plan.buffer_width
+    # A runtime decode mask describes an anchored compact cache whose write
+    # cursor moves within the final stick. Read the complete compact allocation
+    # in that mode: the tensor mask selects the live W rows without turning its
+    # position into Python specialization state. Planned prefill still reads the
+    # smaller per-block slice.
+    buffer_width = key.size(2) if runtime_mask is not None else plan.buffer_width
+
+    # Attention projections commonly arrive as a [B, Lq, H, D] allocation viewed
+    # as [B, H, Lq, D]. Normalize that view before the tiled matmuls: physical
+    # stride order otherwise makes the tiler bind the logical head/query axes to
+    # the wrong loops. This is bounded to the query footprint and mirrors the
+    # full-SDPA fix in #4377; K/V remain windowed rather than copied wholesale.
+    query = query.contiguous()
+
+    # Bound each explicit KV block to the proven SDPA tile size. Unlike a coarse
+    # tile over the reduction dimension, explicit blocks make online-softmax
+    # state ordinary functional graph values. SWA already caps Q at 64 rows, so
+    # there is no need for full SDPA's additional approximately four-way split.
+    kv_block_size = min(_SDPA_MAX_SEQUENCE_TILE_SIZE, buffer_width)
+    num_kv_blocks = (buffer_width + kv_block_size - 1) // kv_block_size
 
     out_blocks = []
     for block_index in range(plan.num_q_blocks):
@@ -809,95 +840,148 @@ def _windowed_attention(
             "should have rejected a query length that does not divide"
         )
 
-        read_start = plan.read_start(block_index)
-        k_win, v_win = torch.ops.spyre.kv_window(
-            key, value, read_start, buffer_width, num_heads
-        )
+        read_start = 0 if runtime_mask is not None else plan.read_start(block_index)
         # A valid_start that masks anything makes the band load-bearing even for a
         # block the window alone fully covers.
-        fully_attended = (
-            plan.block_is_fully_attended(block_index)
-            and band_valid_start(valid_start) is None
-        )
-        band = (
-            None
-            if fully_attended
-            else torch.ops.spyre.window_band_mask(
-                # Logical, not read_start: the row side of this op
-                # (q_row_origin) is a logical coordinate, and delta = row -
-                # column only means anything if both sides agree. Identical
-                # to read_start while buffer_origin is 0 -- a still-filling
-                # or exactly-full cache -- and diverges for a rolled buffer.
-                plan.read_start_logical(block_index),
-                q_block,
-                buffer_width,
-                plan.q_kv_offset + q_start,
-                plan.window_size,
-                plan.is_causal,
-                query.dtype,
-                query.device,
-                valid_start,
+        if runtime_mask is not None:
+            band = runtime_mask
+        else:
+            fully_attended = (
+                plan.block_is_fully_attended(block_index)
+                and band_valid_start(valid_start) is None
             )
-        )
+            band = (
+                None
+                if fully_attended
+                else torch.ops.spyre.window_band_mask(
+                    # Logical, not read_start: the row side of this op
+                    # (q_row_origin) is a logical coordinate, and delta = row -
+                    # column only means anything if both sides agree. Identical
+                    # to read_start while buffer_origin is 0 -- a still-filling
+                    # or exactly-full cache -- and diverges for a rolled buffer.
+                    plan.read_start_logical(block_index),
+                    q_block,
+                    buffer_width,
+                    plan.q_kv_offset + q_start,
+                    plan.window_size,
+                    plan.is_causal,
+                    query.dtype,
+                    query.device,
+                    valid_start,
+                )
+            )
+
+        # Keep the multi-output custom reads outside the coarse-tile scope.
+        # FallbackKernel/MultiOutput nodes do not carry named dimensions; putting
+        # them inside the scope can pull GQA expansion and batch dependencies into
+        # the wrong loop group (and, for batch > 1, leave a dangling scheduler
+        # dependency after grouping).
+        window_chunks = []
+        for kv_block in range(num_kv_blocks):
+            start = kv_block * kv_block_size
+            end = min(start + kv_block_size, buffer_width)
+            k_blk, v_blk = torch.ops.spyre.kv_window(
+                key,
+                value,
+                read_start + start,
+                end - start,
+                num_heads,
+            )
+            window_chunks.append((start, end, k_blk, v_blk))
+
         q_rows = query[:, :, q_start:q_end, :]
 
-        # SDPA's "sparse via reduction" construction. On a single pass M is
-        # -inf, so correction is exp(-inf) == 0 and the running terms drop out.
-        m_reduced = torch.full(
-            (batch_size, num_heads, q_block, 64),
-            float("-inf"),
-            device=query.device,
-            dtype=query.dtype,
-        )
-        running_max = m_reduced.amax(dim=-1)
+        with spyre_hint(named_dims=["_b", "num_heads", "q_block", "head_dim"]):
+            q_scaled = q_rows * scaling_factor
 
-        denominator_reduced = torch.zeros(
-            (batch_size, num_heads, q_block, 64),
-            device=query.device,
-            dtype=query.dtype,
-        )
-        denominator = denominator_reduced.amax(dim=-1)
+        if num_kv_blocks > 1:
+            # SDPA's sparse-via-reduction construction. Single-chunk windows do
+            # not need synthetic state; omitting it also avoids dead hinted ops
+            # retaining scheduler dependencies after DCE.
+            m_reduced = torch.full(
+                (batch_size, num_heads, q_block, 64),
+                float("-inf"),
+                device=query.device,
+                dtype=query.dtype,
+            )
+            with spyre_hint(named_dims=["_b", "num_heads", "q_block"]):
+                running_max = m_reduced.amax(dim=-1)
 
-        output = torch.zeros(
-            (batch_size, num_heads, q_block, head_dim),
-            device=query.device,
-            dtype=query.dtype,
-        )
+            denominator_reduced = torch.zeros(
+                (batch_size, num_heads, q_block, 64),
+                device=query.device,
+                dtype=query.dtype,
+            )
+            with spyre_hint(named_dims=["_b", "num_heads", "q_block"]):
+                denominator = denominator_reduced.amax(dim=-1)
 
-        with spyre_hint(tiles={"batch_size": max(1, batch_size // 2)}):
-            with spyre_hint(tiles={"num_heads": max(1, num_heads // 4)}):
-                with spyre_hint(tiles={"window_size": max(1, buffer_width // 64)}):
-                    with spyre_hint(work_div={"num_heads": 4, "window_size": 8}):
-                        # k_win arrives transposed.
-                        scores = torch.matmul(
-                            q_rows * scaling_factor, k_win * scaling_factor
-                        )  # batch, num_heads, q_block, buffer_width
+            with spyre_hint(named_dims=["_b", "num_heads", "q_block", "head_dim"]):
+                output = torch.zeros(
+                    (batch_size, num_heads, q_block, head_dim),
+                    device=query.device,
+                    dtype=query.dtype,
+                )
 
-                        if band is not None:
-                            scores = scores + band
+        # Do not create a one-tile hint group. Besides doing no useful work, that
+        # group can make post-layout restickify producers appear after their
+        # consumers for small batched MHA graphs.
+        num_head_tiles = _sdpa_num_head_tiles(num_heads)
+        with (
+            spyre_hint(tiles={"num_heads": num_head_tiles})
+            if num_head_tiles > 1
+            else nullcontext()
+        ):
+            for kv_block, (start, end, k_blk, v_blk) in enumerate(window_chunks):
+                # k_blk is already transposed to [B, Hq, D, block_width].
+                with spyre_hint(named_dims=["_b", "num_heads", "q_block", "kv_block"]):
+                    scores = torch.matmul(
+                        q_scaled, k_blk * scaling_factor
+                    )  # batch, num_heads, q_block, block_width
 
-                        block_max = torch.amax(scores, dim=-1)
-                        max_running = torch.maximum(running_max, block_max)
+                if band is not None:
+                    scores = scores + band[..., start:end]
 
-                        exp_scores = torch.exp(scores - max_running.unsqueeze(-1))
-                        correction = torch.exp(running_max - max_running)
+                block_max = torch.amax(scores, dim=-1)
+                if kv_block == 0:
+                    # Seed from real scores. Besides avoiding dead arithmetic,
+                    # this keeps the single-chunk decode case as the direct
+                    # stable-softmax formula instead of involving synthetic
+                    # -inf/zero accumulators.
+                    new_max = block_max
+                    exp_scores = torch.exp(scores - new_max.unsqueeze(-1))
+                    new_denominator = exp_scores.sum(dim=-1)
+                else:
+                    new_max = torch.maximum(running_max, block_max)
+                    exp_scores = torch.exp(scores - new_max.unsqueeze(-1))
+                    correction = torch.exp(running_max - new_max)
+                    new_denominator = denominator * correction + exp_scores.sum(dim=-1)
+                exp_scores = exp_scores.contiguous()
+                with spyre_hint(named_dims=["_b", "num_heads", "q_block", "head_dim"]):
+                    weighted = torch.matmul(exp_scores, v_blk)
+                new_output = (
+                    weighted
+                    if kv_block == 0
+                    else output * correction.unsqueeze(-1) + weighted
+                )
 
-                        denominator = torch.ops.spyre.copy_forced(
-                            denominator * correction + exp_scores.sum(dim=-1),
-                            denominator,
-                        )
-                        output = torch.ops.spyre.copy_forced(
-                            output * correction.unsqueeze(-1)
-                            + torch.matmul(exp_scores, v_win),
-                            output,
-                        )
-                        running_max = torch.ops.spyre.copy_forced(
-                            max_running, running_max
-                        )
+                if kv_block == num_kv_blocks - 1:
+                    # Keep the final divide in the same hint scope as its
+                    # producer, as full SDPA does for split-layout outputs.
+                    with spyre_hint(
+                        named_dims=[
+                            "_b",
+                            "num_heads",
+                            "q_block",
+                            "head_dim",
+                        ]
+                    ):
+                        output = new_output / new_denominator.unsqueeze(-1)
+                else:
+                    running_max = new_max
+                    denominator = new_denominator
+                    output = new_output
 
-        out_blocks.append(
-            torch.ops.spyre.copy_forced(output / denominator.unsqueeze(-1), output)
-        )
+        out_blocks.append(output)
 
     return torch.cat(out_blocks, dim=2)
 
@@ -913,6 +997,7 @@ def spyre_sliding_window_attention(
     cache_seqlen: int | None = None,
     buffer_origin: int | None = None,
     valid_start: list[int] | None = None,
+    decode_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Sliding-window attention: each Q block attends only its own KV slice.
 
@@ -932,6 +1017,69 @@ def spyre_sliding_window_attention(
     seqlen_q = query.size(2)
     cache_capacity = key.size(2)
 
+    if scale is not None and scale < 0:
+        # math.sqrt would otherwise raise a bare ValueError in the planned path;
+        # keep the runtime-mask path on the same public contract.
+        raise Unsupported(
+            f"sliding_window_attention: scale={scale} must be non-negative"
+        )
+    if not is_causal:
+        raise Unsupported(
+            "sliding_window_attention: bidirectional windows are not implemented, "
+            "only causal ones"
+        )
+    if window_size <= 0:
+        raise Unsupported(
+            f"sliding_window_attention: window_size={window_size} must be positive"
+        )
+
+    if decode_mask is not None:
+        # This path deliberately has no Python position argument: the fixed-shape
+        # tensor carries all position-dependent state at runtime, which lets every
+        # anchored decode step reuse one graph.
+        if seqlen_q != 1:
+            raise Unsupported(
+                "sliding_window_attention: decode_mask requires a single query row"
+            )
+        if (
+            cache_seqlen is not None
+            or buffer_origin is not None
+            or valid_start is not None
+        ):
+            raise Unsupported(
+                "sliding_window_attention: decode_mask cannot be combined with "
+                "cache_seqlen, buffer_origin, or valid_start"
+            )
+        expected_shape = (batch_size, 1, 1, cache_capacity)
+        if tuple(decode_mask.shape) != expected_shape:
+            raise Unsupported(
+                "sliding_window_attention: decode_mask shape "
+                f"{tuple(decode_mask.shape)} must be {expected_shape}"
+            )
+        if decode_mask.dtype != query.dtype:
+            raise Unsupported(
+                "sliding_window_attention: decode_mask dtype "
+                f"{decode_mask.dtype} must match query dtype {query.dtype}"
+            )
+        if decode_mask.device != query.device:
+            raise Unsupported(
+                "sliding_window_attention: decode_mask device "
+                f"{decode_mask.device} must match query device {query.device}"
+            )
+
+        # Use fixed trace-time geometry for the anchored compact allocation.
+        # The runtime mask is consumed by the SWA recurrence below and carries
+        # the moving write position, padding boundary, and unwritten tail.
+        cache_seqlen = cache_capacity
+        buffer_origin = 0
+
+    # Split across query and key, not applied once to their product: keeps the
+    # intermediate in float16 range.
+    if scale is None:
+        scaling_factor = 1.0 / math.sqrt(math.sqrt(head_dim))
+    else:
+        scaling_factor = math.sqrt(scale)
+
     # The cache's position, not its allocation. None means "exactly full",
     # which is what reading key.size(2) as a position silently assumed.
     # Degenerate values (<= 0, either of them) need no check here:
@@ -943,19 +1091,6 @@ def spyre_sliding_window_attention(
     reason = check_valid_start(valid_start, batch_size, cache_seqlen)
     if reason is not None:
         raise Unsupported(f"sliding_window_attention: {reason}")
-
-    if scale is not None and scale < 0:
-        # math.sqrt would otherwise raise a bare ValueError.
-        raise Unsupported(
-            f"sliding_window_attention: scale={scale} must be non-negative"
-        )
-
-    # Split across query and key, not applied once to their product: keeps the
-    # intermediate in float16 range.
-    if scale is None:
-        scaling_factor = 1.0 / math.sqrt(math.sqrt(head_dim))
-    else:
-        scaling_factor = math.sqrt(scale)
 
     # Pad at the FRONT: row i sits at coordinate seqlen_kv - seqlen_q + i, so
     # once seqlen_q is the padded length the two shifts cancel and every real
@@ -1001,7 +1136,14 @@ def spyre_sliding_window_attention(
         )
 
     output = _windowed_attention(
-        query, key, value, plan, scaling_factor, num_heads, valid_start
+        query,
+        key,
+        value,
+        plan,
+        scaling_factor,
+        num_heads,
+        valid_start,
+        decode_mask,
     )
     return output[:, :, pad_rows:, :] if pad_rows else output
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -773,15 +773,6 @@ def spyre_kv_window(
     k_win = key[:, :, read_start : read_start + buffer_width, :].transpose(-1, -2)
     v_win = value[:, :, read_start : read_start + buffer_width, :]
 
-    # A four-stick head dimension (Gemma 4 uses D=256) needs a materialized
-    # bounded window before the tiled matmuls. Keeping the source-cache strides
-    # there makes the layout solver bind a multi-stick head row as though it were
-    # the window axis. One- and two-stick rows retain the zero-copy view: forcing
-    # those through this clone currently regresses offset decode reads.
-    if key.size(3) > 128:
-        k_win = k_win.contiguous()
-        v_win = v_win.contiguous()
-
     expansion = num_heads // key.size(1)
     if expansion != 1:
         k_win = k_win.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
@@ -816,13 +807,6 @@ def _windowed_attention(
     # position into Python specialization state. Planned prefill still reads the
     # smaller per-block slice.
     buffer_width = key.size(2) if runtime_mask is not None else plan.buffer_width
-
-    # Attention projections commonly arrive as a [B, Lq, H, D] allocation viewed
-    # as [B, H, Lq, D]. Normalize that view before the tiled matmuls: physical
-    # stride order otherwise makes the tiler bind the logical head/query axes to
-    # the wrong loops. This is bounded to the query footprint and mirrors the
-    # full-SDPA fix in #4377; K/V remain windowed rather than copied wholesale.
-    query = query.contiguous()
 
     # Bound each explicit KV block to the proven SDPA tile size. Unlike a coarse
     # tile over the reduction dimension, explicit blocks make online-softmax

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -865,6 +865,7 @@ def _windowed_attention(
             denominator = None
             output = None
             for kv_block, (start, end, k_blk, v_blk) in enumerate(window_chunks):
+                correction = None
                 # k_blk is already transposed to [B, Hq, D, block_width].
                 with spyre_hint(named_dims=["_b", "num_heads", "q_block", "kv_block"]):
                     scores = torch.matmul(
@@ -901,11 +902,12 @@ def _windowed_attention(
                 exp_scores = exp_scores.contiguous()
                 with spyre_hint(named_dims=["_b", "num_heads", "q_block", "head_dim"]):
                     weighted = torch.matmul(exp_scores, v_blk)
-                new_output = (
-                    weighted
-                    if kv_block == 0
-                    else output * correction.unsqueeze(-1) + weighted
-                )
+                if kv_block == 0:
+                    new_output = weighted
+                else:
+                    assert output is not None
+                    assert correction is not None
+                    new_output = output * correction.unsqueeze(-1) + weighted
 
                 if kv_block == num_kv_blocks - 1:
                     # Keep the final divide in the same hint scope as its

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -36,6 +36,7 @@ import torch._decomp as decomp
 from .constants import DEVICE_NAME, FP8_E4M3FN_MAX, FP8_E4M3FN_MIN
 from .errors import Unsupported
 from .sliding_window_plan import (
+    STICK,
     SlidingWindowPlan,
     check_window_read,
     plan_sliding_window,
@@ -783,10 +784,11 @@ def _windowed_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     attention_mask: torch.Tensor,
-    plan: SlidingWindowPlan,
+    causal_plan: SlidingWindowPlan | None,
+    q_block: int,
+    padded_seqlen_q: int,
     scaling_factor: float,
     num_heads: int,
-    full_cache: bool,
 ) -> torch.Tensor:
     """Blocked online attention over each query block's physical KV window.
 
@@ -796,12 +798,10 @@ def _windowed_attention(
     a mutation-based ``copy_forced`` carry is not tile-safe when the output row
     spans multiple sticks (Gemma's head_dim=256).
     """
-    q_block = plan.q_block
-    # Runtime-positioned queries (decode and chunked prefill) read the complete
-    # compact allocation; their tensor mask is the only source of geometry.
-    # Square prefill has position fixed by shape, so it retains the cheaper
-    # per-block physical window.
-    buffer_width = key.size(2) if full_cache else plan.buffer_width
+    # A causal square prefill has a static narrow read plan. Generic masks and
+    # runtime-positioned calls scan the complete compact allocation; their
+    # tensor mask is the only source of geometry.
+    buffer_width = key.size(2) if causal_plan is None else causal_plan.buffer_width
 
     # Bound each explicit KV block to the proven SDPA tile size. Unlike a coarse
     # tile over the reduction dimension, explicit blocks make online-softmax
@@ -818,15 +818,17 @@ def _windowed_attention(
     positive_min = torch.finfo(storage_dtype).tiny
 
     out_blocks = []
-    for block_index in range(plan.num_q_blocks):
-        q_start, q_end = plan.block_q_range(block_index)
+    num_q_blocks = padded_seqlen_q // q_block
+    for block_index in range(num_q_blocks):
+        q_start = block_index * q_block
+        q_end = q_start + q_block
         assert q_end - q_start == q_block, (
             f"sliding_window_attention: Q block {block_index} is "
-            f"{q_end - q_start} rows, expected {q_block} -- plan_sliding_window "
-            "should have rejected a query length that does not divide"
+            f"{q_end - q_start} rows, expected {q_block} -- query padding "
+            "should have produced a whole number of blocks"
         )
 
-        read_start = 0 if full_cache else plan.read_start(block_index)
+        read_start = 0 if causal_plan is None else causal_plan.read_start(block_index)
         mask_rows = attention_mask[:, :, q_start:q_end, :]
 
         # Keep the multi-output custom reads outside the coarse-tile scope.
@@ -940,13 +942,15 @@ def spyre_sliding_window_attention(
     value: torch.Tensor,
     attention_mask: torch.Tensor,
     window_size: int,
+    is_causal: bool,
     scale: float | None = None,
 ) -> torch.Tensor:
     """Sliding-window attention with all runtime geometry in a tensor mask.
 
-    Square prefill uses static per-block KV windows. Every other shape reads the
-    complete cache allocation in bounded chunks, so changing mask contents never
-    changes the graph. A ragged query length is padded up rather than refused.
+    Strictly causal square prefill uses static per-block KV windows. Generic
+    masks and every other shape read the complete cache allocation in bounded
+    chunks, so changing mask contents never changes the graph. A ragged query
+    length is padded up rather than refused.
     """
     num_heads = query.size(1)
     head_dim = query.size(3)
@@ -962,6 +966,21 @@ def spyre_sliding_window_attention(
     if window_size <= 0:
         raise Unsupported(
             f"sliding_window_attention: window_size={window_size} must be positive"
+        )
+    if seqlen_q <= 0 or cache_capacity <= 0:
+        raise Unsupported(
+            "sliding_window_attention: query and cache lengths must be positive, "
+            f"got seqlen_q={seqlen_q}, cache_capacity={cache_capacity}"
+        )
+    if seqlen_q > cache_capacity:
+        raise Unsupported(
+            f"sliding_window_attention: seqlen_q={seqlen_q} exceeds "
+            f"cache_capacity={cache_capacity}"
+        )
+    if cache_capacity % STICK != 0:
+        raise Unsupported(
+            f"sliding_window_attention: cache_capacity={cache_capacity} must be a "
+            f"multiple of {STICK}"
         )
 
     expected_mask_shape = (batch_size, 1, seqlen_q, cache_capacity)
@@ -994,34 +1013,35 @@ def spyre_sliding_window_attention(
     q_block, padded_seqlen_q = query_blocking(seqlen_q)
     pad_rows = padded_seqlen_q - seqlen_q
 
-    # Only square prefill has position fully determined by tensor shapes. All
-    # other calls may carry a changing query origin in attention_mask and must
-    # therefore read the complete allocation rather than specialize on a Python
-    # offset. A compact decode allocation keeps this bounded by the window.
-    full_cache = seqlen_q != cache_capacity
-    plan = plan_sliding_window(
-        padded_seqlen_q,
-        cache_capacity,
-        window_size,
-        is_causal=True,
-        q_block=q_block,
-        cache_capacity=cache_capacity,
-    )
-    if plan is None:
-        # Never None when the plan is, but the type says otherwise.
-        reason = (
-            rejection_reason(
-                padded_seqlen_q,
-                cache_capacity,
-                window_size,
-                True,
-                q_block,
-                cache_capacity,
-            )
-            or "the window placement cannot express this shape"
+    # Only a strictly causal square prefill has position and its upper bound
+    # fully determined by tensor shapes. A generic mask can allow future keys,
+    # while non-square calls can carry a changing query origin in mask values;
+    # both must scan the complete allocation. A compact decode cache keeps that
+    # bounded by the configured window.
+    causal_plan = None
+    if is_causal and seqlen_q == cache_capacity:
+        causal_plan = plan_sliding_window(
+            padded_seqlen_q,
+            cache_capacity,
+            window_size,
+            is_causal=True,
+            q_block=q_block,
+            cache_capacity=cache_capacity,
         )
-        raise Unsupported(f"sliding_window_attention: {reason}")
-
+        if causal_plan is None:
+            # Never None when the plan is valid, but the type says otherwise.
+            reason = (
+                rejection_reason(
+                    padded_seqlen_q,
+                    cache_capacity,
+                    window_size,
+                    True,
+                    q_block,
+                    cache_capacity,
+                )
+                or "the window placement cannot express this shape"
+            )
+            raise Unsupported(f"sliding_window_attention: {reason}")
     if pad_rows:
         query = torch.cat(
             [
@@ -1051,10 +1071,11 @@ def spyre_sliding_window_attention(
         key,
         value,
         attention_mask,
-        plan,
+        causal_plan,
+        q_block,
+        padded_seqlen_q,
         scaling_factor,
         num_heads,
-        full_cache,
     )
     return output[:, :, pad_rows:, :] if pad_rows else output
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -38,7 +38,13 @@ from torch._inductor.ir import (
 from torch._inductor.ops_handler import WrapperHandler
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.graph import GraphLowering
-from torch._inductor.dependencies import MemoryDep, ReadWrites, StarDep, is_indirect
+from torch._inductor.dependencies import (
+    MemoryDep,
+    ReadWrites,
+    StarDep,
+    WeakDep,
+    is_indirect,
+)
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import (
@@ -73,6 +79,36 @@ from .views import (
 # PyTorch's default lower bound for size symbols (sizes 0/1 are specialised).
 _SHAPE_ENV_DEFAULT_LOWER = 2
 logger = get_inductor_logger("pass_utils")
+
+
+def register_operation_after_graph_edit(graph: GraphLowering, op: Operation) -> str:
+    """Register an operation after passes may have removed graph operations.
+
+    ``GraphLowering.register_operation`` derives the next name from
+    ``len(graph.operations)``.  That is safe while lowering only appends, but a
+    late graph-editing pass can remove or replace operations before inserting a
+    new one.  The shortened list can then point at an ``opN`` that is still in
+    use, silently overwrite ``name_to_op[N]``, and leave two operations with the
+    same name.  The scheduler subsequently resolves a dependency to the wrong
+    producer (or to one that occurs later) and fails while computing ancestors.
+
+    Keep upstream's naming convention, but find the first name that has never
+    been registered.  Scratchpad edits use this helper because they run late in
+    the lowering pipeline, after graph-pruning passes.
+    """
+    assert op.operation_name is None, f"Operation registered twice: {op}"
+
+    index = len(graph.operations)
+    while True:
+        name = graph.qualify_name(f"op{index}")
+        if name not in graph.name_to_op:
+            break
+        index += 1
+
+    graph.operations.append(op)
+    graph.name_to_op[name] = op
+    op.operation_name = name
+    return name
 
 
 class SchedNodeArg(NamedTuple):
@@ -1581,7 +1617,8 @@ def iteration_space(n: SchedulerNode) -> dict[sympy.Symbol, sympy.Expr]:
         # spurious dims even for multi-input reductions (matmul, conv2d, etc.).
         result = next(iter(n.read_writes.writes)).ranges.copy()
         for dep in n.read_writes.reads:
-            if isinstance(dep, StarDep):
+            # Ordering-only dependencies carry no index/range information.
+            if isinstance(dep, (StarDep, WeakDep)):
                 continue
             for sym, size in dep.ranges.items():
                 if sym not in result:
@@ -1604,7 +1641,7 @@ def iteration_space_from_op(op: ComputedBuffer) -> dict[sympy.Symbol, sympy.Expr
         # spurious dims even for multi-input reductions (matmul, conv2d, etc.).
         result = next(iter(rw.writes)).ranges.copy()
         for dep in rw.reads:
-            if isinstance(dep, StarDep):
+            if isinstance(dep, (StarDep, WeakDep)):
                 continue
             for sym, size in dep.ranges.items():
                 if sym not in result:

--- a/torch_spyre/_inductor/scratchpad/graph_editor.py
+++ b/torch_spyre/_inductor/scratchpad/graph_editor.py
@@ -25,6 +25,7 @@ from torch_spyre._inductor.pass_utils import (
     iteration_space_from_op,
     invalidate_op_read_writes,
     op_read_writes,
+    register_operation_after_graph_edit,
 )
 from torch._inductor.virtualized import V
 from torch._inductor.ir import (
@@ -183,7 +184,7 @@ class GraphEditor:
         new_com_buf.origin_node = new_fx_node
         copy_op_metadata(metadata_source, new_com_buf)
         new_com_buf.name = self.lowering.register_buffer(new_com_buf)
-        self.lowering.register_operation(new_com_buf)
+        register_operation_after_graph_edit(self.lowering, new_com_buf)
         new_buf_name = new_com_buf.get_name()
 
         # Clone loops mirror their source/consumer symbols before Scheduler.

--- a/torch_spyre/_inductor/scratchpad/lx_context_switching.py
+++ b/torch_spyre/_inductor/scratchpad/lx_context_switching.py
@@ -44,7 +44,10 @@ from torch._inductor.lowering import clone as clone_lowering
 from torch_spyre._inductor import config
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.logging_utils import get_inductor_logger, warn_once
-from torch_spyre._inductor.pass_utils import copy_op_metadata
+from torch_spyre._inductor.pass_utils import (
+    copy_op_metadata,
+    register_operation_after_graph_edit,
+)
 from torch_spyre._inductor.scratchpad.allocator import ScratchpadOptimizationPass
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 from torch_spyre._inductor.scratchpad.utils import calculate_liveness
@@ -233,7 +236,7 @@ def _dump_buffers(
         copy_op_metadata(buf, dump_buf)  # keep it in buf's coarse-tile/loop-group
         dump_buf.op_it_space_splits = getattr(buf, "op_it_space_splits", ({}, {}))
         dump_buf.name = graph.register_buffer(dump_buf)
-        graph.register_operation(dump_buf)
+        register_operation_after_graph_edit(graph, dump_buf)
 
         # Reposition into graph.operations right before target_op
         # (remove()+insert(), same pattern GraphEditor.push_allocation_with_clone
@@ -302,7 +305,7 @@ def _restore_buffers(
         # clones around a buffer that no longer resides on LX at all).
         restore_buf.op_it_space_splits = getattr(buf, "op_it_space_splits", ({}, {}))
         restore_buf.name = graph.register_buffer(restore_buf)
-        graph.register_operation(restore_buf)
+        register_operation_after_graph_edit(graph, restore_buf)
 
         graph.operations.remove(restore_buf)
         graph.operations.insert(graph.operations.index(target_op) + 1, restore_buf)

--- a/torch_spyre/_inductor/sliding_window_plan.py
+++ b/torch_spyre/_inductor/sliding_window_plan.py
@@ -153,9 +153,9 @@ class SlidingWindowPlan:
     def read_start_logical(self, qi: int) -> int:
         """``read_start`` converted back to a logical coordinate.
 
-        ``window_band_mask`` needs this, not ``read_start``: its row side is
-        logical, so the column side must be too for ``delta = row - column``
-        to mean anything. A no-op whenever ``buffer_origin`` is 0.
+        A logical-coordinate mask needs this, not ``read_start``: its row and
+        column sides must use the same coordinate space. A no-op whenever
+        ``buffer_origin`` is 0.
         """
         return self.read_start(qi) + self.buffer_origin
 
@@ -412,47 +412,3 @@ def plan_sliding_window(
         cache_capacity=cache_capacity,
         buffer_origin=buffer_origin,
     )
-
-
-def band_valid_start(valid_start: list[int] | None) -> list[int] | None:
-    """The ``valid_start`` the band must actually apply, or None when it masks nothing.
-
-    A caller with no left padding passes zeros rather than tracking whether it has
-    any; collapsing that to None here is what keeps the band broadcast over batch
-    and keeps ``block_is_fully_attended``'s skip available.
-    """
-    if not valid_start or max(valid_start) <= 0:
-        return None
-    return list(valid_start)
-
-
-def band_batch(valid_start: list[int] | None) -> int:
-    """Leading dimension of the band: 1 unless the threshold differs per sequence.
-
-    The band is ``q_block x buffer_width`` per distinct threshold, so a uniform one
-    stays a single broadcast row rather than one copy per batch entry.
-    """
-    effective = band_valid_start(valid_start)
-    if effective is None or min(effective) == max(effective):
-        return 1
-    return len(effective)
-
-
-def check_valid_start(
-    valid_start: list[int] | None, batch: int, cache_seqlen: int
-) -> str | None:
-    """Why this ``valid_start`` is invalid, or None.
-
-    Strings not exceptions, matching ``check_window_read`` -- this module stays
-    free of torch and of the backend's error classes. Batch is a tensor property,
-    so this cannot live in ``rejection_reason``, which answers placement questions
-    from integers alone.
-    """
-    if valid_start is None:
-        return None
-    if len(valid_start) != batch:
-        return f"valid_start has {len(valid_start)} entries for a batch of {batch}"
-    for entry in valid_start:
-        if entry < 0 or entry > cache_seqlen:
-            return f"valid_start={entry} outside [0, cache_seqlen={cache_seqlen}]"
-    return None


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [x] cleanup
- [ ] documentation

#### What this PR does:

Follow-up to #3405 for the Gemma 3/4 integration in torch-spyre/hf-adapters#496.

- replaces position-dependent Python geometry with one required runtime additive `attention_mask`
- removes `cache_seqlen`, `buffer_origin`, `valid_start`, `decode_mask`, and the internal `window_band_mask` op
- keeps both prefill and decode on fused sliding-window attention; the enabled SWA path does not route through SDPA
- reuses one decode graph while mask contents and tensor cache indices change
- adds a required static `is_causal` guarantee: causal square prefill retains narrow per-window reads, while generic masks scan the complete physical cache in bounded chunks
- supports masks with non-causal regions, including Gemma 4 bidirectional vision blocks
- fixes online softmax for fully masked `-inf` chunks and removes dead synthetic accumulator initialization
- fixes D=256, transposed-query, batched MHA/GQA, and related compiler-pass issues exposed by the kernel
- adds a measured tiling selector for Gemma 3/4 production SWA shapes, while retaining the proven conservative fallback for uncalibrated shapes and hardware

The public schema is now:

```python
torch.ops.spyre.sliding_window_attention(
    query, key, value, attention_mask, window_size, is_causal, scale=None
)
```

`window_size`, `is_causal`, `scale`, shapes, and dtypes are static model configuration. Decode position, padding, valid rows, window placement, and bidirectional regions are tensor data. `is_causal=False` makes no semantic claim beyond disabling causal-only narrow reads; the tensor mask remains authoritative.

The SWA tiling selector uses only compile-time shape, dtype, core-count, and LX-budget facts, so it does not reintroduce specialization on mask contents or cache position. On the calibrated 32-core target it keeps all query heads in one coarse tile and selects 576-row KV blocks for Gemma 3 or 512-row KV blocks for Gemma 4. Other geometries keep the prior 512-row/at-most-four-head fallback exactly.

#### Which issue(s) this PR is related to:

- Follow-up to #3405
- Companion integration: torch-spyre/hf-adapters#496

#### Special notes for your reviewer:

Focused validation on current `main` (`769c9d2d`):

- selector/SDPA unit tests plus runtime-mask and non-causal regressions: 22 passed, 20 subtests passed
- Gemma 3 production compact-cache decode device test: passed
- Gemma 4 production decode and prefill device tests: 2 passed
- production selector: cosine 0.999998, no recompilation, expected 16-head/512-KV policy
- hf-adapters Gemma 4 Spyre A/B suite: 5 passed, including 70 decode steps across a cache roll
- hf-adapters focused CPU SWA suite: 36 passed
- Gemma 4 E2B CPU-vs-Spyre greedy-token comparison from the preceding revision: 5/5 top-1 agreement, no NaNs
- Ruff, formatting, py_compile, and diff checks pass

Measured warm E2E results from the SWA shape sweep:

| model / query rows | previous policy | selected policy | previous | selected | change |
|---|---|---|---:|---:|---:|
| Gemma 4 / 1 | H=4, KV=512 | H=16, KV=512 | 1.558 ms | 1.142 ms | -26.7% |
| Gemma 4 / 64 | H=4, KV=512 | H=16, KV=512 | 2.510 ms | 1.620 ms | -35.5% |
| Gemma 4 / 512 | H=4, KV=512 | H=16, KV=512 | 17.704 ms | 11.927 ms | -32.6% |
| Gemma 3 / 1 | H=4, KV=512 | H=8, KV=576 | 0.738 ms | 0.503 ms | -31.8% |
| Gemma 3 / 64 | H=4, KV=512 | H=8, KV=576 | 1.018 ms | 0.666 ms | -34.6% |

All successful sweep points met the correctness threshold and reported no recompilation. A final production-selector Gemma 4 decode rerun measured 1.156 ms E2E / 0.901 ms kernel with cosine 0.999998.

Explicit full-core work division was also tested rather than assumed. It is not currently valid for this decomposition: a query split propagates to the mask's singleton broadcast-head dimension, and KV splits encounter physical-stick placement constraints. The selected policies therefore improve the existing legal coarse tiling without hiding dropped or invalid work-division hints.

The compact 1088-column mask build plus host-to-device transfer measured 146.2 us median and is paid once per decode step, shared across all sliding layers. Generic non-causal prefill scans the full physical cache because future allowed regions are known only from runtime mask values; decode remains bounded by the compact cache.

#### Does this PR introduce a user-facing change?

Yes. This intentionally replaces the unshipped #3405 API. `attention_mask` is required and is the only runtime geometry input. `is_causal` is a required static access-plan guarantee, not position-dependent state.
