### PR TITLE
ci: check out pytorch on the trunk push path

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -130,7 +130,14 @@ jobs:
       image_label: ${{ inputs.runner_label || 'image_spyre_backend' }}
       extra_test_flags: -v -m "not xfail"
       extra_test_flags_multi_spyre: -v
-      checkout_pytorch: false
+      # On push (trunk) the matrix scans the whole tests/configs/ tree, which
+      # includes upstream configs whose `path:` references ${TORCH_ROOT} (the
+      # pytorch source tree, e.g. upstream_tests_beta/profiler-test_profiler).
+      # The spyre-backend runner image carries no pytorch source, so run_test.sh
+      # cannot resolve TORCH_ROOT and hard-exits. checkout-pytorch is the only
+      # step that sets TORCH_ROOT, so enable it on the push path. PRs
+      # (regression) do not schedule those configs and skip the checkout.
+      checkout_pytorch: ${{ github.event_name == 'push' }}
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}
       rpm_location: ${{ inputs.rpm_location || '' }}


### PR DESCRIPTION
## What

Enable `checkout_pytorch` on the push (trunk) path in `torch_spyre_tests.yaml`.

## Why

On push to `main`, this workflow calls `_test_matrix.yaml` with `test_type: trunk`. `trunk` is the one tier that scans the whole `tests/configs/` tree, so it schedules upstream configs whose `path:` references `${TORCH_ROOT}` (the pytorch source tree), for example `tests/configs/upstream_tests_beta/profiler-test_profiler.yaml`.

These runs use the spyre-backend runner image, which carries no pytorch source and no editable torch-spyre install. `checkout-pytorch` is the only step that exports `TORCH_ROOT`, and it was gated off (`checkout_pytorch: false`) for every event. So `tests/run_test.sh` cannot resolve `TORCH_ROOT` and hard-exits:

```
[spyre_run]   YAML config references ${TORCH_ROOT} root — resolving...
[spyre_run] Resolving TORCH_ROOT...
ERROR: Could not locate PyTorch source root.
       Expected pytorch/ as a sibling of your torch-spyre repo, or
       an editable install (pip install -e .).
       Set TORCH_ROOT explicitly if the layout differs.
=== Attempt 1 FAILED (exit=1) ===
```

This is a deterministic failure: the config resolves the same way on every pod, so the same-pod and fresh-pod retries cannot clear it. It is distinct from the RAS/hardware failures, which are retryable.

## Change

```diff
-      checkout_pytorch: false
+      checkout_pytorch: ${{ github.event_name == 'push' }}
```

Push builds (trunk) check out pytorch and resolve `TORCH_ROOT`. PR builds run `test_type: regression`, which does not schedule `${TORCH_ROOT}` configs, so they keep skipping the checkout and pay no extra cost.

## Testing

Push-triggered trunk runs on this branch will exercise the changed path once merged to a branch that receives pushes. The change is a one-line workflow input gated on `github.event_name == 'push'`; PR-triggered runs are unaffected by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
