### PR TITLE
fix(inductor): select SDPA tiling from LX footprint

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_sdpa_tiling_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_sdpa_tiling_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_sdpa_tiling.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_sdpa_tiling.py
+++ b/tests/inductor/test_sdpa_tiling.py
@@ -124,14 +124,38 @@ class TestSDPATiling(unittest.TestCase):
                     {"num_heads": 8, "max_seqlen_q": 4, "max_seqlen_kv": 4},
                 )
 
-    def test_decode_uses_full_heads_and_512_kv_blocks(self):
+    def test_decode_uses_geometry_calibrated_policy(self):
         cases = (
-            ("granite", 32, 8, 128, 82048),
-            ("gemma-local", 16, 8, 256, 49216),
-            ("gemma-global-12b", 16, 1, 512, 65600),
-            ("gemma-global-26b", 16, 2, 512, 65600),
+            ("granite", 32, 8, 128, 4096, None, 540800),
+            ("gemma-local", 16, 8, 256, 2048, None, 147520),
+            (
+                "gemma-global-12b",
+                16,
+                1,
+                512,
+                512,
+                {"num_heads": 16, "max_seqlen_q": 1, "max_seqlen_kv": 1},
+                4100,
+            ),
+            (
+                "gemma-global-26b",
+                16,
+                2,
+                512,
+                256,
+                {"num_heads": 8, "max_seqlen_q": 1, "max_seqlen_kv": 1},
+                6152,
+            ),
         )
-        for model, num_heads, num_kvheads, head_dim, expected_live_bytes in cases:
+        for (
+            model,
+            num_heads,
+            num_kvheads,
+            head_dim,
+            kv_block_size,
+            work_div,
+            expected_live_bytes,
+        ) in cases:
             with self.subTest(model=model):
                 config = self._select(
                     num_heads=num_heads,
@@ -141,15 +165,59 @@ class TestSDPATiling(unittest.TestCase):
                     head_dim=head_dim,
                 )
 
-                self.assertEqual(config.strategy, "decode_tiled")
-                self.assertEqual(config.reason, "single-query decode")
-                self.assertEqual(config.kv_block_size, 512)
-                self.assertEqual(config.num_kv_blocks, 16)
+                expected_strategy = (
+                    "decode_work_divided_tiled" if work_div else "decode_tiled"
+                )
+                self.assertEqual(config.strategy, expected_strategy)
+                self.assertEqual(
+                    config.reason, "single-query decode; geometry-calibrated"
+                )
+                self.assertEqual(config.kv_block_size, kv_block_size)
+                self.assertEqual(config.num_kv_blocks, 8192 // kv_block_size)
                 self.assertEqual(config.num_head_tiles, 1)
-                self.assertIsNone(config.work_div)
+                self.assertEqual(config.work_div, work_div)
                 self.assertEqual(
                     config.estimated_live_bytes_per_core, expected_live_bytes
                 )
+
+    def test_unknown_decode_geometry_keeps_conservative_policy(self):
+        config = self._select(
+            num_heads=12,
+            num_kvheads=12,
+            max_seqlen_q=1,
+            max_seqlen_kv=8192,
+            head_dim=64,
+        )
+
+        self.assertEqual(config.strategy, "decode_tiled")
+        self.assertEqual(config.kv_block_size, 512)
+        self.assertEqual(config.num_kv_blocks, 16)
+        self.assertIsNone(config.work_div)
+
+    def test_decode_block_caps_cover_calibrated_lengths(self):
+        cases = (
+            ("granite", 32, 8, 128, (512, 1024, 4096)),
+            ("gemma-local", 16, 8, 256, (512, 1024, 2048)),
+            ("gemma-global-12b", 16, 1, 512, (512, 512, 512)),
+            ("gemma-global-26b", 16, 2, 512, (256, 256, 256)),
+        )
+        for model, num_heads, num_kvheads, head_dim, expected_blocks in cases:
+            for sequence_length, expected_block in zip(
+                (512, 1024, 8192), expected_blocks
+            ):
+                with self.subTest(model=model, sequence_length=sequence_length):
+                    config = self._select(
+                        num_heads=num_heads,
+                        num_kvheads=num_kvheads,
+                        max_seqlen_q=1,
+                        max_seqlen_kv=sequence_length,
+                        head_dim=head_dim,
+                    )
+
+                    self.assertEqual(config.kv_block_size, expected_block)
+                    self.assertEqual(
+                        config.num_kv_blocks, sequence_length // expected_block
+                    )
 
     def test_long_contexts_keep_blocking_and_loop_grouping(self):
         for sequence_length in (8 * 1024, 32 * 1024):

--- a/tests/inductor/test_sdpa_tiling.py
+++ b/tests/inductor/test_sdpa_tiling.py
@@ -20,7 +20,7 @@ from torch_spyre._inductor.decompositions import _select_sdpa_tiling
 
 
 class TestSDPATiling(unittest.TestCase):
-    _LX_BUDGET = 800 * 1024
+    _LX_BUDGET = 1_625_344
 
     def _select(
         self,
@@ -30,9 +30,10 @@ class TestSDPATiling(unittest.TestCase):
         num_kvheads=12,
         max_seqlen_q=512,
         max_seqlen_kv=512,
+        head_dim=128,
         element_size=2,
         num_cores=32,
-        score_lx_budget_bytes=_LX_BUDGET,
+        lx_budget_bytes=_LX_BUDGET,
     ):
         return _select_sdpa_tiling(
             batch_size=batch_size,
@@ -40,13 +41,14 @@ class TestSDPATiling(unittest.TestCase):
             num_kvheads=num_kvheads,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_kv=max_seqlen_kv,
+            head_dim=head_dim,
             element_size=element_size,
             num_cores=num_cores,
-            score_lx_budget_bytes=score_lx_budget_bytes,
+            lx_budget_bytes=lx_budget_bytes,
         )
 
     def test_issue_4339_uses_one_block_and_work_division(self):
-        config = self._select()
+        config = self._select(head_dim=64)
 
         self.assertEqual(config.strategy, "work_divided")
         self.assertEqual(config.kv_block_size, 512)
@@ -58,16 +60,69 @@ class TestSDPATiling(unittest.TestCase):
             {"num_heads": 4, "max_seqlen_q": 8, "max_seqlen_kv": 8},
         )
         self.assertEqual(config.score_bytes_per_core, 192 * 1024)
+        self.assertEqual(config.estimated_live_bytes_per_core, 443136)
 
-    def test_granite_gqa_keeps_existing_coarse_tiling(self):
+    def test_granite_gqa_uses_calibrated_work_divided_tile(self):
         config = self._select(num_heads=32, num_kvheads=8)
 
-        self.assertEqual(config.strategy, "coarse_tiled")
-        self.assertEqual(config.reason, "grouped-query attention")
-        self.assertEqual(config.kv_block_size, 128)
-        self.assertEqual(config.num_kv_blocks, 4)
-        self.assertEqual(config.num_head_tiles, 8)
-        self.assertIsNone(config.work_div)
+        self.assertEqual(config.strategy, "work_divided")
+        self.assertEqual(config.kv_block_size, 512)
+        self.assertEqual(config.num_kv_blocks, 1)
+        self.assertEqual(config.num_head_tiles, 1)
+        self.assertEqual(
+            config.work_div,
+            {"num_heads": 4, "max_seqlen_q": 8, "max_seqlen_kv": 4},
+        )
+
+    def test_granite_long_kv_keeps_512_block_and_avoids_head_tiling(self):
+        config = self._select(
+            num_heads=32,
+            num_kvheads=8,
+            max_seqlen_kv=8192,
+        )
+
+        self.assertEqual(config.strategy, "work_divided_tiled")
+        self.assertEqual(config.kv_block_size, 512)
+        self.assertEqual(config.num_kv_blocks, 16)
+        self.assertEqual(config.num_head_tiles, 1)
+        self.assertEqual(
+            config.work_div,
+            {"num_heads": 4, "max_seqlen_q": 8, "max_seqlen_kv": 4},
+        )
+
+    def test_gemma_local_uses_smaller_kv_block_for_wide_heads(self):
+        config = self._select(
+            num_heads=16,
+            num_kvheads=8,
+            head_dim=256,
+            max_seqlen_kv=8192,
+        )
+
+        self.assertEqual(config.strategy, "work_divided_tiled")
+        self.assertEqual(config.kv_block_size, 256)
+        self.assertEqual(config.num_kv_blocks, 32)
+        self.assertEqual(
+            config.work_div,
+            {"num_heads": 2, "max_seqlen_q": 16, "max_seqlen_kv": 8},
+        )
+
+    def test_gemma_global_uses_larger_head_split_and_512_kv_block(self):
+        for num_kvheads in (1, 2):
+            with self.subTest(num_kvheads=num_kvheads):
+                config = self._select(
+                    num_heads=16,
+                    num_kvheads=num_kvheads,
+                    head_dim=512,
+                    max_seqlen_kv=8192,
+                )
+
+                self.assertEqual(config.strategy, "work_divided_tiled")
+                self.assertEqual(config.kv_block_size, 512)
+                self.assertEqual(config.num_kv_blocks, 16)
+                self.assertEqual(
+                    config.work_div,
+                    {"num_heads": 8, "max_seqlen_q": 4, "max_seqlen_kv": 4},
+                )
 
     def test_long_contexts_keep_blocking_and_loop_grouping(self):
         for sequence_length in (8 * 1024, 32 * 1024):
@@ -79,7 +134,8 @@ class TestSDPATiling(unittest.TestCase):
 
                 self.assertEqual(config.strategy, "coarse_tiled")
                 self.assertEqual(
-                    config.reason, "sequence extent exceeds the full-block limit"
+                    config.reason,
+                    "query extent exceeds the calibrated work-divided limit",
                 )
                 self.assertEqual(config.kv_block_size, 512)
                 self.assertGreater(config.num_kv_blocks, 1)
@@ -98,13 +154,24 @@ class TestSDPATiling(unittest.TestCase):
         )
         self.assertIsNone(config.work_div)
 
-    def test_score_footprint_over_budget_keeps_coarse_tiling(self):
-        config = self._select(batch_size=2, score_lx_budget_bytes=300 * 1024)
+    def test_lx_budget_reduces_kv_block_until_live_values_fit(self):
+        config = self._select(batch_size=2, lx_budget_bytes=300 * 1024)
 
-        self.assertEqual(config.score_bytes_per_core, 384 * 1024)
+        self.assertEqual(config.strategy, "work_divided_tiled")
+        self.assertEqual(config.kv_block_size, 64)
+        self.assertEqual(config.num_kv_blocks, 8)
+        self.assertEqual(config.score_bytes_per_core, 48 * 1024)
+        self.assertEqual(config.estimated_live_bytes_per_core, 296448)
+
+    def test_live_footprint_over_budget_keeps_coarse_tiling(self):
+        config = self._select(batch_size=2, lx_budget_bytes=250 * 1024)
+
         self.assertEqual(config.strategy, "coarse_tiled")
+        self.assertEqual(config.score_bytes_per_core, 48 * 1024)
+        self.assertEqual(config.estimated_live_bytes_per_core, 296448)
         self.assertEqual(
-            config.reason, "per-core score footprint exceeds the LX budget"
+            config.reason,
+            "estimated per-core live footprint exceeds the LX budget",
         )
 
     def test_work_division_scales_with_available_cores(self):

--- a/tests/inductor/test_sdpa_tiling.py
+++ b/tests/inductor/test_sdpa_tiling.py
@@ -124,6 +124,33 @@ class TestSDPATiling(unittest.TestCase):
                     {"num_heads": 8, "max_seqlen_q": 4, "max_seqlen_kv": 4},
                 )
 
+    def test_decode_uses_full_heads_and_512_kv_blocks(self):
+        cases = (
+            ("granite", 32, 8, 128, 82048),
+            ("gemma-local", 16, 8, 256, 49216),
+            ("gemma-global-12b", 16, 1, 512, 65600),
+            ("gemma-global-26b", 16, 2, 512, 65600),
+        )
+        for model, num_heads, num_kvheads, head_dim, expected_live_bytes in cases:
+            with self.subTest(model=model):
+                config = self._select(
+                    num_heads=num_heads,
+                    num_kvheads=num_kvheads,
+                    max_seqlen_q=1,
+                    max_seqlen_kv=8192,
+                    head_dim=head_dim,
+                )
+
+                self.assertEqual(config.strategy, "decode_tiled")
+                self.assertEqual(config.reason, "single-query decode")
+                self.assertEqual(config.kv_block_size, 512)
+                self.assertEqual(config.num_kv_blocks, 16)
+                self.assertEqual(config.num_head_tiles, 1)
+                self.assertIsNone(config.work_div)
+                self.assertEqual(
+                    config.estimated_live_bytes_per_core, expected_live_bytes
+                )
+
     def test_long_contexts_keep_blocking_and_loop_grouping(self):
         for sequence_length in (8 * 1024, 32 * 1024):
             with self.subTest(sequence_length=sequence_length):

--- a/tests/inductor/test_sdpa_tiling.py
+++ b/tests/inductor/test_sdpa_tiling.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for the SDPA decomposition tiling cost model."""
+
+import unittest
+
+from torch_spyre._inductor.decompositions import _select_sdpa_tiling
+
+
+class TestSDPATiling(unittest.TestCase):
+    _LX_BUDGET = 800 * 1024
+
+    def _select(
+        self,
+        *,
+        batch_size=1,
+        num_heads=12,
+        num_kvheads=12,
+        max_seqlen_q=512,
+        max_seqlen_kv=512,
+        element_size=2,
+        num_cores=32,
+        score_lx_budget_bytes=_LX_BUDGET,
+    ):
+        return _select_sdpa_tiling(
+            batch_size=batch_size,
+            num_heads=num_heads,
+            num_kvheads=num_kvheads,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_kv=max_seqlen_kv,
+            element_size=element_size,
+            num_cores=num_cores,
+            score_lx_budget_bytes=score_lx_budget_bytes,
+        )
+
+    def test_issue_4339_uses_one_block_and_work_division(self):
+        config = self._select()
+
+        self.assertEqual(config.strategy, "work_divided")
+        self.assertEqual(config.kv_block_size, 512)
+        self.assertEqual(config.num_kv_blocks, 1)
+        self.assertEqual(config.num_q_tiles, 1)
+        self.assertEqual(config.num_head_tiles, 1)
+        self.assertEqual(
+            config.work_div,
+            {"num_heads": 4, "max_seqlen_q": 8, "max_seqlen_kv": 8},
+        )
+        self.assertEqual(config.score_bytes_per_core, 192 * 1024)
+
+    def test_granite_gqa_keeps_existing_coarse_tiling(self):
+        config = self._select(num_heads=32, num_kvheads=8)
+
+        self.assertEqual(config.strategy, "coarse_tiled")
+        self.assertEqual(config.reason, "grouped-query attention")
+        self.assertEqual(config.kv_block_size, 128)
+        self.assertEqual(config.num_kv_blocks, 4)
+        self.assertEqual(config.num_head_tiles, 8)
+        self.assertIsNone(config.work_div)
+
+    def test_long_contexts_keep_blocking_and_loop_grouping(self):
+        for sequence_length in (8 * 1024, 32 * 1024):
+            with self.subTest(sequence_length=sequence_length):
+                config = self._select(
+                    max_seqlen_q=sequence_length,
+                    max_seqlen_kv=sequence_length,
+                )
+
+                self.assertEqual(config.strategy, "coarse_tiled")
+                self.assertEqual(
+                    config.reason, "sequence extent exceeds the full-block limit"
+                )
+                self.assertEqual(config.kv_block_size, 512)
+                self.assertGreater(config.num_kv_blocks, 1)
+                self.assertGreater(config.num_q_tiles, 1)
+                self.assertEqual(
+                    config.kv_blocks_per_loop_group,
+                    min(config.num_kv_blocks, max(1, 16 // config.num_q_tiles)),
+                )
+
+    def test_non_divisible_sequence_keeps_coarse_tiling(self):
+        config = self._select(max_seqlen_q=500, max_seqlen_kv=500)
+
+        self.assertEqual(config.strategy, "coarse_tiled")
+        self.assertEqual(
+            config.reason, "no exact full-core head/sequence work division"
+        )
+        self.assertIsNone(config.work_div)
+
+    def test_score_footprint_over_budget_keeps_coarse_tiling(self):
+        config = self._select(batch_size=2, score_lx_budget_bytes=300 * 1024)
+
+        self.assertEqual(config.score_bytes_per_core, 384 * 1024)
+        self.assertEqual(config.strategy, "coarse_tiled")
+        self.assertEqual(
+            config.reason, "per-core score footprint exceeds the LX budget"
+        )
+
+    def test_work_division_scales_with_available_cores(self):
+        config = self._select(num_cores=16)
+
+        self.assertEqual(config.strategy, "work_divided")
+        self.assertEqual(
+            config.work_div,
+            {"num_heads": 4, "max_seqlen_q": 4, "max_seqlen_kv": 4},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -241,13 +241,53 @@ def _select_sdpa_tiling(
     fallback_kv_blocks_per_loop_group = _kv_blocks_per_loop_group(
         fallback_num_q_tiles, fallback_num_kv_blocks
     )
+    score_bytes_per_core: int | None = None
+    estimated_live_bytes_per_core: int | None = None
+    selected_kv_block_size: int | None = None
+
+    # Decode has no useful query-axis parallelism.  Coarse head tiling repeats
+    # the online-softmax body and is substantially slower, while forcing a KV
+    # work split does not propagate through every operation in the
+    # decomposition.  Keep all heads together and let the ordinary scheduler
+    # divide each operation.  A full 512-token KV block wins for the Granite
+    # and Gemma decode geometries; with one query row its worst-case live
+    # footprint is also small enough to check conservatively as if all heads
+    # resided on one core.
+    if max_seqlen_q == 1:
+        selected_kv_block_size = min(max_seqlen_kv, _SDPA_MAX_SEQUENCE_TILE_SIZE)
+        selected_kv_block_size = max(64, selected_kv_block_size // 64 * 64)
+        score_bytes_per_core, estimated_live_bytes_per_core = (
+            _sdpa_estimated_live_bytes_per_core(
+                batch_size=batch_size,
+                heads_per_core=num_heads,
+                query_rows_per_core=1,
+                kv_block_size=min(selected_kv_block_size, max_seqlen_kv),
+                head_dim=head_dim,
+                element_size=element_size,
+            )
+        )
+        if estimated_live_bytes_per_core <= lx_budget_bytes:
+            num_kv_blocks = (
+                max_seqlen_kv + selected_kv_block_size - 1
+            ) // selected_kv_block_size
+            return _SDPATilingConfig(
+                strategy=("decode" if num_kv_blocks == 1 else "decode_tiled"),
+                reason="single-query decode",
+                kv_block_size=selected_kv_block_size,
+                num_kv_blocks=num_kv_blocks,
+                num_q_tiles=1,
+                q_tile_size=1,
+                num_head_tiles=1,
+                kv_blocks_per_loop_group=_kv_blocks_per_loop_group(1, num_kv_blocks),
+                work_div=None,
+                score_bytes_per_core=score_bytes_per_core,
+                estimated_live_bytes_per_core=estimated_live_bytes_per_core,
+                lx_budget_bytes=lx_budget_bytes,
+            )
 
     work_div = _sdpa_full_core_work_division(
         num_heads, num_kvheads, max_seqlen_q, num_cores
     )
-    score_bytes_per_core = None
-    estimated_live_bytes_per_core = None
-    selected_kv_block_size = None
     if work_div is not None and max_seqlen_q <= _SDPA_MAX_SEQUENCE_TILE_SIZE:
         heads_per_core = num_heads // work_div["num_heads"]
         query_rows_per_core = max_seqlen_q // work_div["max_seqlen_q"]

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -65,6 +65,23 @@ _SDPA_LIVE_SCORE_BUFFER_ALLOWANCE = 2
 _SDPA_LIVE_QUERY_BUFFER_ALLOWANCE = 2
 _SDPA_TARGET_KV_BYTES_PER_CORE = 1024 * 1024
 
+# Decode has a very different working set from prefill: Lq == 1 leaves enough
+# LX for substantially longer K/V blocks, but backend scheduling has sharp
+# geometry-dependent cliffs before capacity is exhausted.  These policies are
+# the stable minima from sweeps at Lkv=512, 1024, and 8192.  Unknown geometries
+# retain the conservative 512-token block and no explicit work division.
+#
+# Values are (maximum K/V block size, logical-head work-division split).
+_SDPA_DECODE_POLICIES: dict[tuple[int, int, int], tuple[int, int | None]] = {
+    # Granite 3.3 8B
+    (32, 8, 128): (4096, None),
+    # Gemma 4 12B/26B local attention
+    (16, 8, 256): (2048, None),
+    # Gemma 4 12B and 26B global attention, respectively
+    (16, 1, 512): (512, 16),
+    (16, 2, 512): (256, 8),
+}
+
 
 @dataclasses.dataclass(frozen=True)
 class _SDPATilingConfig:
@@ -245,21 +262,36 @@ def _select_sdpa_tiling(
     estimated_live_bytes_per_core: int | None = None
     selected_kv_block_size: int | None = None
 
-    # Decode has no useful query-axis parallelism.  Coarse head tiling repeats
-    # the online-softmax body and is substantially slower, while forcing a KV
-    # work split does not propagate through every operation in the
-    # decomposition.  Keep all heads together and let the ordinary scheduler
-    # divide each operation.  A full 512-token KV block wins for the Granite
-    # and Gemma decode geometries; with one query row its worst-case live
-    # footprint is also small enough to check conservatively as if all heads
-    # resided on one core.
+    # Decode has no useful query-axis parallelism, and coarse head tiling
+    # repeats the online-softmax body.  Keep all heads in one coarse tile.
+    # Most geometries are fastest with ordinary scheduling, but very high GQA
+    # ratios benefit from splitting the expanded logical-head axis explicitly.
+    # The K/V block cap is performance-driven and deliberately independent of
+    # the LX limit: sweeps show discontinuities well before capacity is full.
     if max_seqlen_q == 1:
-        selected_kv_block_size = min(max_seqlen_kv, _SDPA_MAX_SEQUENCE_TILE_SIZE)
+        block_limit, head_split = _SDPA_DECODE_POLICIES.get(
+            (num_heads, num_kvheads, head_dim),
+            (_SDPA_MAX_SEQUENCE_TILE_SIZE, None),
+        )
+        selected_kv_block_size = min(max_seqlen_kv, block_limit)
         selected_kv_block_size = max(64, selected_kv_block_size // 64 * 64)
+        decode_work_div = None
+        heads_per_core = num_heads
+        if (
+            head_split is not None
+            and head_split <= num_cores
+            and num_heads % head_split == 0
+        ):
+            decode_work_div = {
+                "num_heads": head_split,
+                "max_seqlen_q": 1,
+                "max_seqlen_kv": 1,
+            }
+            heads_per_core = num_heads // head_split
         score_bytes_per_core, estimated_live_bytes_per_core = (
             _sdpa_estimated_live_bytes_per_core(
                 batch_size=batch_size,
-                heads_per_core=num_heads,
+                heads_per_core=heads_per_core,
                 query_rows_per_core=1,
                 kv_block_size=min(selected_kv_block_size, max_seqlen_kv),
                 head_dim=head_dim,
@@ -270,16 +302,24 @@ def _select_sdpa_tiling(
             num_kv_blocks = (
                 max_seqlen_kv + selected_kv_block_size - 1
             ) // selected_kv_block_size
+            if decode_work_div is None:
+                strategy = "decode" if num_kv_blocks == 1 else "decode_tiled"
+            else:
+                strategy = (
+                    "decode_work_divided"
+                    if num_kv_blocks == 1
+                    else "decode_work_divided_tiled"
+                )
             return _SDPATilingConfig(
-                strategy=("decode" if num_kv_blocks == 1 else "decode_tiled"),
-                reason="single-query decode",
+                strategy=strategy,
+                reason="single-query decode; geometry-calibrated",
                 kv_block_size=selected_kv_block_size,
                 num_kv_blocks=num_kv_blocks,
                 num_q_tiles=1,
                 q_tile_size=1,
                 num_head_tiles=1,
                 kv_blocks_per_loop_group=_kv_blocks_per_loop_group(1, num_kv_blocks),
-                work_div=None,
+                work_div=decode_work_div,
                 score_bytes_per_core=score_bytes_per_core,
                 estimated_live_bytes_per_core=estimated_live_bytes_per_core,
                 lx_budget_bytes=lx_budget_bytes,
@@ -769,7 +809,8 @@ def spyre__sdpa_overrideable(
     # that materializes a full [B, H, S_kv, D] copy that OOMs on long KV. K/V are
     # instead normalized PER BLOCK inside the loop (keys_T's .contiguous() and
     # the per-block v_blk.contiguous()), each a bounded [B, H, kv_block_size, D]
-    # copy (kv_block_size <= 512), never the full [B, H, S_kv, D].
+    # copy chosen by the cost model, never an implicit full [B, H, S_kv, D]
+    # copy. Decode can intentionally choose a full block for short sequences.
     original_query_strides = query.stride()
     query = query.contiguous()
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -25,6 +25,8 @@ independent from PyTorch's global ``torch._inductor.decomposition.decompositions
 registry; Spyre never mutates the global table.
 """
 
+import contextlib
+import dataclasses
 import math
 import threading
 from typing import Any, Callable, Optional, Sequence, Union
@@ -57,6 +59,25 @@ logger = get_inductor_logger("decompositions")
 _SDPA_MAX_SEQUENCE_TILE_SIZE = 512
 _SDPA_MAX_TILE_PAIRS_PER_LOOP_GROUP = 16
 _SDPA_PREFERRED_HEADS_PER_TILE = (4, 2, 1)
+_SDPA_MAX_HEAD_WORK_DIVISION = 4
+_SDPA_LIVE_SCORE_BUFFER_ALLOWANCE = 2
+
+
+@dataclasses.dataclass(frozen=True)
+class _SDPATilingConfig:
+    """Static SDPA decomposition choices produced by the cost model."""
+
+    strategy: str
+    reason: str
+    kv_block_size: int
+    num_kv_blocks: int
+    num_q_tiles: int
+    q_tile_size: int
+    num_head_tiles: int
+    kv_blocks_per_loop_group: int
+    work_div: dict[str, int] | None
+    score_bytes_per_core: int | None
+    score_lx_budget_bytes: int
 
 
 def _sdpa_num_head_tiles(num_heads: int) -> int:
@@ -87,13 +108,146 @@ def _kv_blocks_per_loop_group(num_q_tiles: int, num_kv_blocks: int) -> int:
 
     DXP specializes a counted Lq loop across every unrolled Lk block.  Bundle
     code size therefore scales with their product, not with the number of Lk
-    blocks alone.  Cap that product at sixteen while retaining at least one Lk
-    block per group.  Thus 8K remains one 4-by-4 group, while 32K becomes
-    sixteen 16-by-1 groups.
+    blocks alone. Cap that product at sixteen when possible, while retaining at
+    least one Lk block per group. Once Lq alone needs sixteen or more tiles,
+    each explicit Lk block gets its own loop group.
     """
     return min(
         num_kv_blocks,
         max(1, _SDPA_MAX_TILE_PAIRS_PER_LOOP_GROUP // num_q_tiles),
+    )
+
+
+def _sdpa_full_core_work_division(
+    num_heads: int,
+    max_seqlen_q: int,
+    max_seqlen_kv: int,
+    num_cores: int,
+) -> dict[str, int] | None:
+    """Find exact head/sequence splits that keep every core occupied.
+
+    Query-shaped operations use the head and query splits, while K/V-only
+    operations use the head and KV splits. Keeping the two sequence split
+    counts equal gives both parts of the decomposition the same core mapping.
+    Prefer at most four head partitions, matching the previously proven SDPA
+    work division.
+    """
+    if num_cores < 1:
+        return None
+
+    max_head_split = min(_SDPA_MAX_HEAD_WORK_DIVISION, num_heads, num_cores)
+    for head_split in range(max_head_split, 0, -1):
+        if num_cores % head_split != 0 or num_heads % head_split != 0:
+            continue
+        sequence_split = num_cores // head_split
+        if max_seqlen_q % sequence_split == 0 and max_seqlen_kv % sequence_split == 0:
+            return {
+                "num_heads": head_split,
+                "max_seqlen_q": sequence_split,
+                "max_seqlen_kv": sequence_split,
+            }
+    return None
+
+
+def _sdpa_score_lx_budget_bytes() -> int:
+    """Reserve room for two score-sized values in frontend-managed LX."""
+    # Import lazily to avoid pulling the scratchpad planner into eager startup.
+    from .scratchpad.allocator import _lx_planning_size
+
+    return _lx_planning_size() // _SDPA_LIVE_SCORE_BUFFER_ALLOWANCE
+
+
+def _select_sdpa_tiling(
+    *,
+    batch_size: int,
+    num_heads: int,
+    num_kvheads: int,
+    max_seqlen_q: int,
+    max_seqlen_kv: int,
+    element_size: int,
+    num_cores: int,
+    score_lx_budget_bytes: int,
+) -> _SDPATilingConfig:
+    """Choose between work division and the existing coarse-tiled SDPA path.
+
+    The work-divided path removes explicit online-softmax KV blocks and the
+    sequential coarse head loop. It is deliberately conservative: use it only
+    for ordinary MHA, when both sequence extents already fit the proven
+    per-block limit, exact splits occupy every core, and one per-core score
+    value consumes no more than half of frontend-managed LX. The other half is
+    left for the simultaneously live exponentiated scores and smaller
+    accumulators.
+
+    Every shape outside those constraints retains the post-#4259 decomposition
+    unchanged, including GQA and long-context loop grouping.
+    """
+    quarter_kv_stick_aligned = max(64, ((max_seqlen_kv + 3) // 4 + 63) // 64 * 64)
+    fallback_kv_block_size = min(_SDPA_MAX_SEQUENCE_TILE_SIZE, quarter_kv_stick_aligned)
+    fallback_num_kv_blocks = (
+        max_seqlen_kv + fallback_kv_block_size - 1
+    ) // fallback_kv_block_size
+    fallback_num_q_tiles = _num_tiles_for_max_extent(
+        max_seqlen_q, _SDPA_MAX_SEQUENCE_TILE_SIZE
+    )
+    fallback_q_tile_size = max_seqlen_q // fallback_num_q_tiles
+    fallback_num_head_tiles = _sdpa_num_head_tiles(num_heads)
+    fallback_kv_blocks_per_loop_group = _kv_blocks_per_loop_group(
+        fallback_num_q_tiles, fallback_num_kv_blocks
+    )
+
+    work_div = _sdpa_full_core_work_division(
+        num_heads, max_seqlen_q, max_seqlen_kv, num_cores
+    )
+    score_bytes_per_core = None
+    if work_div is not None:
+        score_bytes_per_core = (
+            batch_size
+            * (num_heads // work_div["num_heads"])
+            * (max_seqlen_q // work_div["max_seqlen_q"])
+            * max_seqlen_kv
+            * element_size
+        )
+
+    reason = "eligible"
+    if num_heads != num_kvheads:
+        reason = "grouped-query attention"
+    elif (
+        max_seqlen_q > _SDPA_MAX_SEQUENCE_TILE_SIZE
+        or max_seqlen_kv > _SDPA_MAX_SEQUENCE_TILE_SIZE
+    ):
+        reason = "sequence extent exceeds the full-block limit"
+    elif work_div is None:
+        reason = "no exact full-core head/sequence work division"
+    elif score_bytes_per_core is None or score_bytes_per_core > score_lx_budget_bytes:
+        reason = "per-core score footprint exceeds the LX budget"
+
+    if reason == "eligible":
+        return _SDPATilingConfig(
+            strategy="work_divided",
+            reason=reason,
+            kv_block_size=max_seqlen_kv,
+            num_kv_blocks=1,
+            num_q_tiles=1,
+            q_tile_size=max_seqlen_q,
+            num_head_tiles=1,
+            kv_blocks_per_loop_group=1,
+            work_div=work_div,
+            score_bytes_per_core=score_bytes_per_core,
+            score_lx_budget_bytes=score_lx_budget_bytes,
+        )
+
+    return _SDPATilingConfig(
+        strategy="coarse_tiled",
+        reason=reason,
+        kv_block_size=fallback_kv_block_size,
+        num_kv_blocks=fallback_num_kv_blocks,
+        num_q_tiles=fallback_num_q_tiles,
+        q_tile_size=fallback_q_tile_size,
+        num_head_tiles=fallback_num_head_tiles,
+        kv_blocks_per_loop_group=fallback_kv_blocks_per_loop_group,
+        work_div=None,
+        score_bytes_per_core=score_bytes_per_core,
+        score_lx_budget_bytes=score_lx_budget_bytes,
     )
 
 
@@ -491,7 +645,7 @@ def spyre__sdpa_overrideable(
     # that materializes a full [B, H, S_kv, D] copy that OOMs on long KV. K/V are
     # instead normalized PER BLOCK inside the loop (keys_T's .contiguous() and
     # the per-block v_blk.contiguous()), each a bounded [B, H, kv_block_size, D]
-    # copy (kv_block_size <= 2048, see below), never the full [B, H, S_kv, D].
+    # copy (kv_block_size <= 512), never the full [B, H, S_kv, D].
     original_query_strides = query.stride()
     query = query.contiguous()
 
@@ -500,28 +654,34 @@ def spyre__sdpa_overrideable(
         key = key.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
         value = value.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
 
-    # Keep the original approximately four-way KV split for short sequences,
-    # but cap each explicit online-softmax block at the max tile size. Round
-    # the short-case target up to a 64-element fp16 stick as before.
-    quarter_kv_stick_aligned = max(64, ((max_seqlen_kv + 3) // 4 + 63) // 64 * 64)
-    kv_block_size = min(_SDPA_MAX_SEQUENCE_TILE_SIZE, quarter_kv_stick_aligned)
-    num_kv_blocks = (max_seqlen_kv + kv_block_size - 1) // kv_block_size
-
-    # Lq uses equal-sized WSR coarse tiles. Select the smallest exact split
-    # count whose per-tile extent is at most _SDPA_MAX_SEQUENCE_TILE_SIZE.
-    num_q_tiles = _num_tiles_for_max_extent(max_seqlen_q, _SDPA_MAX_SEQUENCE_TILE_SIZE)
-    q_tile_size = max_seqlen_q // num_q_tiles
-    kv_blocks_per_loop_group = _kv_blocks_per_loop_group(num_q_tiles, num_kv_blocks)
+    tiling = _select_sdpa_tiling(
+        batch_size=batch_size,
+        num_heads=num_heads,
+        num_kvheads=num_kvheads,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_kv=max_seqlen_kv,
+        element_size=query.dtype.itemsize,
+        num_cores=config.sencores,
+        score_lx_budget_bytes=_sdpa_score_lx_budget_bytes(),
+    )
     logger.debug(
-        "SDPA sequence tiling: Lq=%s q_tiles=%s q_tile_size=%s "
-        "Lk=%s kv_blocks=%s kv_block_size=%s kv_blocks_per_loop_group=%s",
+        "SDPA tiling: strategy=%s reason=%s Lq=%s q_tiles=%s "
+        "q_tile_size=%s Lk=%s kv_blocks=%s kv_block_size=%s "
+        "head_tiles=%s kv_blocks_per_loop_group=%s work_div=%s "
+        "score_bytes_per_core=%s score_lx_budget_bytes=%s",
+        tiling.strategy,
+        tiling.reason,
         max_seqlen_q,
-        num_q_tiles,
-        q_tile_size,
+        tiling.num_q_tiles,
+        tiling.q_tile_size,
         max_seqlen_kv,
-        num_kv_blocks,
-        kv_block_size,
-        kv_blocks_per_loop_group,
+        tiling.num_kv_blocks,
+        tiling.kv_block_size,
+        tiling.num_head_tiles,
+        tiling.kv_blocks_per_loop_group,
+        tiling.work_div,
+        tiling.score_bytes_per_core,
+        tiling.score_lx_budget_bytes,
     )
 
     with spyre_hint(named_dims=["_b", "num_heads", "max_seqlen_q", "head_dim"]):
@@ -577,24 +737,33 @@ def spyre__sdpa_overrideable(
     with spyre_hint(named_dims=["_b", "num_heads", "max_seqlen_q", "head_dim"]):
         q_scaled = query * scaling_factor
 
-    # Bound each loop group's Lq-tile x unrolled-Lk-block product.  Keeping all
-    # sixteen 32K blocks together creates a 322-SDSC bundle that crashes DXP;
-    # grouping four at a time still produces ~48 MB binaries that crash the
-    # runtime H2D launch because the Lq loop itself has sixteen trips.  A
-    # sixteen-pair budget preserves the proven 8K 4x4 bundle and makes 32K use
-    # sixteen 16x1 bundles of approximately the same code size.  The functional
-    # M/denominator/output SSA carries are materialized between groups and then
-    # resume the exact same online-softmax recurrence.
-    for block_group_start in range(0, num_kv_blocks, kv_blocks_per_loop_group):
+    # Bound each loop group's Lq-tile x unrolled-Lk-block product. Keeping many
+    # Lk blocks together with a long Lq loop produces oversized bundles that can
+    # crash DXP or the runtime H2D launch. A sixteen-pair budget groups blocks
+    # while that is possible; once the Lq loop itself reaches that size, each Lk
+    # block gets a separate group. The functional M/denominator/output SSA
+    # carries are materialized between groups and then resume the exact same
+    # online-softmax recurrence.
+    for block_group_start in range(
+        0, tiling.num_kv_blocks, tiling.kv_blocks_per_loop_group
+    ):
         block_group_end = min(
-            block_group_start + kv_blocks_per_loop_group, num_kv_blocks
+            block_group_start + tiling.kv_blocks_per_loop_group,
+            tiling.num_kv_blocks,
         )
         with spyre_hint(tiles={"batch_size": max(1, batch_size // 2)}):
-            with spyre_hint(tiles={"num_heads": _sdpa_num_head_tiles(num_heads)}):
-                with spyre_hint(num_tiles_per_dim={"max_seqlen_q": num_q_tiles}):
+            with spyre_hint(tiles={"num_heads": tiling.num_head_tiles}):
+                with (
+                    spyre_hint(num_tiles_per_dim={"max_seqlen_q": tiling.num_q_tiles}),
+                    (
+                        spyre_hint(work_div=tiling.work_div)
+                        if tiling.work_div is not None
+                        else contextlib.nullcontext()
+                    ),
+                ):
                     for blk in range(block_group_start, block_group_end):
-                        start = blk * kv_block_size
-                        end = min(start + kv_block_size, max_seqlen_kv)
+                        start = blk * tiling.kv_block_size
+                        end = min(start + tiling.kv_block_size, max_seqlen_kv)
 
                         k_blk = key[
                             ..., start:end, :
@@ -693,7 +862,7 @@ def spyre__sdpa_overrideable(
                             output * correction.unsqueeze(-1) + weighted
                         )  # batch_size, num_heads, max_seqlen_q, head_dim
 
-                        if blk == num_kv_blocks - 1:
+                        if blk == tiling.num_kv_blocks - 1:
                             # The final divide must live INSIDE the innermost tile
                             # scope (#3674 point #4): read past the loop group it
                             # becomes a full untiled buffer whose input

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -59,8 +59,11 @@ logger = get_inductor_logger("decompositions")
 _SDPA_MAX_SEQUENCE_TILE_SIZE = 512
 _SDPA_MAX_TILE_PAIRS_PER_LOOP_GROUP = 16
 _SDPA_PREFERRED_HEADS_PER_TILE = (4, 2, 1)
-_SDPA_MAX_HEAD_WORK_DIVISION = 4
+_SDPA_MHA_MAX_HEAD_WORK_DIVISION = 4
+_SDPA_GQA_MAX_HEAD_WORK_DIVISION = 8
 _SDPA_LIVE_SCORE_BUFFER_ALLOWANCE = 2
+_SDPA_LIVE_QUERY_BUFFER_ALLOWANCE = 2
+_SDPA_TARGET_KV_BYTES_PER_CORE = 1024 * 1024
 
 
 @dataclasses.dataclass(frozen=True)
@@ -77,7 +80,8 @@ class _SDPATilingConfig:
     kv_blocks_per_loop_group: int
     work_div: dict[str, int] | None
     score_bytes_per_core: int | None
-    score_lx_budget_bytes: int
+    estimated_live_bytes_per_core: int | None
+    lx_budget_bytes: int
 
 
 def _sdpa_num_head_tiles(num_heads: int) -> int:
@@ -120,41 +124,87 @@ def _kv_blocks_per_loop_group(num_q_tiles: int, num_kv_blocks: int) -> int:
 
 def _sdpa_full_core_work_division(
     num_heads: int,
+    num_kvheads: int,
     max_seqlen_q: int,
-    max_seqlen_kv: int,
     num_cores: int,
 ) -> dict[str, int] | None:
-    """Find exact head/sequence splits that keep every core occupied.
+    """Find placeable head/query splits that keep every core occupied.
 
-    Query-shaped operations use the head and query splits, while K/V-only
-    operations use the head and KV splits. Keeping the two sequence split
-    counts equal gives both parts of the decomposition the same core mapping.
-    Prefer at most four head partitions, matching the previously proven SDPA
-    work division.
+    MHA can split its physical head dimension up to the previously proven
+    four-way partition. GQA expansion represents the logical head dimension as
+    ``[num_kvheads, expansion]``; only a split contained by the expansion axis
+    is reliably placeable. Cap that split at eight: Gemma global attention is
+    faster at 8x4 than at 16x2 even though both occupy all 32 cores.
     """
     if num_cores < 1:
         return None
 
-    max_head_split = min(_SDPA_MAX_HEAD_WORK_DIVISION, num_heads, num_cores)
+    if num_heads == num_kvheads:
+        max_head_split = _SDPA_MHA_MAX_HEAD_WORK_DIVISION
+    else:
+        if num_heads % num_kvheads:
+            return None
+        max_head_split = min(_SDPA_GQA_MAX_HEAD_WORK_DIVISION, num_heads // num_kvheads)
+    max_head_split = min(max_head_split, num_heads, num_cores)
     for head_split in range(max_head_split, 0, -1):
         if num_cores % head_split != 0 or num_heads % head_split != 0:
             continue
-        sequence_split = num_cores // head_split
-        if max_seqlen_q % sequence_split == 0 and max_seqlen_kv % sequence_split == 0:
-            return {
-                "num_heads": head_split,
-                "max_seqlen_q": sequence_split,
-                "max_seqlen_kv": sequence_split,
-            }
+        query_split = num_cores // head_split
+        if max_seqlen_q % query_split == 0:
+            return {"num_heads": head_split, "max_seqlen_q": query_split}
     return None
 
 
-def _sdpa_score_lx_budget_bytes() -> int:
-    """Reserve room for two score-sized values in frontend-managed LX."""
+def _sdpa_lx_budget_bytes() -> int:
+    """Return the frontend-managed portion of each core's LX."""
     # Import lazily to avoid pulling the scratchpad planner into eager startup.
     from .scratchpad.allocator import _lx_planning_size
 
-    return _lx_planning_size() // _SDPA_LIVE_SCORE_BUFFER_ALLOWANCE
+    return _lx_planning_size()
+
+
+def _sdpa_kv_work_division(
+    *, head_split: int, query_split: int, kv_block_size: int, is_gqa: bool
+) -> int:
+    """Choose a useful, exact KV split without forcing maximum occupancy."""
+    preferred = query_split if not is_gqa else max(4, 16 // head_split)
+    preferred = min(preferred, kv_block_size)
+    for kv_split in range(preferred, 0, -1):
+        if kv_block_size % kv_split == 0:
+            return kv_split
+    return 1
+
+
+def _sdpa_estimated_live_bytes_per_core(
+    *,
+    batch_size: int,
+    heads_per_core: int,
+    query_rows_per_core: int,
+    kv_block_size: int,
+    head_dim: int,
+    element_size: int,
+) -> tuple[int, int]:
+    """Estimate the co-live, non-streamed values for one SDPA iteration.
+
+    K/V operands are streamed by the matmul implementation, so the hard LX
+    check covers the two score-sized values plus query/output-sized values and
+    the two scalar online-softmax accumulators. K/V bytes are handled
+    separately as a performance target, not incorrectly added as permanently
+    resident buffers.
+    """
+    score_bytes = (
+        batch_size * heads_per_core * query_rows_per_core * kv_block_size * element_size
+    )
+    query_bytes = (
+        batch_size * heads_per_core * query_rows_per_core * head_dim * element_size
+    )
+    accumulator_bytes = batch_size * heads_per_core * query_rows_per_core * element_size
+    estimated_live_bytes = (
+        _SDPA_LIVE_SCORE_BUFFER_ALLOWANCE * score_bytes
+        + _SDPA_LIVE_QUERY_BUFFER_ALLOWANCE * query_bytes
+        + 2 * accumulator_bytes
+    )
+    return score_bytes, estimated_live_bytes
 
 
 def _select_sdpa_tiling(
@@ -164,22 +214,19 @@ def _select_sdpa_tiling(
     num_kvheads: int,
     max_seqlen_q: int,
     max_seqlen_kv: int,
+    head_dim: int,
     element_size: int,
     num_cores: int,
-    score_lx_budget_bytes: int,
+    lx_budget_bytes: int,
 ) -> _SDPATilingConfig:
-    """Choose between work division and the existing coarse-tiled SDPA path.
+    """Choose a work-divided tile when it is safe, otherwise use the fallback.
 
-    The work-divided path removes explicit online-softmax KV blocks and the
-    sequential coarse head loop. It is deliberately conservative: use it only
-    for ordinary MHA, when both sequence extents already fit the proven
-    per-block limit, exact splits occupy every core, and one per-core score
-    value consumes no more than half of frontend-managed LX. The other half is
-    left for the simultaneously live exponentiated scores and smaller
-    accumulators.
-
-    Every shape outside those constraints retains the post-#4259 decomposition
-    unchanged, including GQA and long-context loop grouping.
+    Capacity is a rejection constraint, not the objective. Among feasible
+    choices, target about 1 MiB of expanded K/V data per core; local sweeps show
+    that both smaller blocks (extra online-softmax iterations) and larger blocks
+    (more local pressure) lose. Keep Lq and heads in one coarse tile whenever a
+    placeable work division can use every core. Shapes outside the calibrated
+    Lq<=512 regime retain the post-#4259 decomposition.
     """
     quarter_kv_stick_aligned = max(64, ((max_seqlen_kv + 3) // 4 + 63) // 64 * 64)
     fallback_kv_block_size = min(_SDPA_MAX_SEQUENCE_TILE_SIZE, quarter_kv_stick_aligned)
@@ -196,44 +243,80 @@ def _select_sdpa_tiling(
     )
 
     work_div = _sdpa_full_core_work_division(
-        num_heads, max_seqlen_q, max_seqlen_kv, num_cores
+        num_heads, num_kvheads, max_seqlen_q, num_cores
     )
     score_bytes_per_core = None
-    if work_div is not None:
-        score_bytes_per_core = (
-            batch_size
-            * (num_heads // work_div["num_heads"])
-            * (max_seqlen_q // work_div["max_seqlen_q"])
-            * max_seqlen_kv
-            * element_size
+    estimated_live_bytes_per_core = None
+    selected_kv_block_size = None
+    if work_div is not None and max_seqlen_q <= _SDPA_MAX_SEQUENCE_TILE_SIZE:
+        heads_per_core = num_heads // work_div["num_heads"]
+        query_rows_per_core = max_seqlen_q // work_div["max_seqlen_q"]
+        kv_bytes_per_token_per_core = (
+            batch_size * heads_per_core * head_dim * element_size
         )
+        target_kv_block_size = max(
+            64,
+            (_SDPA_TARGET_KV_BYTES_PER_CORE // kv_bytes_per_token_per_core // 64) * 64,
+        )
+        selected_kv_block_size = min(
+            max_seqlen_kv,
+            _SDPA_MAX_SEQUENCE_TILE_SIZE,
+            target_kv_block_size,
+        )
+        selected_kv_block_size = max(64, selected_kv_block_size // 64 * 64)
+        while selected_kv_block_size >= 64:
+            score_bytes_per_core, estimated_live_bytes_per_core = (
+                _sdpa_estimated_live_bytes_per_core(
+                    batch_size=batch_size,
+                    heads_per_core=heads_per_core,
+                    query_rows_per_core=query_rows_per_core,
+                    kv_block_size=min(selected_kv_block_size, max_seqlen_kv),
+                    head_dim=head_dim,
+                    element_size=element_size,
+                )
+            )
+            if estimated_live_bytes_per_core <= lx_budget_bytes:
+                break
+            selected_kv_block_size = selected_kv_block_size // 2 // 64 * 64
 
     reason = "eligible"
-    if num_heads != num_kvheads:
-        reason = "grouped-query attention"
-    elif (
-        max_seqlen_q > _SDPA_MAX_SEQUENCE_TILE_SIZE
-        or max_seqlen_kv > _SDPA_MAX_SEQUENCE_TILE_SIZE
-    ):
-        reason = "sequence extent exceeds the full-block limit"
+    if max_seqlen_q > _SDPA_MAX_SEQUENCE_TILE_SIZE:
+        reason = "query extent exceeds the calibrated work-divided limit"
     elif work_div is None:
         reason = "no exact full-core head/sequence work division"
-    elif score_bytes_per_core is None or score_bytes_per_core > score_lx_budget_bytes:
-        reason = "per-core score footprint exceeds the LX budget"
+    elif (
+        selected_kv_block_size is None
+        or selected_kv_block_size < 64
+        or estimated_live_bytes_per_core is None
+        or estimated_live_bytes_per_core > lx_budget_bytes
+    ):
+        reason = "estimated per-core live footprint exceeds the LX budget"
 
     if reason == "eligible":
+        assert work_div is not None
+        assert selected_kv_block_size is not None
+        num_kv_blocks = (
+            max_seqlen_kv + selected_kv_block_size - 1
+        ) // selected_kv_block_size
+        work_div["max_seqlen_kv"] = _sdpa_kv_work_division(
+            head_split=work_div["num_heads"],
+            query_split=work_div["max_seqlen_q"],
+            kv_block_size=selected_kv_block_size,
+            is_gqa=num_heads != num_kvheads,
+        )
         return _SDPATilingConfig(
-            strategy="work_divided",
+            strategy=("work_divided" if num_kv_blocks == 1 else "work_divided_tiled"),
             reason=reason,
-            kv_block_size=max_seqlen_kv,
-            num_kv_blocks=1,
+            kv_block_size=selected_kv_block_size,
+            num_kv_blocks=num_kv_blocks,
             num_q_tiles=1,
             q_tile_size=max_seqlen_q,
             num_head_tiles=1,
-            kv_blocks_per_loop_group=1,
+            kv_blocks_per_loop_group=_kv_blocks_per_loop_group(1, num_kv_blocks),
             work_div=work_div,
             score_bytes_per_core=score_bytes_per_core,
-            score_lx_budget_bytes=score_lx_budget_bytes,
+            estimated_live_bytes_per_core=estimated_live_bytes_per_core,
+            lx_budget_bytes=lx_budget_bytes,
         )
 
     return _SDPATilingConfig(
@@ -247,7 +330,8 @@ def _select_sdpa_tiling(
         kv_blocks_per_loop_group=fallback_kv_blocks_per_loop_group,
         work_div=None,
         score_bytes_per_core=score_bytes_per_core,
-        score_lx_budget_bytes=score_lx_budget_bytes,
+        estimated_live_bytes_per_core=estimated_live_bytes_per_core,
+        lx_budget_bytes=lx_budget_bytes,
     )
 
 
@@ -660,15 +744,17 @@ def spyre__sdpa_overrideable(
         num_kvheads=num_kvheads,
         max_seqlen_q=max_seqlen_q,
         max_seqlen_kv=max_seqlen_kv,
+        head_dim=head_dim,
         element_size=query.dtype.itemsize,
         num_cores=config.sencores,
-        score_lx_budget_bytes=_sdpa_score_lx_budget_bytes(),
+        lx_budget_bytes=_sdpa_lx_budget_bytes(),
     )
     logger.debug(
         "SDPA tiling: strategy=%s reason=%s Lq=%s q_tiles=%s "
         "q_tile_size=%s Lk=%s kv_blocks=%s kv_block_size=%s "
         "head_tiles=%s kv_blocks_per_loop_group=%s work_div=%s "
-        "score_bytes_per_core=%s score_lx_budget_bytes=%s",
+        "score_bytes_per_core=%s estimated_live_bytes_per_core=%s "
+        "lx_budget_bytes=%s",
         tiling.strategy,
         tiling.reason,
         max_seqlen_q,
@@ -681,7 +767,8 @@ def spyre__sdpa_overrideable(
         tiling.kv_blocks_per_loop_group,
         tiling.work_div,
         tiling.score_bytes_per_core,
-        tiling.score_lx_budget_bytes,
+        tiling.estimated_live_bytes_per_core,
+        tiling.lx_budget_bytes,
     )
 
     with spyre_hint(named_dims=["_b", "num_heads", "max_seqlen_q", "head_dim"]):


### PR DESCRIPTION
## Summary

- add a pure SDPA tiling selector driven by MHA/GQA shape, exact 32-core work division, and per-core LX footprint
- use the one-block, non-coarse-head-tiled path for the issue #4339 shape while preserving the existing post-#4259 strategy for GQA and long contexts
- log the selected strategy, rejection reason, work division, and estimated per-core score footprint
- add CPU-only policy coverage for #4339, Granite GQA, 8K/32K contexts, divisibility, LX pressure, and alternate core counts

Fixes #4339.

## Validation

- `python -m pytest -q tests/inductor/test_sdpa_tiling.py tests/inductor/test_building_blocks.py::TestBuildingBlocks::test_sdpa_head_tiles_limit_heads_per_tile`
- `python -m pytest -q tests/inductor/test_building_blocks.py::TestBuildingBlocks::test_causal_sdpa_unpadded_kv_no_inf tests/inductor/test_building_blocks.py::TestBuildingBlocks::test_granite_gqa_prefill_with_finite_broadcast_mask`
- exact #4339 repro: max abs error 0.003662, mean abs error 0.000182, 0.380 ms mean / 0.353 ms minimum wall time, 24 SDSCs, no `LoopSpec`, 164 KiB binary