### PR TITLE
test: align spyreccl LOCAL_RANK assertion to actual runtime message

### DIFF
--- a/tests/distributed/spyreccl_backend.py
+++ b/tests/distributed/spyreccl_backend.py
@@ -59,8 +59,9 @@ class TestSpyreCCLBackend(TestCase):
         output = f"{proc.stdout}\n{proc.stderr}"
         assert proc.returncode != 0, output
         # - Torch Spyre will catch and throw with the message:
-        #   LOCAL_RANK must be a valid integer (no digits found): 'invalid'
-        assert "LOCAL_RANK must be a valid integer" in output, output
+        #   LOCAL_RANK is not a valid integer: 'invalid'
+        #   (raised from torch_spyre/csrc/spyre_guard.cpp)
+        assert "LOCAL_RANK is not a valid integer" in output, output
 
     def test_parse_local_rank_negative_raises(self) -> None:
         proc = self._run_local_rank_script("-1")


### PR DESCRIPTION
## Problem

`tests/distributed/spyreccl_backend.py::test_parse_local_rank_invalid_text_raises` asserts that a subprocess given `LOCAL_RANK=invalid` prints `LOCAL_RANK must be a valid integer`. The guard that actually runs raises a different string. `torch_spyre/csrc/spyre_guard.cpp:47` throws:

```
LOCAL_RANK is not a valid integer: 'invalid'
```

So the substring never matches and the test fails:

```
ValueError: LOCAL_RANK is not a valid integer: 'invalid'
assert "LOCAL_RANK must be a valid integer" in output
```

The test and the C++ guard were added in the same commit (`b6ce97b`, #3728), but the assertion string (and its comment) were never matched to the message the guard raises. The C++ source is the authority.

## Fix

Align the assertion and its comment to the runtime message: `LOCAL_RANK is not a valid integer`. No product code changes; the guard behavior is unchanged.

```diff
-        #   LOCAL_RANK must be a valid integer (no digits found): 'invalid'
-        assert "LOCAL_RANK must be a valid integer" in output, output
+        #   LOCAL_RANK is not a valid integer: 'invalid'
+        #   (raised from torch_spyre/csrc/spyre_guard.cpp)
+        assert "LOCAL_RANK is not a valid integer" in output, output
```

## Why it matters

This test carries the `trunk` label, so it runs on every push to `main` (the trunk tier is the only tier that scans the whole `tests/configs/` tree). It has been red on `main` since `b6ce97b`. The regression tier (PR builds) also runs it. The leaf that fails is `run-tests / Test Multi-Spyre Setup`; the other red checks on trunk are downstream aggregators of it.

## Test

<!-- TEST_LINK_PLACEHOLDER -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
