### PR TITLE
packaging: exclude tests.*/extensions.* subpackages from the wheel (fixes #4426)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ package-dir = { torch_spyre = "torch_spyre" }
 package-data = { torch_spyre = ["*.dll", "*.dylib", "*.so"] }
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "extensions"]  # exclude packages matching these glob patterns (empty by default)
+exclude = ["tests*", "extensions*"]  # glob patterns: the trailing * also excludes tests.* / extensions.* subpackages, not just the bare top-level name
 
 [tool.setuptools.dynamic]
 version = {attr = "torch_spyre.version.__version__"}  # any module attribute compatible with ast.literal_eval


### PR DESCRIPTION
## Problem

Fixes #4426.

The wheel ships a top-level `tests` package into `site-packages`, which shadows spyre-inference's own namespace `tests/` package on the prebaked integration image and breaks the regression tier:

```
tests/attention/test_spyre_attn_recorder.py: in test_...
    from tests.attention.test_spyre_attn import _padded_mask_metadata
E   ModuleNotFoundError: No module named 'tests.attention'
```

## Root cause

`[tool.setuptools.packages.find]` uses namespace-aware discovery. The excludes `"tests"` and `"extensions"` match only the bare top-level names. Top-level `tests/` has no `__init__.py`, but its subdirectories do (`tests.models`, `tests.configs`, `tests.oot_framework`, ...), so `find` still discovers and ships them. That materializes `site-packages/tests/` in the installed wheel. On the prebaked image the repo root is not on `sys.path`, so `import tests` binds to torch-spyre's shipped `tests`, which has no `attention` submodule.

## Fix

Add the trailing glob so the whole subtree is excluded:

```diff
-exclude = ["tests", "extensions"]
+exclude = ["tests*", "extensions*"]
```

## Verification

Resolved packages through setuptools' actual pyproject config path (`apply_configuration` → `dist.packages`) against this branch:

| exclude | `tests*` / `extensions*` packages shipped | total |
|---|---|---|
| `["tests", "extensions"]` (before) | **26** (incl. `tests.models`, `tests.configs`, `extensions.spyre-cli.*`) | 81 |
| `["tests*", "extensions*"]` (after) | **0** | 55 |

Only the packaging metadata changes; no source or test code moves.
