### PR TITLE
Fix submitToHardware event name in the profiler's torch trace

### DIFF
--- a/torch_spyre/csrc/profiler/AiuptiActivityHandlers.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiActivityHandlers.cpp
@@ -174,6 +174,8 @@ inline std::string runtimeCbidName(AIUpti_runtime_api_trace_cbid cbid) {
       return "aiuIssueCallback";
     case AIUPTI_RUNTIME_TRACE_CBID_VERIFY_ASYC_MSGS:
       return "aiuVerifyAsyncMsgs";
+    case AIUPTI_RUNTIME_TRACE_CBID_SUBMIT_TO_HARDWARE:
+      return "aiuSubmitToHardware";
     default:
       break;
   }


### PR DESCRIPTION
## Summary

- Added the `AIUPTI_RUNTIME_TRACE_CBID_SUBMIT_TO_HARDWARE` case to
  `runtimeCbidName()`, so the activity is named `aiuSubmitToHardware` in the
  torch trace instead of falling through to `Unknown CBID`.

## Testing

- Verified the event appears as `aiuSubmitToHardware` in a captured torch trace.
- No behavioural change to existing activities: the change adds one case to an
  existing switch and leaves the `default` branch intact.

## Related Issues

- https://github.com/torch-spyre/torch-spyre/issues/2002

## Notes

- Naming only. This does not enable or emit the activity; it maps an existing
  runtime cbid to its display name for traces that already carry it.
- Requires an AIUPTI runtime that emits this cbid. With an older runtime the case
  is simply never hit, so the change is backward compatible.