### PR TITLE
 ci: fail linters job if pre-commit autofix leaves a diff

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -55,3 +55,6 @@ jobs:
 
       - name: Run pre-commit
         run: pre-commit run --all-files
+
+      - name: Fail if pre-commit modified files
+        run: git diff --exit-code


### PR DESCRIPTION
## Summary

- `ruff-check` in `.pre-commit-config.yaml` runs with `--fix`. When a hook can auto-fix a violation (e.g. unsorted imports/`I001`, unsorted `__all__`/`RUF022`), it rewrites the file in place and the hook reports "Passed" — even though the fix never makes it back into the PR's actual commits.
- The `linters` workflow runs `pre-commit run --all-files` but never checks whether that left the working tree dirty, so this class of violation goes undetected in CI while still being present in the merged code.
- Found while reviewing #4136: two new files had unsorted imports (confirmed with `ruff==0.14.5`, the exact version pinned in `.pre-commit-config.yaml`), but the "linters" check was green because the CI runner's ephemeral checkout got silently autofixed.
- Adds a `git diff --exit-code` step after `pre-commit run --all-files`, so any hook's autofix output now fails the job instead of disappearing. This covers every autofixing hook in the config (ruff-check, pymarkdown's `fix`, yamlfmt), not just ruff.

## Test plan

- [x] Ran `pre-commit run --all-files` against current `main` locally — clean, so this does not introduce any false positive against the existing codebase.
- [x] Simulated the failure mode locally: added a file with unsorted imports, ran `pre-commit run --all-files ruff-check` (autofixes and reports "Failed" locally since the tree becomes dirty), then confirmed `git diff --exit-code` exits non-zero on the resulting diff — the same sequence the CI job will now run.
- [ ] CI on this PR should confirm the `linters` job still passes on a clean branch (no unrelated autofix drift).
