### PR TITLE
Implement Tiling on non bmm Reduction Ranges for automatic hints

### DIFF
--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -1622,8 +1622,10 @@ making any new ones. The exact buffer allocation depends on whether tiling
 is flat (reduction dim only) or nested (outer output dim + inner reduction
 dim):
 
-**Flat (K-only) tiling** — a single `accum_full` HBM buffer is allocated.
-The fill and combine ops both target `accum_full` directly.
+**Flat (reduction-dim only) tiling** — a single `accum_full` HBM buffer is
+allocated.  The fill and combine ops both target `accum_full` directly.  The
+reduction dim here is BMM `k` or the reduced axis of a `sum`/`prod`/`max`/`min`
+reduction (the span-overflow pass now routes both).
 
 1. **Allocate `accum_full`** with the full output shape (`data.ranges`,
    which is already the full output since only `reduction_ranges` was

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -354,33 +354,50 @@ _split_candidates_for_host_dim
           _post_tile_stick_alignment_error -> _within_stick_host_dim
 ```
 
-### 8. Reduction-Controlled Span: Known Unsupported Case
+### 8. Reduction-Controlled Span: Reduction-Range Tiling
 
 Example operation:
 
 ```python
 def fn(x):
-    return x.sum(dim=-1)
+    return x.sum(dim=1)  # x.shape == (1, 65536, 16, 64); reads all of x
 ```
 
-If the only overflowing input coordinate is controlled by a generic reduction
-symbol, output-range tiling cannot fix it and the output-range input scan skips
-that candidate.  BMM is the special case: when the reduction symbol is the
-single identifiable matmul `k`, the planner can use the BMM K fallback to emit
-an independent reduction-range tile plan.
+When the only overflowing input coordinate is controlled by the reduced axis,
+no output-range tile can shrink it -- the reduction range itself must be split
+and accumulated in rounds.  This is supported for:
 
-Code flow for generic reductions:
+- batch-matmul `k` (the original case); and
+- a non-matmul `Reduction` whose `reduction_type` is one of `sum`, `prod`,
+  `max`, `min` **and** which has exactly one reduction range
+  (`_supports_reduction_range_tiling`).  These recombine associatively through
+  coarse tiling's identity-fill + per-tile combine + drain path
+  (`coarse_tile._reduction_identity_value` / `_insert_combine_op`).
+
+The planner emits a `SpanOverflowTileLevel(selected_host_dim=0,
+is_reduction=True)` -- `selected_host_dim` is the reduction-range position,
+always `0` here.  It joins the same bounded search as the output axes, so the
+result can be reduction-only or a nested output+reduction plan.
+
+Code flow:
 
 ```text
-_input_span_infos_controlled_by_output_dims
-  -> coordinate free symbols include reduction-only symbol
-  -> symbol is not in output_symbol_to_dim
-  -> reduction_syms is non-empty and not the BMM K special case
-  -> continue
+_input_span_candidates
+  -> _supports_reduction_range_tiling(op) == True
+  -> _bmm_k_span_infos  (name retained; now covers sum/prod/max/min too)
+       -> reduction-only coordinate span > MAX_SPAN_BYTES
+       -> SpanOverflowCandidate(is_reduction=True)
+  -> _search_min_cost_tile_plan
+       -> _split_candidates_for_axis -> _bmm_k_split_candidates (exact divisors)
 ```
 
-Generic reduction-range tiling and combined output+reduction tiling remain
-future work.
+Still unsupported (raise `Unsupported` with a clear message rather than
+silently dropping the overflow -- `_has_untileable_reduction_span`):
+
+- `mean` (its per-tile scale factor needs separate handling);
+- `xor_sum` / `any` / welford (no Spyre kernel lowering);
+- more than one reduction range on one op (coarse tiling tiles at most one
+  reduction dim per level).
 
 ### 9. Coordinate Jointly Controlled by Two Output Symbols
 
@@ -471,11 +488,11 @@ groups:
 [([op], [(hint_id, split_count), ...])]
 ```
 
-Whether a level tiles an output range or the BMM K reduction range is stored on
-the per-op `DimHint` (`is_reduction`), not in the group-level `levels` list.
-Output-range automatic hints have `is_reduction=False`; BMM K hints have
-`is_reduction=True`. Plans containing K are emitted as independent singleton
-groups, including combined output+K plans.
+Whether a level tiles an output range or a reduction range is stored on the
+per-op `DimHint` (`is_reduction`), not in the group-level `levels` list.
+Output-range automatic hints have `is_reduction=False`; reduction-range hints
+have `is_reduction=True`. Plans containing a reduction-range level are emitted
+as independent singleton groups, including combined output+reduction plans.
 
 ## Scope
 
@@ -486,8 +503,10 @@ The production planner handles:
 - output layout span overflow;
 - reduction/BMM input span overflow when the span is controlled by output
   symbols;
-- BMM input span overflow controlled by the single K reduction symbol,
-  searched together with output dimensions to allow K-only or combined plans;
+- input span overflow controlled by the single reduction symbol -- BMM `k`, or
+  a `sum`/`prod`/`max`/`min` reduction with one reduction range -- searched
+  together with the output dimensions to allow reduction-only or combined
+  plans;
 - one or more output host dimensions per op, bounded by `_MAX_TILE_DIMS`;
 - static `FixedTiledLayout` metadata only.
 
@@ -497,8 +516,11 @@ The planner skips:
 - non-`FixedTiledLayout` ops, including mutation/copy-back intermediate layouts;
 - symbolic/dynamic layout metadata;
 - scalar/full reductions where `op.data.ranges` is empty;
-- Pointwise or Reduction ops with indirect/gather/scatter-style reads;
-- input spans controlled only by reduction symbols for non-BMM reductions;
+- Pointwise or Reduction ops with indirect/gather/scatter-style reads.
+
+It raises `Unsupported` (rather than skipping) when a reduction-only input span
+overflows but the op cannot be reduction-range tiled -- `mean`, welford, or
+more than one reduction range.
 
 ### Support Matrix
 
@@ -509,10 +531,11 @@ The planner skips:
 | Reduction output span overflow | Yes | Emit output-range tile levels if post-tile layout validates |
 | Reduction input span controlled by output dim | Yes | Emit tile for the matching output dim |
 | Coordinate jointly controlled by 2+ output symbols | Yes | Emit a candidate for each contributing dim |
-| Reduction input span controlled by reduction dim | No | Skip candidate; generic reduction-range tiling is future work |
+| `sum`/`prod`/`max`/`min` input span controlled by the single reduction dim | Yes | Emit reduction-range level (`is_reduction=True`); reduction-only or combined output+reduction |
+| `mean` / welford / multi-reduction-range input span on the reduction dim | No | Raise `Unsupported` with a clear message |
 | BMM input span controlled by `b`, `m`, or `n` | Yes | Emit tile for matching output dim |
-| BMM input span controlled by `k` | Yes | Emit K-only or combined output+K levels when full validation clears every span |
-| BMM input spans needing both output dim and `k` tiling | Yes | Search and validate output+K split combinations together |
+| BMM input span controlled by `k` | Yes | Emit reduction-only or combined output+`k` levels when full validation clears every span |
+| BMM input spans needing both output dim and `k` tiling | Yes | Search and validate output+`k` split combinations together |
 | BMM with ambiguous reduction symbols | No | Return no BMM input candidates |
 | Scalar/full reduction | No | Return `None` |
 | Symbolic layout metadata | No | Return `None` |
@@ -558,8 +581,9 @@ For `Reduction` ops, `plan_span_overflow_tile` does:
 check op/layout eligibility
 check _has_indirect_reads(op); skip if true
 skip scalar reductions
+_has_untileable_reduction_span(op); raise Unsupported if true
 collect output span candidates
-collect input span candidates controlled by output dims
+collect input span candidates (output-controlled + reduction-range)
 search for cheapest valid tile combination
 ```
 
@@ -585,11 +609,13 @@ scanning later device coordinates.  That `continue` behavior is important: a
 reduction-controlled outer coordinate must not prevent discovery of a
 more-inner output-controlled overflowing coordinate.
 
-BMM `k` is the special supported reduction symbol.  The output-range scan does
-not create B/M/N candidates for pure K-controlled spans; instead the later BMM
-K fallback can emit an independent reduction-range plan.  Generic
-reduction-only input span overflow remains a known limitation because it needs
-reduction-range tiling and partial accumulation outside the BMM-specific path.
+The output-range scan does not create B/M/N candidates for a coordinate
+controlled only by a reduction symbol.  Instead `_bmm_k_span_infos` collects
+those as `is_reduction=True` candidates for the reduction-range search -- for
+BMM `k`, or for a `sum`/`prod`/`max`/`min` reduction with one reduction range.
+`mean`, welford, and multi-reduction-range ops cannot be reduction-range tiled;
+`_has_untileable_reduction_span` detects an overflow they cannot fix and the
+planner raises `Unsupported` rather than emitting a plan that still overflows.
 
 ## BMM-Specific Symbol Mapping
 
@@ -605,9 +631,15 @@ input dependencies to identify exactly one reduction-only symbol (`k`).  If
 there is not exactly one such symbol, it returns `{}` and the BMM input-span
 path produces no candidates.
 
+The reduction-symbol derivation itself is not BMM-specific -- `_bmm_k_symbol`
+(name retained) resolves the single reduction-only input symbol for any op
+`_supports_reduction_range_tiling` accepts.  For a non-matmul reduction the
+output-symbol map is plain `_output_symbol_to_dim`; only the B/M/N naming above
+is matmul-specific.
+
 BMM input spans controlled by `b`, `m`, or `n` can be fixed by output-range
-tiling.  Pure `k` spans are handled by the BMM K fallback, which emits an
-independent reduction-range tile only when K-only validation clears every span.
+tiling.  Pure `k` spans are handled by the reduction-range search, which emits
+a reduction-range tile only when validation clears every span.
 
 ## Span Calculation
 
@@ -677,7 +709,9 @@ costs tie.
 ## Split Candidates and Cost Search
 
 For each candidate axis, `_split_candidates_for_axis` dispatches output axes to
-`_split_candidates_for_host_dim` and BMM K to `_bmm_k_split_candidates`.
+`_split_candidates_for_host_dim` and the reduction axis to
+`_bmm_k_split_candidates` (exact divisors of the reduction range; gated on
+`_supports_reduction_range_tiling`).
 
 A split candidate is legal only if:
 
@@ -883,7 +917,9 @@ automatic output-range tile plan.  Common reasons:
 - selected host dim is not in `op.data.ranges`;
 - selected range is size 1 or non-integral;
 - no legal exact divisor exists;
-- BMM K-only candidates still leave non-K span overflows;
+- a reduction-only input span overflows but the op cannot be reduction-range
+  tiled (`mean`, welford, more than one reduction range);
+- reduction-only candidates still leave non-reduction span overflows;
 - stick alignment rejects all candidates;
 - `_resize_device_layout` cannot reconstruct the post-tile layout;
 - every tried combination still leaves output/input spans above the limit;
@@ -900,10 +936,13 @@ violates the hardware span limit or silently creates unsynchronized tile loops.
 
 ## Known Limitations
 
-- Reduction-range tiling is not implemented.  Input spans controlled only by
-  reduction symbols are skipped.  If such a skipped span still exceeds the
-  hardware limit, downstream Work Division currently logs a critical overflow
-  diagnostic but does not raise before backend compilation.
+- Reduction-range tiling covers BMM `k` and single-range `sum`/`prod`/`max`/
+  `min` only.  `mean` needs per-tile scale-factor handling; `xor_sum`, `any`,
+  and welford have no Spyre kernel lowering; more than one reduction range on
+  one op is not searched (coarse tiling tiles at most one reduction dim per
+  level).  A reduction-only overflow on any of these raises `Unsupported`.
+- Combined output+reduction plans are emitted as nested levels only (outer
+  output, inner reduction) -- never a single mixed level.
 - Scalar/full reductions are skipped.
 - Indirect/gather/scatter-style Pointwise and Reduction ops are skipped because
   they require the indirect-access SDSC path.
@@ -1027,9 +1066,12 @@ Current coverage includes:
 - Pointwise output span tiling;
 - Reduction output span tiling;
 - Reduction/BMM input span tiling;
+- generic reduction-range tiling for `sum`/`prod`/`max`/`min` (planner emits an
+  `is_reduction=True` level), combined output+reduction plans, and a clear
+  `Unsupported` for `mean` / welford / multi-reduction-range overflows
+  (`TestSpanOverflowGenericReductionRangeTiling`);
 - scalar reduction skip;
 - indirect-read guards for Pointwise and Reduction;
-- reduction-controlled span known limitation;
 - BMM reduction-symbol validation;
 - input-layout stick alignment, including a symbol that jointly controls an
   input dimension together with another symbol rather than controlling it
@@ -1062,74 +1104,48 @@ Current coverage includes:
 - codegen `LoopSpec` tests for Pointwise, Reduction, and LM-head restickify
   shapes;
 - real end-to-end hardware execution and numeric validation (no kernel-launch
-  mocking) for both join cases, comparing against a CPU reference:
-  `test_pointwise_to_non_matmul_reduction_join_numeric` (forces a matching
-  plan for a `sum` reduction and its pointwise producer, since the real
-  planner's independently-chosen plans did not happen to agree for this toy
-  shape) and `test_lm_head_matmul_join_numeric` (the real
-  `vocab=49152`/`sencores=32` shape, comparing tiled vs. untiled mismatch
-  rates against the same CPU reference to separate ordinary fp16
-  accumulation noise from join-introduced error), in
-  `TestSpanOverflowNumericValidation`.
+  mocking), all in `TestSpanOverflowNumericValidation`:
+  - every producer/consumer join direction (see the matrix below), each
+    asserting the tiled result is no worse than the same graph run untiled
+    against the same CPU reference;
+  - `test_lm_head_matmul_join_numeric`, the real `vocab=49152`/`sencores=32`
+    LM-head shape;
+  - `test_generic_{sum,max,min}_reduction_range_tile_numeric` -- a forced
+    reduction-range tile on `sum`/`amax`/`amin` executed and compared to CPU,
+    exercising each identity/combine path;
+  - `test_generic_sum_reduction_range_tile_numeric_organic` -- the real
+    planner picking a reduction-range tile from a genuine (lowered-limit)
+    overflow, with no plan forcing;
+  - `test_mean_reduction_range_overflow_raises_at_compile` -- a `mean`
+    overflow fails the compile with the clear "not supported" message.
 
 Producer/consumer grouping is covered at three depths -- the grouping decision
 (mocked), codegen (compiled with kernel launch mocked, asserting one shared
-`LoopSpec`), and execution (run against a CPU reference):
+`LoopSpec`), and execution (run against a CPU reference).  All directions
+below pass; the numeric tests assert the tiled run is no worse than the same
+graph run untiled against the same CPU reference, so ordinary fp16
+accumulation noise is not mistaken for a tiling bug.
 
 | Producer -> Consumer | Grouping | Codegen | Execution |
 |---|---|---|---|
 | pointwise -> pointwise | pass | pass | pass |
 | pointwise -> reduction | pass | pass | pass |
 | reduction -> pointwise | pass | pass | pass |
-| reduction -> reduction | pass | xfail (wrong write) | xfail |
+| reduction -> reduction | pass | pass | pass |
 | reduction -> matmul | pass | pass | pass |
-| pointwise -> matmul | pass | pass | xfail (wrong numbers) |
-| matmul -> pointwise | pass | pass | xfail (wrong numbers) |
-| matmul -> reduction | pass | pass | xfail (wrong numbers) |
+| pointwise -> matmul | pass | pass | pass |
+| matmul -> pointwise | pass | pass | pass |
+| matmul -> reduction | pass | pass | pass |
 | matmul -> matmul | pass | n/a | n/a |
 | matmul -> pointwise -> matmul | pass | not tested | not tested |
 
-Each remaining xfail carries a `TODO` naming its own cause.  **#3612 ("coarse
-tiling: optional read copy") changed this picture materially and the table
-above reflects the post-#3612 state.**  Five directions that previously xfailed
-now pass: all three matmul codegen cells, and execution for
-`reduction -> pointwise` and `reduction -> matmul`.
+The read-copy path this depends on was reworked by #3612 ("coarse tiling:
+optional read copy") and the transposed post-tile layout it once built was
+fixed by #3613 (`_raw_to_squeezed_pos`).
 
-What survives is a *different* failure, and a worse-shaped one.  The three
-matmul execution cells no longer fail to compile — they compile, run, and
-return wrong numbers.  `test_lm_head_matmul_join_numeric` reports tiled
-mismatches of 48727/49152 (99.14%) against 781/49152 (1.59%) untiled on the
-same reference, which is far outside fp16 accumulation noise.  The prime
-suspect is the positional walk in the read-copy path, which pairs the buffer's
-non-unit dims against iteration extents by position: instrumenting
-`_resize_device_layout` on the `reduction -> matmul` shape shows it building
-`tile_size=[1,4,32,64]` for a buffer of `[1,20,64,32]`, i.e. with the trailing
-dims transposed.  That walk predates this branch (it comes from #3381) and is
-unchanged by it, but it should be ruled out before any of these are blamed on
-the backend again.
-
-`reduction -> reduction` codegen is also xfailed, on a *known wrong write*
-rather than an unexplained failure.  `validate_writer_tile_advance` (#3678)
-rejects the group because the synthesized copy-out writer never advances:
-`_insert_copy_op` keys its per-level extents by raw dim index, while
-`_tiled_dims_for_dep` matches those keys against the squeezed `dN` symbols of
-`dep.index`.  For a terminal reduction whose output is `[1, 20]` the leading
-unit dim squeezes away, the raw key matches nothing, and every tile is written
-on top of tile 0.  It is not gated in the pass because the same code path
-serves `reduction -> matmul`, which works; what separates them is output shape,
-not direction.  Tagged `TODO(copy-out-writer-advance)`.
-
-Only one backend-attributed xfail remains, `reduction -> reduction` execution.
-Given
-that two of the three cases originally filed under the same
-`DtException: Could not find any suitable dimension mapping` diagnosis turned
-out to be unblocked by a read-copy change rather than a backend fix, that
-attribution has not been re-established and should not be assumed.
-
-`matmul -> matmul` is marked n/a rather
-than xfail because it is refused by design -- a Reduction consumer has no
-conform path, so both plans must independently agree
-(`TODO(span-overflow-reduction-conform)`,
+`matmul -> matmul` is marked n/a rather than xfail because it is refused by
+design -- a Reduction consumer has no conform path, so both plans must
+independently agree (`TODO(span-overflow-reduction-conform)`,
 [#3625](https://github.com/torch-spyre/torch-spyre/issues/3625) — the same tag
 as the `can_conform_reduction_tile` limitation above; retire both together).
 

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -36,7 +36,8 @@ Coverage in this file:
 
 import os
 import sys
-import unittest
+
+import regex as re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 from torch_spyre._inductor.work_division import MAX_SPAN_BYTES
@@ -4133,7 +4134,11 @@ class TestSpanOverflowAdditionalPlannerCases(InductorTestCase):
         self.assertEqual(plan.levels[0].selected_host_dim, 0)
         self.assertEqual(plan.levels[0].split_count, 2)
 
-    def test_multiple_reduction_dims_are_skipped_as_known_limitation(self):
+    def test_multiple_reduction_dims_raise_clear_untileable_error(self):
+        # More than one reduction range: coarse tiling can only tile a single
+        # reduction dim per level, so this op cannot be reduction-range tiled.
+        # The reduction-only input span still overflows, so the planner must
+        # fail loudly rather than silently drop it.
         op = _reduction_op((64,), reduction_ranges=(8192, 8192))
         n, k0, k1 = sympy.symbols("n k0 k1")
         dep = MemoryDep(
@@ -4149,11 +4154,16 @@ class TestSpanOverflowAdditionalPlannerCases(InductorTestCase):
             patch.object(soha, "_input_read_deps", return_value=[(dep, layout)]),
             patch.object(soha, "_output_symbol_to_dim", return_value={n: 0}),
         ):
+            # No output-controlled candidate is produced for a reduction-only
+            # coordinate.
             infos = soha._input_span_infos_controlled_by_output_dims(op, max_cores=1)
-            plan = plan_span_overflow_tile(op, max_cores=1)
+            self.assertEqual(infos, [])
 
-        self.assertEqual(infos, [])
-        self.assertIsNone(plan)
+            with self.assertRaisesRegex(
+                Unsupported,
+                "reduction-dimension tiling is not supported",
+            ):
+                plan_span_overflow_tile(op, max_cores=1)
 
     def test_full_scalar_reduction_returns_none(self):
         op = _reduction_op((), reduction_ranges=(4096, 4096, 128))
@@ -4457,7 +4467,7 @@ class TestSpanOverflowAdditionalPlannerCases(InductorTestCase):
             with config.patch({"enable_reduction_tiling": False}):
                 with self.assertRaisesRegex(
                     Unsupported,
-                    "K reduction-range tiling is required but disabled via "
+                    "reduction-range tiling is required but disabled via "
                     "enable_reduction_tiling",
                 ):
                     plan_span_overflow_tile(op, max_cores=1)
@@ -4841,6 +4851,486 @@ class TestSpanOverflowAdditionalPlannerCases(InductorTestCase):
         self.assertEqual(symbol_to_dim, {})
 
 
+class TestSpanOverflowGenericReductionRangeTiling(InductorTestCase):
+    """Reduction-range ("K-style") coarse tiling for non-matmul reductions.
+
+    Before this, only batch-matmul K could be reduction-range tiled.  Now a
+    plain sum/prod/max/min whose *reduced axis* controls an oversized input
+    read gets the same identity-fill + per-tile-combine + drain treatment.
+    Everything else (mean, welford, >1 reduction range) must fail with a clear
+    message instead of silently leaving the span over the hardware limit.
+    """
+
+    def _reduction_dim_overflow_op(self, reduction_type, reduction_ranges=(65536,)):
+        op = _reduction_op(
+            (1, 1, 64), reduction_ranges=reduction_ranges, reduction_type=reduction_type
+        )
+        b, m, n, k = sympy.symbols("b m n k")
+        rhs_dep = MemoryDep("rhs", k * 64 + n, (k, n), (reduction_ranges[0], 64))
+        rhs_layout = _fixed_tiled_layout((reduction_ranges[0], 64))
+        return op, (b, m, n, k), rhs_dep, rhs_layout
+
+    def _plan_with_reduction_dim_overflow(
+        self, reduction_type, span_limit=5 * 1024 * 1024
+    ):
+        op, (b, m, n, _k), rhs_dep, rhs_layout = self._reduction_dim_overflow_op(
+            reduction_type
+        )
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", span_limit),
+            patch.object(soha, "_output_span_candidates_from_op", return_value=[]),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+        ):
+            return plan_span_overflow_tile(op, max_cores=1)
+
+    def test_supported_reduction_types_plan_a_reduction_range_tile(self):
+        # A sum/prod/max/min whose reduced axis drives an oversized input read
+        # is chopped into rounds: one reduction-range tile level, split >= 2.
+        for reduction_type in ("sum", "prod", "max", "min"):
+            with self.subTest(reduction_type=reduction_type):
+                plan = self._plan_with_reduction_dim_overflow(reduction_type)
+                self.assertIsNotNone(plan)
+                self.assertEqual(
+                    plan.levels,
+                    (
+                        SpanOverflowTileLevel(
+                            selected_host_dim=0, split_count=2, is_reduction=True
+                        ),
+                    ),
+                )
+                self.assertIn("reduction-range input span overflow", plan.reason)
+
+    def test_mean_reduction_dim_overflow_raises_clear_error(self):
+        # mean can't be summed in rounds without per-tile scale-factor handling,
+        # so an overflow on its averaged-over axis must fail loudly.
+        with self.assertRaisesRegex(
+            Unsupported,
+            r"reduction-dimension tiling is not supported.*reduction_type='mean'",
+        ):
+            self._plan_with_reduction_dim_overflow("mean")
+
+    def test_non_family_reduction_dim_overflow_is_left_alone(self):
+        # welford / xor_sum / any / conv / top-k / fp8-BMM etc. are outside the
+        # sum/prod/max/min/mean family: the guard does not fire (other passes
+        # own their span handling), so the planner returns None rather than
+        # raising.
+        for reduction_type in ("welford_reduce", "xor_sum", "any"):
+            with self.subTest(reduction_type=reduction_type):
+                self.assertIsNone(
+                    self._plan_with_reduction_dim_overflow(reduction_type)
+                )
+
+    def test_reduction_range_with_no_legal_split_raises(self):
+        # A prime reduced-axis size has no usable divisor, so no round count
+        # works; the planner reports it rather than emitting a bad plan.
+        op, (b, m, n, _k), rhs_dep, rhs_layout = self._reduction_dim_overflow_op(
+            "sum", reduction_ranges=(65537,)
+        )
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", 5 * 1024 * 1024),
+            patch.object(soha, "_output_span_candidates_from_op", return_value=[]),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+        ):
+            with self.assertRaisesRegex(
+                Unsupported, r"reduction range has no legal .*nontrivial split"
+            ):
+                plan_span_overflow_tile(op, max_cores=1)
+
+    def test_reduction_range_tile_respects_kill_switch(self):
+        # With reduction tiling disabled for a non-BMM reduction, the flag is
+        # a real escape hatch: no reduction candidate is ever created, so the
+        # planner falls back to its pre-widening behavior (no plan) instead
+        # of hard-aborting.  BMM's own kill switch (post-search, still
+        # enforced) is covered separately by
+        # test_bmm_k_span_overflow_respects_reduction_tiling_kill_switch.
+        op, (b, m, n, _k), rhs_dep, rhs_layout = self._reduction_dim_overflow_op("sum")
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", 5 * 1024 * 1024),
+            patch.object(soha, "_output_span_candidates_from_op", return_value=[]),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+            config.patch({"enable_reduction_tiling": False}),
+        ):
+            self.assertIsNone(plan_span_overflow_tile(op, max_cores=1))
+
+    def test_combined_output_and_reduction_range_plan_uses_real_divisors(self):
+        # Both an output dim and the reduced axis overflow -> a nested plan
+        # (outer output level, inner reduction level).  Split candidates are
+        # computed for real here, only the post-tile re-check is stubbed.
+        op = _reduction_op((1, 64, 64), reduction_ranges=(64,), reduction_type="sum")
+        output_candidate = soha.SpanOverflowCandidate(
+            ChunkingInfo(
+                total_bytes=1,
+                per_core_span=2 * (5 * 1024 * 1024),
+                core_split_estimate=1,
+                selected_device_dim_size=64,
+                selected_device_span_stride_elems=64,
+                selected_host_dim=1,
+                stick_elems=64,
+                reason="output span overflow",
+            ),
+            source="input:rhs",
+        )
+        reduction_candidate = soha.SpanOverflowCandidate(
+            ChunkingInfo(
+                total_bytes=1,
+                per_core_span=4 * (5 * 1024 * 1024),
+                core_split_estimate=1,
+                selected_device_dim_size=64,
+                selected_device_span_stride_elems=64,
+                selected_host_dim=0,
+                stick_elems=64,
+                reason="reduction-range input span overflow for rhs",
+            ),
+            source="input:rhs",
+            is_reduction=True,
+        )
+
+        def remaining(_op, _mc, output_splits, *, k_split=None):
+            if output_splits == {1: 2} and k_split == 2:
+                return []
+            return [output_candidate]
+
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", 5 * 1024 * 1024),
+            patch.object(
+                soha, "_combined_tile_stick_alignment_error", return_value=None
+            ),
+            patch.object(
+                soha, "_remaining_span_candidates_after_tile", side_effect=remaining
+            ),
+        ):
+            plan = soha._search_min_cost_tile_plan(
+                op, 1, [output_candidate, reduction_candidate]
+            )
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(
+            plan.levels,
+            (
+                SpanOverflowTileLevel(1, 2),
+                SpanOverflowTileLevel(0, 2, is_reduction=True),
+            ),
+        )
+
+    def test_adapter_resolves_reduction_loop_var_for_non_matmul_reduction(self):
+        # _dims_to_hints must accept a non-matmul reduction's reduction level,
+        # not just BMM K.
+        op = _reduction_op((1, 1, 64), reduction_ranges=(65536,), reduction_type="sum")
+        k = sympy.Symbol("k")
+        with (
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile_span_overflow.op_out_coords",
+                return_value=[sympy.Symbol("b"), sympy.Symbol("m"), sympy.Symbol("n")],
+            ),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile_span_overflow._bmm_k_symbol",
+                return_value=k,
+            ),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile_span_overflow."
+                "_loop_var_to_reduction_ranges_pos",
+                return_value=0,
+            ),
+        ):
+            hints = _dims_to_hints(op, ((0, 4, True),), [_SPAN_OVERFLOW_HINT_ID])
+
+        self.assertEqual(len(hints), 1)
+        self.assertEqual(hints[0].loop_var, k)
+        self.assertEqual(hints[0].split_count, 4)
+        self.assertTrue(hints[0].is_reduction)
+
+    def test_output_only_overflow_on_reduction_op_is_not_a_reduction_tile(self):
+        # Sanity: when the *output* is what overflows, the plan is a normal
+        # output-range tile, not a reduction-range one.
+        op = _reduction_op((4_194_304,), reduction_ranges=(64,), reduction_type="sum")
+        m, k = sympy.symbols("m k")
+        dep = MemoryDep("arg0", m * 64 + k, (m, k), (4_194_304, 64))
+        layout = _fixed_tiled_layout((4_194_304, 64))
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", MAX_SPAN_BYTES),
+            patch.object(soha, "_output_span_candidates_from_op", return_value=[]),
+            patch.object(soha, "_input_read_deps", return_value=[(dep, layout)]),
+            patch.object(soha, "_output_symbol_to_dim", return_value={m: 0}),
+            patch.object(
+                soha, "_remaining_span_candidates_after_tile", return_value=[]
+            ),
+        ):
+            plan = plan_span_overflow_tile(op, max_cores=1)
+
+        self.assertIsNotNone(plan)
+        self.assertFalse(plan.levels[0].is_reduction)
+        self.assertEqual(plan.levels[0].selected_host_dim, 0)
+
+    def test_integer_max_min_not_reduction_range_tiled(self):
+        # _reduction_identity_value seeds +/-inf; float(inf) cast into an
+        # integer spyre.constant saturates to the wrong bound.  int max/min
+        # must be rejected; int sum/prod (identity 0/1) stay eligible.
+        float_min = _reduction_op(
+            (64,), reduction_ranges=(65536,), reduction_type="min"
+        )
+        self.assertTrue(soha._supports_reduction_range_tiling(float_min))
+
+        int_data = MagicMock(spec=Reduction)
+        int_data.ranges = [64]
+        int_data.reduction_ranges = [65536]
+        int_data.reduction_type = "min"
+        int_op = ComputedBuffer(
+            name="buf0",
+            layout=_fixed_tiled_layout((64,), dtype=torch.int32),
+            data=int_data,
+        )
+        self.assertFalse(soha._supports_reduction_range_tiling(int_op))
+        int_data.reduction_type = "max"
+        self.assertFalse(soha._supports_reduction_range_tiling(int_op))
+        int_data.reduction_type = "sum"
+        self.assertTrue(soha._supports_reduction_range_tiling(int_op))
+
+    def test_untileable_check_skips_integer_reductions(self):
+        # int max/min are excluded from tiling by dtype; the guard must not
+        # convert them into a compile abort either -- keep the historical
+        # silent skip.
+        int_data = MagicMock(spec=Reduction)
+        int_data.ranges = [1, 1, 64]
+        int_data.reduction_ranges = [65536]
+        int_data.reduction_type = "min"
+        op = ComputedBuffer(
+            name="buf0",
+            layout=_fixed_tiled_layout((1, 1, 64), dtype=torch.int32),
+            data=int_data,
+        )
+        b, m, n, k = sympy.symbols("b m n k")
+        rhs_dep = MemoryDep("rhs", k * 64 + n, (k, n), (65536, 64))
+        rhs_layout = _fixed_tiled_layout((65536, 64), dtype=torch.int32)
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", 5 * 1024 * 1024),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+        ):
+            self.assertFalse(soha._has_untileable_reduction_span(op, max_cores=1))
+
+    def test_untileable_check_charges_mixed_coord_only_its_reduction_part(self):
+        # An inner coordinate mixing an output symbol (m) and a reduction
+        # symbol (k) -- an interleaved stride -- must be charged only its
+        # reduction extent in the best case, since an output tile shrinks m.
+        op = _reduction_op((4096,), reduction_ranges=(2, 64), reduction_type="mean")
+        k0, m, k1 = sympy.symbols("k0 m k1")
+        # device coords: [k0 (outer, reduction-only), m*2 + k1 (mixed), stick]
+        dep = MemoryDep(
+            "arg0",
+            k0 * 4096 * 128 + m * 128 + k1,
+            (k0, m, k1),
+            (2, 4096, 64),
+        )
+        layout = _fixed_tiled_layout((2, 4096, 64))
+        with (
+            # best case: k0(2) * [m->1, k1->64] * k1_stick(64) * 2 B = 16 KiB;
+            # charging m at full 4096 -> ~1 MiB, which this limit would flag.
+            patch.object(soha, "MAX_SPAN_BYTES", 512 * 1024),
+            patch.object(soha, "_input_read_deps", return_value=[(dep, layout)]),
+            patch.object(soha, "_output_symbol_to_dim", return_value={m: 0}),
+            patch.object(
+                soha,
+                "_device_coordinates_for_span",
+                return_value=[k0, 2 * m + k1, k1],
+            ),
+        ):
+            self.assertFalse(soha._has_untileable_reduction_span(op, max_cores=1))
+
+    def test_best_case_inner_span_returns_none_for_unbounded_coordinate(self):
+        # Mod(3*h, 64) has a coefficient on the Mod argument, which
+        # _coordinate_span_elems explicitly refuses to bound -- the best-case
+        # helper must propagate that as "unknown", not assume a size.
+        h = sympy.Symbol("h")
+        dep = MemoryDep("x", h, (h,), (100,))
+        self.assertIsNone(
+            soha._best_case_inner_span([sympy.Mod(3 * h, 64)], [64], dep, {})
+        )
+
+    def test_untileable_check_skips_coordinate_with_unbounded_inner_span(self):
+        # An inner coordinate _coordinate_span_elems refuses to bound must not
+        # be charged as the worst case (a prior version substituted the full
+        # dim size there) -- that inflates the best-case estimate and can
+        # falsely declare an unprovable coordinate untileable.
+        op = _reduction_op(
+            (1, 1, 64), reduction_ranges=(65536, 100), reduction_type="sum"
+        )
+        b, m, n, k, h = sympy.symbols("b m n k h")
+        rhs_dep = MemoryDep(
+            "rhs",
+            k * 64 * 100 + sympy.Mod(3 * h, 64) * 64 + n,
+            (k, h, n),
+            (65536, 100, 64),
+        )
+        rhs_layout = _fixed_tiled_layout((65536, 100, 64))
+        with (
+            # Tiny on purpose: the old (buggy) estimate for this shape is
+            # ~800 MB and would trip any realistic limit; the fix skips the
+            # coordinate entirely rather than comparing an assumed bound.
+            patch.object(soha, "MAX_SPAN_BYTES", 1024),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+            patch.object(
+                soha,
+                "_device_coordinates_for_span",
+                return_value=[k, sympy.Mod(3 * h, 64), n],
+            ),
+        ):
+            self.assertFalse(soha._has_untileable_reduction_span(op, max_cores=1))
+
+    def test_untileable_check_respects_kill_switch(self):
+        # enable_reduction_tiling=False is a real escape hatch for this guard
+        # too, not just for the search's own post-search kill-switch check.
+        op, (b, m, n, _k), rhs_dep, rhs_layout = self._reduction_dim_overflow_op("mean")
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", 5 * 1024 * 1024),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+            config.patch({"enable_reduction_tiling": False}),
+        ):
+            self.assertFalse(soha._has_untileable_reduction_span(op, max_cores=1))
+
+    def test_reduction_loop_vars_skips_stardep_without_crashing(self):
+        # StarDep.index raises NotImplementedError, not AttributeError, so
+        # hasattr(d, "index") does not safely filter it out.  A StarDep read
+        # (e.g. from a bucketize pattern) anywhere in rw.reads must not crash
+        # the scan.
+        from torch._inductor.dependencies import StarDep
+        from torch_spyre._inductor.wsr.coarse_tile import reduction_loop_vars
+
+        m, k = sympy.symbols("m k")
+        star_dep = StarDep("table")
+        x_dep = MemoryDep("x", m * 16 + k, (m, k), (20, 16))
+        out_dep = MemoryDep("out", m, (m,), (20,))
+        op = _reduction_op((20,), reduction_ranges=(16,), reduction_type="sum")
+        op.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(reads=[star_dep, x_dep], writes={out_dep})
+        )
+        self.assertEqual(reduction_loop_vars(op), [k])
+
+    def test_reduction_range_too_large_for_max_split_raises(self):
+        # Composite reduction range whose largest legal split (64) still
+        # overflows -> Unsupported, not a silent drop.  (The prime-size case
+        # is covered by test_reduction_range_with_no_legal_split_raises.)
+        op = _reduction_op((1, 1, 64), reduction_ranges=(4096,), reduction_type="sum")
+        b, m, n, k = sympy.symbols("b m n k")
+        rhs_dep = MemoryDep("rhs", k * 64 + n, (k, n), (4096, 64))
+        rhs_layout = _fixed_tiled_layout((4096, 64))
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", 4096),
+            patch.object(soha, "_output_span_candidates_from_op", return_value=[]),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+        ):
+            with self.assertRaisesRegex(Unsupported, "no legal.*reduction-range split"):
+                plan_span_overflow_tile(op, max_cores=1)
+
+    def test_untileable_check_falls_through_when_output_dim_in_inner_span(self):
+        # A reduction-only outer coordinate (k0), but an inner coordinate (m)
+        # is output-controlled -- tiling m could shrink the span, so the
+        # detector must not hard-raise.
+        op = _reduction_op((65536,), reduction_ranges=(8, 1024), reduction_type="sum")
+        k0, k1, m = sympy.symbols("k0 k1 m")
+        dep = MemoryDep(
+            "arg0",
+            k0 * 65536 * 1024 + m * 1024 + k1,
+            (k0, m, k1),
+            (8, 65536, 1024),
+        )
+        layout = _fixed_tiled_layout((8, 65536, 1024))
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", MAX_SPAN_BYTES),
+            patch.object(soha, "_input_read_deps", return_value=[(dep, layout)]),
+            patch.object(soha, "_output_symbol_to_dim", return_value={m: 0}),
+        ):
+            self.assertFalse(soha._has_untileable_reduction_span(op, max_cores=1))
+
+    def test_reduction_loop_vars_skips_leading_broadcast_dep(self):
+        # A fused reduction reading a broadcast operand first (no reduction
+        # symbol) must still resolve its reduction loop var.
+        from torch_spyre._inductor.wsr.coarse_tile import reduction_loop_vars
+
+        m, k = sympy.symbols("m k")
+        bias_dep = MemoryDep("bias", m, (m,), (20,))
+        x_dep = MemoryDep("x", m * 16 + k, (m, k), (20, 16))
+        out_dep = MemoryDep("out", m, (m,), (20,))
+        op = _reduction_op((20,), reduction_ranges=(16,), reduction_type="sum")
+        op.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(reads=[bias_dep, x_dep], writes={out_dep})
+        )
+        self.assertEqual(reduction_loop_vars(op), [k])
+
+    def test_reduction_loop_vars_picks_dep_with_most_reduction_syms(self):
+        # A dep indexing a strict subset of the reduction symbols must not be
+        # chosen over one indexing the full, correctly-ordered set.
+        from torch_spyre._inductor.wsr.coarse_tile import reduction_loop_vars
+
+        m, k0, k1 = sympy.symbols("m k0 k1")
+        partial_dep = MemoryDep("p", m * 8 + k1, (m, k1), (20, 8))
+        full_dep = MemoryDep("f", k0 * 20 * 8 + m * 8 + k1, (k0, m, k1), (4, 20, 8))
+        out_dep = MemoryDep("out", m, (m,), (20,))
+        op = _reduction_op((20,), reduction_ranges=(4, 8), reduction_type="sum")
+        op.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(
+                reads=[partial_dep, full_dep], writes={out_dep}
+            )
+        )
+        self.assertEqual(reduction_loop_vars(op), [k0, k1])
+
+    def test_untileable_check_skips_non_family_reduction_types(self):
+        # fp8 batch-matmul (and conv/top-k/welford/...) are owned by other
+        # passes -- work division splits fp8 BMM K -- so the guard must not
+        # convert their silent-skip into a compile abort.
+        op = _reduction_op(
+            (1, 1, 64),
+            reduction_ranges=(65536,),
+            reduction_type="batchmatmulfp8",
+        )
+        b, m, n, k = sympy.symbols("b m n k")
+        rhs_dep = MemoryDep("rhs", k * 64 + n, (k, n), (65536, 64))
+        rhs_layout = _fixed_tiled_layout((65536, 64))
+        with (
+            patch.object(soha, "MAX_SPAN_BYTES", 5 * 1024 * 1024),
+            patch.object(
+                soha, "_input_read_deps", return_value=[(rhs_dep, rhs_layout)]
+            ),
+            patch.object(
+                soha, "_output_symbol_to_dim", return_value={b: 0, m: 1, n: 2}
+            ),
+        ):
+            self.assertFalse(soha._has_untileable_reduction_span(op, max_cores=1))
+
+
 class TestSpanOverflowLargeShapeContract(InductorTestCase):
     """Unit-style coverage for the real large shape used in E2E testing."""
 
@@ -4967,6 +5457,71 @@ def _forced_span_plan_on_dim1(split_count, expect_size):
                 ),
             ),
             reason="forced for join validation",
+        )
+
+    return forced
+
+
+def _forced_reduction_range_plan(split_count, reduction_size, output_split=None):
+    """Force a non-matmul Reduction onto a reduction-range tile plan.
+
+    The automatic-span-overflow analogue of the manual
+    ``spyre_hint(expected_reduction_dims=...)`` tests in
+    ``test_coarse_tile_e2e.py``: it drives the *planner output*
+    (``is_reduction=True``), so the full
+    ``span_overflow_groups -> coarse_tile -> identity-fill/combine/drain``
+    path runs for a plain sum/max/min and its result is checked against CPU.
+
+    When ``output_split`` is given the plan is nested: an outer output-dim
+    level (host dim 0) then an inner reduction-range level, exercising the
+    combined output+reduction path end to end.
+
+    Keys on "a single reduction range of this size" rather than a buffer name,
+    which a Reduction graph does not expose before it runs.  Divisibility is
+    asserted here so a bad split fails in test setup, not deep in the pass.
+    """
+    real_plan = plan_span_overflow_tile
+    assert reduction_size % split_count == 0
+
+    def _info(host_dim, split, reason):
+        return ChunkingInfo(
+            total_bytes=1,
+            per_core_span=1,
+            core_split_estimate=1,
+            selected_device_dim_size=split,
+            selected_device_span_stride_elems=1,
+            selected_host_dim=host_dim,
+            stick_elems=64,
+            reason=reason,
+        )
+
+    def forced(op, max_cores):
+        rranges = list(
+            getattr(getattr(op, "data", None), "reduction_ranges", None) or []
+        )
+        try:
+            match = len(rranges) == 1 and int(rranges[0]) == reduction_size
+        except (TypeError, ValueError):
+            match = False
+        if not match:
+            return real_plan(op, max_cores)
+
+        levels = []
+        infos = []
+        if output_split is not None:
+            levels.append(
+                SpanOverflowTileLevel(selected_host_dim=0, split_count=output_split)
+            )
+            infos.append(_info(0, output_split, "forced output level"))
+        levels.append(
+            SpanOverflowTileLevel(
+                selected_host_dim=0, split_count=split_count, is_reduction=True
+            )
+        )
+        infos.append(_info(0, split_count, "forced reduction-range level"))
+        reason = "forced reduction-range plan for numeric validation"
+        return SpanOverflowTilePlan(
+            levels=tuple(levels), chunking_infos=tuple(infos), reason=reason
         )
 
     return forced
@@ -5284,16 +5839,16 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
             "ignore_span_overflow_hints": False,
         }
     )
-    @unittest.expectedFailure
     def test_reduction_input_span_codegen_contains_auto_loop_spec(self):
-        """Decision xfail: failing in CI (Actions run 30385154736, job
-        90362759197) on PR #3293. We've decided to xfail the coarse tiling
+        """A reduction whose input read overflows gets an output-range coarse
+        tile lowered to a counted ``LoopSpec``.
 
-        TODO(3293-decision-xfail): investigate and un-xfail; no root cause
-        was bisected when this was marked.
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
+        ``x.sum(dim=0)`` on ``(2,20,16,64)`` reads all of ``x``; under the 8 KB
+        limit that overflows on the output ``20`` dim, so the planner tiles it
+        by 10 (per-tile extent 2).  A prior version pinned the tiled loop
+        symbol to the literal ``sympify('c0')``; coarse tiling now names it
+        ``_tile_adv_op<N>_lvl<L>``, so this asserts on structure instead --
+        ``TODO(3293-decision-xfail)``.
         """
         x = torch.randn(2, 20, 16, 64, dtype=torch.float16).to("spyre")
 
@@ -5313,7 +5868,10 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
         self.assertIn("LoopSpec(", src)
         self.assertIn("count=sympify('10')", src)
         self.assertIn("op='sum'", src)
-        self.assertIn("tiled_symbols=[[sympify('c0')]]", src)
+        # One dim tiled at one level; symbol name is not pinned.
+        m = re.search(r"tiled_symbols=\[\[sympify\('([^']+)'\)\]\]", src)
+        self.assertIsNotNone(m, src)
+        self.assertIn(f"tiled_symbol_trip_counts={{sympify('{m.group(1)}'): 10}}", src)
 
     @config.patch(
         {
@@ -5381,6 +5939,134 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
         self.assertIn("count=sympify('4')", src)
         self.assertIn("op='sum'", src)
 
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_generic_reduction_range_tile_codegen_contains_auto_loop_spec(self):
+        # End-to-end for the new path: a plain sum whose reduced axis is
+        # coarse-tiled must lower to a counted loop, and the downstream
+        # identity-fill + per-tile-combine machinery must accept it.
+        x = torch.randn(20, 16, 64, dtype=torch.float16).to("spyre")
+
+        def fn(x):
+            return x.sum(dim=1)
+
+        fake_plan = SpanOverflowTilePlan(
+            levels=(
+                SpanOverflowTileLevel(
+                    selected_host_dim=0, split_count=2, is_reduction=True
+                ),
+            ),
+            chunking_infos=(
+                ChunkingInfo(
+                    total_bytes=1,
+                    per_core_span=1,
+                    core_split_estimate=1,
+                    selected_device_dim_size=1,
+                    selected_device_span_stride_elems=1,
+                    selected_host_dim=0,
+                    stick_elems=64,
+                    reason="reduction-range input span overflow for arg0",
+                ),
+            ),
+            reason="reduction-range input span overflow for arg0",
+        )
+
+        cfn = torch.compile(fn, dynamic=False)
+        with (
+            patch(_LAUNCH_JOBPLAN),
+            patch(_PREPARE_KERNEL),
+            patch("subprocess.run"),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile_span_overflow."
+                "plan_span_overflow_tile",
+                return_value=fake_plan,
+            ),
+        ):
+            _, source_codes = run_and_get_code(cfn, x)
+
+        self.assertTrue(source_codes)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src)
+        self.assertIn("count=sympify('2')", src)
+        self.assertIn("op='sum'", src)
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_generic_combined_output_and_reduction_range_codegen(self):
+        # Both an output dim and the reduced axis overflow -> a nested plan
+        # (outer output level, inner reduction level), the same shape as BMM's
+        # combined output+K.  Both loop levels must lower.
+        x = torch.randn(20, 16, 64, dtype=torch.float16).to("spyre")
+
+        def fn(x):
+            return x.sum(dim=1)
+
+        fake_plan = SpanOverflowTilePlan(
+            levels=(
+                SpanOverflowTileLevel(selected_host_dim=0, split_count=4),
+                SpanOverflowTileLevel(
+                    selected_host_dim=0, split_count=2, is_reduction=True
+                ),
+            ),
+            chunking_infos=(
+                ChunkingInfo(
+                    total_bytes=1,
+                    per_core_span=1,
+                    core_split_estimate=1,
+                    selected_device_dim_size=1,
+                    selected_device_span_stride_elems=1,
+                    selected_host_dim=0,
+                    stick_elems=64,
+                    reason="output span overflow",
+                ),
+                ChunkingInfo(
+                    total_bytes=1,
+                    per_core_span=1,
+                    core_split_estimate=1,
+                    selected_device_dim_size=1,
+                    selected_device_span_stride_elems=1,
+                    selected_host_dim=0,
+                    stick_elems=64,
+                    reason="reduction-range input span overflow for arg0",
+                ),
+            ),
+            reason=(
+                "output span overflow; reduction-range input span overflow for arg0"
+            ),
+        )
+
+        cfn = torch.compile(fn, dynamic=False)
+        with (
+            patch(_LAUNCH_JOBPLAN),
+            patch(_PREPARE_KERNEL),
+            patch("subprocess.run"),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile_span_overflow."
+                "plan_span_overflow_tile",
+                return_value=fake_plan,
+            ),
+        ):
+            _, source_codes = run_and_get_code(cfn, x)
+
+        self.assertTrue(source_codes)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src)
+        self.assertIn("count=sympify('4')", src)  # outer output level
+        self.assertIn("count=sympify('2')", src)  # inner reduction level
+        self.assertIn("op='sum'", src)
+
     # test_lm_head_restickify_codegen_contains_auto_loop_spec removed: its
     # "restickify producer tiled, BMM consumer stays untiled" premise is not
     # reachable for this op pair. buf0 (the BMM) always independently detects
@@ -5401,16 +6087,17 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
             "ignore_span_overflow_hints": False,
         }
     )
-    @unittest.expectedFailure
     def test_auto_span_overflow_matches_equivalent_spyre_hint_loop_spec(self):
-        """Decision xfail: failing in CI (Actions run 30385154736, job
-        90362759197) on PR #3293. We've decided to xfail the coarse tiling
+        """Automatic span-overflow tiling must lower through the *same* coarse-
+        tile -> LoopSpec path as an explicit ``spyre_hint``.
 
-        TODO(3293-decision-xfail): investigate and un-xfail; no root cause
-        was bisected when this was marked.
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
+        The test does NOT assert which split the planner picks -- that is the
+        planner's own decision and any legal divisor is fine.  It reads the
+        tile count the auto pass actually chose out of its ``LoopSpec``, feeds
+        that same count into a manual ``spyre_hint(num_tiles_per_dim=...)``,
+        and asserts the two compiles emit an identical ``LoopSpec`` block.  A
+        prior version pinned the count to a hard-coded ``5`` and broke when the
+        planner (validly) chose ``4`` instead -- ``TODO(3293-decision-xfail)``.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -5421,16 +6108,37 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
         def auto_fn(x, y):
             return x + y
 
-        def manual_hint_fn(x, y):
-            with spyre_hint(num_tiles_per_dim={"SO_H": 5}):
-                return x + y
-
         _pnd.declare_tensor_dim("SO_B", shape[0])
         _pnd.declare_tensor_dim("SO_H", shape[1])
         _pnd.declare_tensor_dim("SO_L", shape[2])
         _pnd.declare_tensor_dim("SO_D", shape[3])
         _pnd.name_tensor_dims(x, ["SO_B", "SO_H", "SO_L", "SO_D"])
         _pnd.name_tensor_dims(y, ["SO_B", "SO_H", "SO_L", "SO_D"])
+
+        def _balanced(src, start):
+            depth = 0
+            for i in range(start, len(src)):
+                if src[i] == "(":
+                    depth += 1
+                elif src[i] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        return i + 1
+            raise AssertionError("unbalanced parentheses")
+
+        def _loop_spec_block(src):
+            """Return the single ``LoopSpec( ... )`` substring, with the
+            per-op ``debug_handle=DebugHandle(...)`` stripped -- it carries a
+            hash id and source line numbers that legitimately differ between
+            the two ``fn`` definitions and are not part of the loop structure.
+            """
+            self.assertEqual(src.count("LoopSpec("), 1, src)
+            start = src.index("LoopSpec(")
+            block = src[start : _balanced(src, start + len("LoopSpec"))]
+            while (j := block.find("debug_handle=DebugHandle(")) != -1:
+                end = _balanced(block, j + len("debug_handle=DebugHandle"))
+                block = block[:j] + "debug_handle=<stripped>" + block[end:]
+            return block
 
         with (
             patch(_LAUNCH_JOBPLAN),
@@ -5440,22 +6148,36 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
             _, auto_sources = run_and_get_code(
                 torch.compile(auto_fn, dynamic=False), x, y
             )
+
+        auto_block = _loop_spec_block(auto_sources[0])
+
+        # The tile count the planner chose for itself -- not asserted, echoed
+        # into the manual hint below.
+        m = re.search(r"count=sympify\('(\d+)'\)", auto_block)
+        self.assertIsNotNone(m, auto_block)
+        auto_count = int(m.group(1))
+        self.assertGreater(auto_count, 1)
+        self.assertEqual(shape[1] % auto_count, 0)
+
+        def manual_hint_fn(x, y):
+            with spyre_hint(num_tiles_per_dim={"SO_H": auto_count}):
+                return x + y
+
+        with (
+            patch(_LAUNCH_JOBPLAN),
+            patch(_PREPARE_KERNEL),
+            patch("subprocess.run"),
+        ):
             _, manual_sources = run_and_get_code(
                 torch.compile(manual_hint_fn, dynamic=False), x, y
             )
 
-        auto_src = auto_sources[0]
-        manual_src = manual_sources[0]
+        manual_block = _loop_spec_block(manual_sources[0])
 
-        # Automatic span-overflow tiling should lower to the same one-level
-        # counted loop shape as the equivalent explicit spyre_hint.
-        self.assertEqual(auto_src.count("LoopSpec("), manual_src.count("LoopSpec("))
-        self.assertEqual(auto_src.count("sympify('5')"), 1)
-        self.assertEqual(manual_src.count("sympify('5')"), 1)
-        self.assertIn("sympify('4')", auto_src)
-        self.assertIn("sympify('4')", manual_src)
-        self.assertIn("op='add'", auto_src)
-        self.assertIn("op='add'", manual_src)
+        # Same tile count -> identical lowering: the auto pass reuses the
+        # manual-hint coarse-tile machinery, not a divergent path.
+        self.assertIn("op='add'", auto_block)
+        self.assertEqual(auto_block, manual_block)
 
 
 class TestSpanOverflowNumericValidation(InductorTestCase):
@@ -5866,41 +6588,66 @@ class TestSpanOverflowNumericValidation(InductorTestCase):
 
         return check
 
-    # TODO(span-overflow-read-copy): the FAILURE MODE CHANGED with #3612
-    # ("coarse tiling: optional read copy").  The codegen half of this
-    # direction, in TestSpanOverflowPointwiseCodegen, now passes and is no
-    # longer xfailed -- the read copy gets built.  What remains is worse than
-    # the old loud failure: the kernel compiles, executes, and returns WRONG
-    # NUMBERS (compiled-spyre vs CPU mismatch), so this xfail is now masking a
-    # silent wrong-answer path rather than a refusal to compile.
-    #
-    # Most likely cause is the positional walk described below, which is still
-    # present: it pairs each of the buffer's non-unit dims with the next
-    # iteration extent by position.  Instrumenting _resize_device_layout on
-    # this shape shows it handed tile_size=[1,4,32,64] for a buffer of
-    # [1,20,64,32] -- the trailing dims transposed -- so the layout it builds
-    # does not describe the data.  Verify that before assuming a backend bug.
-    #
-    # Blocked by a pre-existing coarse_tile.py defect, not by the grouping this
-    # branch adds: _insert_read_copy_ops cannot build a copy-buffer layout for a
-    # tiled *Reduction* that reads a full-size buffer from outside its loop
-    # group.  It aligns dep.size (the ITERATION space -- for a BMM that is
-    # H/M/N/K) positionally against the input buffer's non-unit dims, which only
-    # coincide for Pointwise ops.  For arg0_1 [1,20,16,64] read as
-    # 1024*d0 + 64*d1 + d3, tile_ranges=[4,16,32,64] has four entries for three
-    # non-unit buffer dims and it asserts.
-    #
-    # Verified pre-existing two ways: a LONE tiled BMM with no consumer at all
-    # (no grouping possible) raises the same assert, and the #3218-era
-    # test_lm_head_matmul_join_numeric below -- already expectedFailure before
-    # this branch -- fails with the identical message.  So automatic
-    # span-overflow tiling of a BMM reading graph inputs has never worked,
-    # grouped or not.
-    #
-    # The grouping decision these validate is fully covered and passing in
-    # TestSpanOverflowGroups; only on-device execution is blocked.  Remove both
-    # decorators once _insert_read_copy_ops handles Reduction iteration spaces.
-    @unittest.expectedFailure
+    def _assert_tiled_span_overflow_matches_untiled(
+        self, fn, *inputs, source_check=None
+    ):
+        """Force a dim-1 span-overflow tile, run for real, and assert it adds
+        no error beyond the fp16 accumulation noise inherent to the shape.
+
+        A fixed ``atol``/``rtol`` cannot tell "tiling broke it" from
+        "fp16 reduction-order noise at this depth" -- the same run with
+        span-overflow tiling disabled is the same-depth, same-reference control
+        (identical technique to ``test_lm_head_matmul_join_numeric``).  These
+        directions were once genuinely broken (``_insert_read_copy_ops`` assert,
+        then transposed tile layout -> garbage), fixed by #3612 and #3613; what
+        a fixed tolerance still flags is a handful of noise elements.
+        """
+        torch.manual_seed(0xAFFE)
+        cpu_result = fn(*inputs)
+
+        def run(ignore_span_overflow_hints, sc=None):
+            torch._dynamo.reset_code_caches()
+            torch._inductor.codecache.FxGraphCache.clear()
+            dev = [t.to("spyre") for t in inputs]
+            with config.patch(
+                {"ignore_span_overflow_hints": ignore_span_overflow_hints}
+            ):
+                if ignore_span_overflow_hints:
+                    result = torch.compile(fn, dynamic=False)(*dev).cpu()
+                else:
+                    with patch(
+                        "torch_spyre._inductor.wsr.coarse_tile_span_overflow."
+                        "plan_span_overflow_tile",
+                        _forced_span_plan_on_dim1(5, 20),
+                    ):
+                        cfn = torch.compile(fn, dynamic=False)
+                        if sc is not None:
+                            result, srcs = run_and_get_code(cfn, *dev)
+                            if srcs:
+                                sc(srcs[0])
+                            result = result.cpu()
+                        else:
+                            result = cfn(*dev).cpu()
+            return result
+
+        def mismatches(actual):
+            diff = (actual.float() - cpu_result.float()).abs()
+            return int((diff > 0.05 + 0.05 * cpu_result.float().abs()).sum())
+
+        tiled = run(False, source_check)
+        untiled = run(True)
+        t, u = mismatches(tiled), mismatches(untiled)
+        print(
+            f"[numeric] tiled={t}/{cpu_result.numel()} untiled={u}/{cpu_result.numel()}"
+        )
+        self.assertLessEqual(
+            t,
+            u + max(10, u),
+            f"tiled span-overflow result has {t} mismatches vs {u} untiled "
+            "against the same CPU reference -- meaningfully worse than the "
+            "same-depth baseline, i.e. tiling introduced error.",
+        )
+
     @config.patch(
         {
             "sencores": 4,
@@ -5910,81 +6657,28 @@ class TestSpanOverflowNumericValidation(InductorTestCase):
         }
     )
     def test_bmm_to_pointwise_join_numeric(self):
-        """A BMM producer whose Pointwise consumer joins its group -- the
-        BMM -> PW direction -- executed for real and compared against a CPU
-        reference.
+        """A BMM producer whose Pointwise consumer joins its span-overflow
+        group (BMM -> PW), forced-tiled on dim 1 and executed for real.
 
-        Every other BMM -> PW test mocks kernel launch and inspects the
-        grouping decision only.  A group can be structurally perfect and still
-        compute wrong values: the producer's per-tile output becomes
-        loop-internal scratch that the consumer reads in the same iteration,
-        and nothing but a real run proves that per-tile addressing pairs the
-        right slices.
-
-        The plan is forced so both ops tile host_dim=1 at split 5 (the
-        technique the sibling pointwise test settled on after an organic-plan
-        version failed on hardware, because the two ops' independent span
-        searches do not land on the same split for a toy shape).  Kernel
-        launch is NOT mocked, so the forced plan still runs for real.
+        The grouped kernel must compute the same values as the untiled run
+        against the same CPU reference -- the producer's per-tile output is
+        loop-internal scratch the consumer reads in the same iteration, and
+        only a real run proves that per-tile addressing pairs the right slices.
         """
         torch.manual_seed(0xAFFE)
-        H = 20
-        a = torch.randn(1, H, 16, 64, dtype=torch.float16)
-        b = torch.randn(1, H, 64, 32, dtype=torch.float16)
+        a = torch.randn(1, 20, 16, 64, dtype=torch.float16)
+        b = torch.randn(1, 20, 64, 32, dtype=torch.float16)
 
         def fn(a, b):
             return torch.matmul(a, b) * 2.0
 
-        with patch(
-            "torch_spyre._inductor.wsr.coarse_tile_span_overflow.plan_span_overflow_tile",
-            _forced_span_plan_on_dim1(5, H),
-        ):
-            compare_with_cpu(
-                fn,
-                a,
-                b,
-                run_compile=True,
-                run_eager=False,
-                source_check=self._assert_single_loop_spec(BATCH_MATMUL_OP, "mul"),
-                atol=0.05,
-                rtol=0.05,
-            )
+        self._assert_tiled_span_overflow_matches_untiled(
+            fn,
+            a,
+            b,
+            source_check=self._assert_single_loop_spec(BATCH_MATMUL_OP, "mul"),
+        )
 
-    # TODO(span-overflow-read-copy): the FAILURE MODE CHANGED with #3612
-    # ("coarse tiling: optional read copy").  The codegen half of this
-    # direction, in TestSpanOverflowPointwiseCodegen, now passes and is no
-    # longer xfailed -- the read copy gets built.  What remains is worse than
-    # the old loud failure: the kernel compiles, executes, and returns WRONG
-    # NUMBERS (compiled-spyre vs CPU mismatch), so this xfail is now masking a
-    # silent wrong-answer path rather than a refusal to compile.
-    #
-    # Most likely cause is the positional walk described below, which is still
-    # present: it pairs each of the buffer's non-unit dims with the next
-    # iteration extent by position.  Instrumenting _resize_device_layout on
-    # this shape shows it handed tile_size=[1,4,32,64] for a buffer of
-    # [1,20,64,32] -- the trailing dims transposed -- so the layout it builds
-    # does not describe the data.  Verify that before assuming a backend bug.
-    #
-    # Blocked by a pre-existing coarse_tile.py defect, not by the grouping this
-    # branch adds: _insert_read_copy_ops cannot build a copy-buffer layout for a
-    # tiled *Reduction* that reads a full-size buffer from outside its loop
-    # group.  It aligns dep.size (the ITERATION space -- for a BMM that is
-    # H/M/N/K) positionally against the input buffer's non-unit dims, which only
-    # coincide for Pointwise ops.  For arg0_1 [1,20,16,64] read as
-    # 1024*d0 + 64*d1 + d3, tile_ranges=[4,16,32,64] has four entries for three
-    # non-unit buffer dims and it asserts.
-    #
-    # Verified pre-existing two ways: a LONE tiled BMM with no consumer at all
-    # (no grouping possible) raises the same assert, and the #3218-era
-    # test_lm_head_matmul_join_numeric below -- already expectedFailure before
-    # this branch -- fails with the identical message.  So automatic
-    # span-overflow tiling of a BMM reading graph inputs has never worked,
-    # grouped or not.
-    #
-    # The grouping decision these validate is fully covered and passing in
-    # TestSpanOverflowGroups; only on-device execution is blocked.  Remove both
-    # decorators once _insert_read_copy_ops handles Reduction iteration spaces.
-    @unittest.expectedFailure
     @config.patch(
         {
             "sencores": 4,
@@ -5994,90 +6688,47 @@ class TestSpanOverflowNumericValidation(InductorTestCase):
         }
     )
     def test_bmm_to_reduction_join_numeric(self):
-        """A BMM producer whose Reduction consumer joins its group -- the
-        BMM -> Reduction direction -- executed for real.
+        """A BMM producer whose Reduction consumer joins its span-overflow
+        group (BMM -> Reduction), forced-tiled on dim 1 and executed for real.
 
-        This is the direction with the most room to go silently wrong: a
-        Reduction consumer paired against the wrong producer slice does not
-        crash, it computes a partial sum and returns it.  A CPU comparison is
-        the only thing that distinguishes that from a correct result, which is
-        why this test exists rather than relying on the grouping unit tests.
-
-        ``sum(dim=2)`` reduces a dim that is neither op's tiled dim, so the
-        tiled dim stays an output range for both -- the case the join is
-        licensed for.  The complementary illegal case (producer tiling a dim
-        that is the consumer's reduction range) is covered structurally by
-        ``test_bmm_to_bmm_rejected_when_producer_tiles_consumer_reduction_dim``,
-        which asserts it is refused rather than executed.
+        The direction with the most room to go silently wrong: a Reduction
+        consumer paired against the wrong producer slice computes a partial sum
+        and returns it without crashing.  ``sum(dim=2)`` reduces a dim that is
+        neither op's tiled dim, so the tiled dim stays an output range for both
+        -- the case the join is licensed for.  Asserted against the same
+        untiled run, not a fixed tolerance.
         """
         torch.manual_seed(0xAFFE)
-        H = 20
-        a = torch.randn(1, H, 16, 64, dtype=torch.float16)
-        b = torch.randn(1, H, 64, 32, dtype=torch.float16)
+        a = torch.randn(1, 20, 16, 64, dtype=torch.float16)
+        b = torch.randn(1, 20, 64, 32, dtype=torch.float16)
 
         def fn(a, b):
             return torch.matmul(a, b).sum(dim=2)
 
-        with patch(
-            "torch_spyre._inductor.wsr.coarse_tile_span_overflow.plan_span_overflow_tile",
-            _forced_span_plan_on_dim1(5, H),
-        ):
-            compare_with_cpu(
-                fn,
-                a,
-                b,
-                run_compile=True,
-                run_eager=False,
-                source_check=self._assert_single_loop_spec(BATCH_MATMUL_OP, "sum"),
-                atol=0.05,
-                rtol=0.05,
-            )
+        self._assert_tiled_span_overflow_matches_untiled(
+            fn,
+            a,
+            b,
+            source_check=self._assert_single_loop_spec(BATCH_MATMUL_OP, "sum"),
+        )
 
-    # TODO(span-overflow-read-copy): the on-device half of
-    # test_pointwise_producer_to_bmm_codegen_shares_one_loop_spec, whose
-    # codegen half now passes after #3612 and is no longer xfailed.
-    #
-    # Added PASSING by #3270 on 21 Jul; marked expectedFailure by #3293 on
-    # 28 Jul with no stated cause.  Before #3612 it failed in the read-copy
-    # path before codegen -- the same rank assert as the codegen xfails, and
-    # explicitly "not a numeric problem".  After #3612 it compiled and ran but
-    # was numerically wrong: tiled mismatches=48727/49152 (99.14%) against
-    # untiled 781/49152 (1.59%) on the same reference -- the same raw-vs-
-    # squeezed copy-out keying bug described in
-    # test_reduction_producer_to_reduction_codegen_shares_one_loop_spec's
-    # TODO. Fixed by #3613's _raw_to_squeezed_pos: tiled mismatches dropped to
-    # 999/49152 (2.03%), within noise of the untiled baseline.
     def test_lm_head_matmul_join_numeric(self):
         """F.linear with an oversized vocab-dim weight: the restickified
         weight producer and the BMM consumer join into one synchronized group
         (#3217/#3218). ``vocab=49152`` (768 stick-aligned sticks, composite)
         and ``sencores=32`` are the exact shape/core-count the PR author
         validated manually with 0% numeric error per the PR description; this
-        test captures that as an automated regression instead of relying on a
-        one-off manual run.
+        test captures that as an automated regression.
 
-        Decision xfail: failing in CI (Actions run 30385154736, job
-        90362759197) on PR #3293. We've decided to xfail the coarse tiling
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
+        A 4096-deep fp16 reduction cannot be checked against a fixed tolerance
+        (CPU and device sum in different orders), so the same shape is also run
+        with span-overflow tiling disabled -- work division alone handles it at
+        sencores=32 -- as a same-depth, same-reference control.  The assertion
+        is that tiled is not meaningfully worse than untiled.
 
-        A first version of this test compared only the tiled (joined) result
-        against a plain fp16 CPU reference with atol=rtol=0.05, and failed:
-        886/49152 (1.8%) elements exceeded that threshold, with the largest
-        absolute diff 0.6875 on values in the ~30-160 magnitude range. Those
-        numbers look like ordinary fp16 accumulation-order noise over a
-        4096-deep reduction (CPU and device sum in different orders), not a
-        correctness bug -- but a fixed tolerance can't distinguish "expected
-        fp16 noise at this reduction depth" from "tiling introduced extra
-        error" by itself. This version isolates that by also running the
-        *same* shape with span-overflow tiling disabled
-        (``ignore_span_overflow_hints=True``) -- work division alone already
-        handles this shape at sencores=32 (splits the 768-stick dim in half),
-        so an untiled run is possible here and gives a same-K-depth,
-        same-CPU-reference control for how much noise is inherent regardless
-        of tiling. The assertion is that tiled isn't *meaningfully worse* than
-        untiled, not an arbitrary fixed threshold.
+        The read-copy path this relies on was reworked by #3612 and its
+        transposed post-tile layout fixed by #3613 (``_raw_to_squeezed_pos``),
+        which dropped tiled mismatches from 99.14% to within noise of untiled.
         """
         torch.manual_seed(0xAFFE)
         vocab, hidden = 49152, 4096
@@ -6150,3 +6801,303 @@ class TestSpanOverflowNumericValidation(InductorTestCase):
             "untiled baseline at the same reduction depth, suggesting the "
             "join introduces extra error beyond ordinary fp16 noise.",
         )
+
+    def _assert_reduction_range_loop_spec(self, reduction_op):
+        """source_check: a counted loop was emitted for a tiled reduction.
+
+        Load-bearing: without it these tests still pass if the forced plan is
+        silently dropped and the reduction runs untiled -- exactly the
+        regression they exist to catch.
+        """
+
+        def check(src):
+            loop_spec_count = src.count("LoopSpec(")
+            has_op = f"op='{reduction_op}'" in src
+            print(
+                f"[reduction-range evidence] LoopSpec count={loop_spec_count}; "
+                f"op='{reduction_op}' present={has_op}"
+            )
+            self.assertIn("LoopSpec(", src)
+            self.assertTrue(has_op, f"expected op='{reduction_op}' in source:\n{src}")
+
+        return check
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_generic_sum_reduction_range_tile_numeric(self):
+        """A plain ``sum`` whose reduced axis is coarse-tiled by the automatic
+        span-overflow planner must execute correctly against a CPU reference --
+        proving the identity(0)-fill + per-tile ``add`` + drain machinery is
+        wired for non-matmul reductions, not just BMM K."""
+        torch.manual_seed(0xAFFE)
+        x = torch.randn(20, 16, 64, dtype=torch.float16)
+
+        def fn(x):
+            return x.sum(dim=1)
+
+        with patch(
+            "torch_spyre._inductor.wsr.coarse_tile_span_overflow.plan_span_overflow_tile",
+            _forced_reduction_range_plan(split_count=4, reduction_size=16),
+        ):
+            compare_with_cpu(
+                fn,
+                x,
+                run_compile=True,
+                run_eager=False,
+                source_check=self._assert_reduction_range_loop_spec("sum"),
+                atol=0.05,
+                rtol=0.05,
+            )
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_generic_max_reduction_range_tile_numeric(self):
+        """Same as the ``sum`` case for ``amax`` -- a separate identity
+        (``-inf``) and per-tile combine (``maximum``) code path, the one most
+        likely to have an identity-value bug."""
+        torch.manual_seed(0xAFFE)
+        x = torch.randn(20, 16, 64, dtype=torch.float16)
+
+        def fn(x):
+            return x.amax(dim=1)
+
+        with patch(
+            "torch_spyre._inductor.wsr.coarse_tile_span_overflow.plan_span_overflow_tile",
+            _forced_reduction_range_plan(split_count=4, reduction_size=16),
+        ):
+            compare_with_cpu(
+                fn,
+                x,
+                run_compile=True,
+                run_eager=False,
+                source_check=self._assert_reduction_range_loop_spec("max"),
+                atol=0.05,
+                rtol=0.05,
+            )
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_generic_min_reduction_range_tile_numeric(self):
+        """``amin`` -- identity ``+inf``, per-tile combine ``minimum``."""
+        torch.manual_seed(0xAFFE)
+        x = torch.randn(20, 16, 64, dtype=torch.float16)
+
+        def fn(x):
+            return x.amin(dim=1)
+
+        with patch(
+            "torch_spyre._inductor.wsr.coarse_tile_span_overflow.plan_span_overflow_tile",
+            _forced_reduction_range_plan(split_count=4, reduction_size=16),
+        ):
+            compare_with_cpu(
+                fn,
+                x,
+                run_compile=True,
+                run_eager=False,
+                source_check=self._assert_reduction_range_loop_spec("min"),
+                atol=0.05,
+                rtol=0.05,
+            )
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_generic_prod_reduction_range_tile_numeric(self):
+        """``prod`` -- identity ``1``, per-tile combine ``mul``.  Inputs are
+        held near 1.0 so the 16-deep fp16 product stays numerically stable for
+        a CPU comparison (reordered multiplication is otherwise unbounded)."""
+        torch.manual_seed(0xAFFE)
+        x = 1.0 + 0.05 * torch.randn(20, 16, 64, dtype=torch.float16)
+
+        def fn(x):
+            return x.prod(dim=1)
+
+        with patch(
+            "torch_spyre._inductor.wsr.coarse_tile_span_overflow.plan_span_overflow_tile",
+            _forced_reduction_range_plan(split_count=4, reduction_size=16),
+        ):
+            compare_with_cpu(
+                fn,
+                x,
+                run_compile=True,
+                run_eager=False,
+                source_check=self._assert_reduction_range_loop_spec("prod"),
+                atol=0.1,
+                rtol=0.1,
+            )
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_generic_combined_output_and_reduction_range_numeric(self):
+        """A nested plan -- outer output-dim level + inner reduction-range
+        level -- on a plain ``sum``, executed for real and compared to CPU.
+        The combined output+reduction path had planner and codegen coverage
+        but no on-device numeric check."""
+        torch.manual_seed(0xAFFE)
+        # sum(dim=1) on (20, 16, 64): output dim 0 is 20 (tiled 4 -> 5),
+        # reduction range is 16 (tiled 2 -> 8).
+        x = torch.randn(20, 16, 64, dtype=torch.float16)
+
+        def fn(x):
+            return x.sum(dim=1)
+
+        def check(src):
+            self.assertIn("LoopSpec(", src)
+            self.assertIn("count=sympify('4')", src)  # outer output level
+            self.assertIn("count=sympify('2')", src)  # inner reduction level
+            self.assertIn("op='sum'", src)
+
+        with patch(
+            "torch_spyre._inductor.wsr.coarse_tile_span_overflow.plan_span_overflow_tile",
+            _forced_reduction_range_plan(
+                split_count=2, reduction_size=16, output_split=4
+            ),
+        ):
+            compare_with_cpu(
+                fn,
+                x,
+                run_compile=True,
+                run_eager=False,
+                source_check=check,
+                atol=0.05,
+                rtol=0.05,
+            )
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_generic_sum_reduction_range_tile_numeric_organic(self):
+        """The *unforced* path: the real planner sees a reduced-axis input span
+        over a lowered limit, chooses a reduction-range tile itself, adapts it,
+        and the compiled kernel runs.  No plan patching -- only the span limit
+        is lowered so a small tensor overflows on its reduced axis.
+
+        The reduction here is 512 deep, so a fixed fp16 tolerance can't tell
+        "tiling introduced error" from "accumulation-order noise at this
+        depth".  Same technique as ``test_lm_head_matmul_join_numeric``: also
+        run with span-overflow tiling disabled as a same-depth control, and
+        assert the tiled run is not meaningfully worse than that baseline.
+        """
+        torch.manual_seed(0xAFFE)
+        # Reading all of x spans dim1 (512) * dim2 (16) * stick (64) * 2 B
+        # = 1 MiB > the lowered 512 KiB limit, and dim1 is the reduced axis.
+        x = torch.randn(1, 512, 16, 64, dtype=torch.float16)
+
+        def fn(x):
+            return x.sum(dim=1)
+
+        cpu_result = fn(x)
+        saw_reduction_loop = []
+
+        def run_on_spyre(ignore_span_overflow_hints, source_check=None):
+            torch._dynamo.reset_code_caches()
+            torch._inductor.codecache.FxGraphCache.clear()
+            with (
+                config.patch(
+                    {"ignore_span_overflow_hints": ignore_span_overflow_hints}
+                ),
+                patch(
+                    "torch_spyre._inductor.wsr.span_overflow_hint_analysis."
+                    "MAX_SPAN_BYTES",
+                    512 * 1024,
+                ),
+            ):
+                cfn = torch.compile(fn, dynamic=False)
+                result, source_codes = run_and_get_code(cfn, x.to("spyre"))
+                if source_check is not None and source_codes:
+                    source_check(source_codes[0])
+            return result.cpu()
+
+        def check_tiled(src):
+            saw_reduction_loop.append("LoopSpec(" in src and "op='sum'" in src)
+
+        tiled = run_on_spyre(False, source_check=check_tiled)
+        untiled = run_on_spyre(True)
+
+        self.assertTrue(
+            saw_reduction_loop and saw_reduction_loop[0],
+            "planner did not emit a tiled sum loop for the overflowing reduced axis",
+        )
+
+        def mismatches(actual):
+            atol = rtol = 0.1
+            diff = (actual.float() - cpu_result.float()).abs()
+            return int((diff > atol + rtol * cpu_result.float().abs()).sum())
+
+        tiled_bad, untiled_bad = mismatches(tiled), mismatches(untiled)
+        print(
+            f"[numeric] tiled={tiled_bad}/{cpu_result.numel()} "
+            f"untiled={untiled_bad}/{cpu_result.numel()}"
+        )
+        self.assertLessEqual(tiled_bad, untiled_bad + max(10, untiled_bad))
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    @patch(
+        "torch_spyre._inductor.wsr.span_overflow_hint_analysis.MAX_SPAN_BYTES",
+        512 * 1024,
+    )
+    def test_mean_reduction_range_overflow_raises_at_compile(self):
+        """End-to-end: a ``mean`` whose averaged-over axis overflows -- and
+        where nothing but reduction-range tiling could shrink it -- must fail
+        the compile with the clear "not supported" message, not silently
+        produce an over-limit kernel.
+
+        ``(8, 8192, 64)`` reducing dim 1: the 8192 axis coordinate has only
+        the stick inside it, so no output-dim tile can help -- genuinely
+        untileable.
+        """
+        x = torch.randn(8, 8192, 64, dtype=torch.float16).to("spyre")
+
+        def fn(x):
+            return x.mean(dim=1)
+
+        cfn = torch.compile(fn, dynamic=False)
+        with self.assertRaisesRegex(
+            Exception, "reduction-dimension tiling is not supported"
+        ):
+            with (
+                patch(_LAUNCH_JOBPLAN),
+                patch(_PREPARE_KERNEL),
+                patch("subprocess.run"),
+            ):
+                run_and_get_code(cfn, x)

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1812,12 +1812,31 @@ def reduction_loop_vars(op: ComputedBuffer) -> list[sympy.Symbol]:
     through it: ``_loop_var_to_reduction_ranges_pos`` (loop_var -> position) and
     coarse tiling's reduction-axis lowering (its inverse, position -> loop_var,
     in ``scratchpad.coarse_tiling.tile_spec_to_dim_hints``).
+
+    A fused pointwise prologue can make the reduction read more than one
+    operand (e.g. ``(x * bias[:, None]).sum(1)``), and a broadcast operand
+    carries a strict subset of the reduction symbols (often none).  Pick the
+    read dep that indexes the *most* reduction symbols, so a leading broadcast
+    operand neither yields an empty result nor a short, mis-positioned list
+    (consumers index this positionally by reduction-range position).
     """
     assert isinstance(op.data, Reduction)
     rw = op.get_read_writes()
     out_dep = next(iter(rw.writes))
     out_syms = out_dep.index.free_symbols
-    in_dep = next(d for d in rw.reads if hasattr(d, "index"))
+    # isinstance, not hasattr(d, "index"): StarDep.index is a property that
+    # raises NotImplementedError rather than being absent, and hasattr only
+    # swallows AttributeError -- a StarDep anywhere in rw.reads (e.g. a
+    # bucketize read) would otherwise crash this list comprehension, which
+    # (unlike the single next(...) it replaced) evaluates the predicate on
+    # every dep rather than stopping at the first match.
+    in_deps = [d for d in rw.reads if isinstance(d, MemoryDep)]
+    if not in_deps:
+        return []
+    in_dep = max(
+        in_deps,
+        key=lambda d: len([s for s in d.ranges if s not in out_syms]),
+    )
     return [s for s in in_dep.ranges if s not in out_syms]
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
@@ -254,11 +254,14 @@ def _dims_to_hints(
                     f"host_dim={host_dim} is out of bounds for reduction ranges "
                     f"{reduction_ranges}."
                 )
+            # _bmm_k_symbol resolves the single reduction-only symbol for BMM K
+            # and, since span_overflow_hint_analysis widened its gate, for a
+            # supported non-matmul reduction (sum/prod/max/min) too.
             loop_var = _bmm_k_symbol(op)
             if loop_var is None:
                 raise Unsupported(
                     f"Cannot adapt span-overflow reduction plan for {op.get_name()}: "
-                    "could not identify the BMM K loop variable."
+                    "could not identify the reduction loop variable."
                 )
             try:
                 reduction_pos = _loop_var_to_reduction_ranges_pos(op, loop_var)
@@ -267,7 +270,7 @@ def _dims_to_hints(
             if reduction_pos != host_dim:
                 raise Unsupported(
                     f"Cannot adapt span-overflow reduction plan for {op.get_name()}: "
-                    f"BMM K loop variable {loop_var} maps to reduction range "
+                    f"reduction loop variable {loop_var} maps to reduction range "
                     f"position {reduction_pos}, expected {host_dim}."
                 )
             coord = loop_var

--- a/torch_spyre/_inductor/wsr/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/wsr/span_overflow_hint_analysis.py
@@ -85,7 +85,12 @@ class InputSpanInfo:
 
 @dataclass(frozen=True)
 class BMMKSpanInfo:
-    """Input span facts controlled by BMM's single reduction range K."""
+    """Input span facts controlled by an op's single reduction range.
+
+    ``k_symbol`` is BMM K, or the sole reduced axis of a supported non-matmul
+    reduction (sum/prod/max/min); ``chunking_info.selected_host_dim`` is its
+    reduction-range position, always ``0``.
+    """
 
     chunking_info: ChunkingInfo
     dep_name: str
@@ -101,8 +106,9 @@ class SpanOverflowTileLevel:
     ``selected_host_dim=1`` tiles ``N``.  ``split_count`` is the number of
     equal-sized chunks to create for that dimension, so the dimension size must
     be divisible by it.  ``is_reduction`` distinguishes an output range from a
-    reduction range. The automatic planner's BMM-only fallback can emit
-    ``selected_host_dim=0, is_reduction=True`` for K.
+    reduction range. The automatic planner can emit
+    ``selected_host_dim=0, is_reduction=True`` for the single reduction range of
+    a batch-matmul (K) or a supported non-matmul reduction (sum/prod/max/min).
     """
 
     selected_host_dim: int
@@ -159,6 +165,24 @@ _MAX_SPLITS_PER_DIM = 16
 # keep automatic plans conservative.  Manual spyre_hint remains user-controlled
 # and can request larger counts explicitly.
 _MAX_AUTO_TILE_SPLIT_COUNT = 64
+
+# Non-matmul reduction types whose partial results recombine associatively
+# through coarse_tile's identity-fill + per-tile combine + drain path
+# (see coarse_tile._reduction_identity_value / _insert_combine_op).  A
+# reduction whose type is in this set and which has exactly one reduction
+# range is eligible for an automatic reduction-range ("K-style") coarse tile,
+# the same mechanism BMM K already uses.  Intentionally excluded: ``mean``
+# (needs per-tile scale-factor handling), ``xor_sum`` / ``any`` (no Spyre
+# kernel lowering), and welford (var/std, no Spyre lowering).
+_GENERIC_REDUCTION_TILING_TYPES = frozenset({"sum", "prod", "max", "min"})
+
+# The reduction_type family the "fail loudly instead of silently dropping"
+# guard (``_has_untileable_reduction_span``) is scoped to.  Anything outside it
+# -- matmul (incl. fp8), conv, top-k, welford, ... -- is owned by other passes
+# (work division splits matmul K; dedicated lowerings own conv/top-k), so the
+# guard must not convert their silent-skip into a compile abort.  ``mean`` is
+# included: it is the concrete case the guard exists to catch loudly.
+_REDUCTION_RANGE_FAMILY = frozenset({"sum", "prod", "max", "min", "mean"})
 
 
 def _layout_has_static_span_metadata(layout: FixedTiledLayout) -> bool:
@@ -329,6 +353,46 @@ def _is_batch_matmul_reduction(op: ComputedBuffer) -> bool:
     )
 
 
+def _supports_reduction_range_tiling(op: ComputedBuffer) -> bool:
+    """Return True when an automatic reduction-range coarse tile is legal here.
+
+    Two families qualify:
+
+    * batch-matmul reductions, whose single K range recombines by addition
+      (the original supported case); and
+    * non-matmul ``Reduction`` ops whose ``reduction_type`` is in
+      ``_GENERIC_REDUCTION_TILING_TYPES`` and which have exactly one reduction
+      range, so coarse tiling can lower one reduction-range tile level as
+      identity-fill + per-tile combine + drain.
+
+    Ops with more than one reduction range are excluded: coarse tiling tiles at
+    most one reduction dim per level (``_validate_planned_reduction_tiling``),
+    and this planner does not yet search nested reduction levels.  The reduction
+    position is therefore always ``0`` wherever this returns True.
+
+    ``max``/``min`` are restricted to floating-point dtypes:
+    ``coarse_tile._reduction_identity_value`` seeds the accumulator with
+    ``-/+inf``, and ``float(inf)`` cast into an integer ``spyre.constant``
+    saturates to the wrong bound (silent wrong numerics).  ``sum``/``prod``
+    seed with ``0``/``1`` and are dtype-safe.
+    """
+    if not isinstance(op.data, Reduction):
+        return False
+    if _is_batch_matmul_reduction(op):
+        return True
+    reduction_type = getattr(op.data, "reduction_type", None)
+    if reduction_type not in _GENERIC_REDUCTION_TILING_TYPES:
+        return False
+    if len(list(getattr(op.data, "reduction_ranges", []))) != 1:
+        return False
+    if reduction_type in ("max", "min"):
+        try:
+            return bool(op.get_dtype().is_floating_point)
+        except (AttributeError, TypeError):
+            return False
+    return True
+
+
 def _output_symbol_to_dim(op: ComputedBuffer) -> dict[sympy.Symbol, int]:
     """Map each output iteration symbol to its logical output host dim.
 
@@ -398,8 +462,15 @@ def _bmm_k_symbol(
     op: ComputedBuffer,
     input_deps: Sequence[tuple[MemoryDep, FixedTiledLayout | None]] | None = None,
 ) -> sympy.Symbol | None:
-    """Return BMM's unique reduction-only input symbol, or ``None``."""
-    if not _is_batch_matmul_reduction(op):
+    """Return the op's unique reduction-only input symbol, or ``None``.
+
+    This is BMM K for a batch-matmul reduction, or the single reduced axis for
+    a supported non-matmul reduction (see ``_supports_reduction_range_tiling``).
+    ``_bmm_symbol_partition`` already derives the reduction symbol generically
+    by subtracting output symbols from input symbols; the only BMM-specific
+    part was the caller gate, now widened.
+    """
+    if not _supports_reduction_range_tiling(op):
         return None
     if len(list(getattr(op.data, "reduction_ranges", []))) != 1:
         return None
@@ -638,7 +709,9 @@ def _input_span_infos_controlled_by_output_dims(
         )
 
     input_deps = _input_read_deps(op)
-    k_symbol = _bmm_k_symbol(op, input_deps) if _is_batch_matmul_reduction(op) else None
+    k_symbol = (
+        _bmm_k_symbol(op, input_deps) if _supports_reduction_range_tiling(op) else None
+    )
     symbol_to_dim = (
         _bmm_output_symbol_to_dim(op, input_deps)
         if _is_batch_matmul_reduction(op)
@@ -757,7 +830,12 @@ def _bmm_k_span_infos(
     *,
     split_by_host_dim: dict[int, int] | None = None,
 ) -> list[BMMKSpanInfo]:
-    """Return BMM input overflows that shrink when K is split."""
+    """Return input overflows that shrink when the sole reduction range is split.
+
+    Covers BMM K and the single reduced axis of a supported non-matmul
+    reduction (sum/prod/max/min); ``selected_host_dim`` on the emitted
+    ``ChunkingInfo`` is the reduction-range position, always ``0`` here.
+    """
     del max_cores  # Conservatively assume no work-division help.
     input_deps = _input_read_deps(op)
     k_symbol = _bmm_k_symbol(op, input_deps)
@@ -765,7 +843,11 @@ def _bmm_k_span_infos(
         return []
     if split_by_host_dim is None:
         split_by_host_dim = {}
-    output_symbol_to_dim = _bmm_output_symbol_to_dim(op, input_deps)
+    output_symbol_to_dim = (
+        _bmm_output_symbol_to_dim(op, input_deps)
+        if _is_batch_matmul_reduction(op)
+        else _output_symbol_to_dim(op)
+    )
     span_symbol_to_dim = {**output_symbol_to_dim, k_symbol: -1}
     span_split_by_host_dim = {**split_by_host_dim, -1: k_split}
 
@@ -826,13 +908,150 @@ def _bmm_k_span_infos(
                         selected_device_span_stride_elems=inner_stride_elems,
                         selected_host_dim=0,
                         stick_elems=stick_elems,
-                        reason=f"BMM K input span overflow for {dep.name}",
+                        reason=(
+                            f"BMM K input span overflow for {dep.name}"
+                            if _is_batch_matmul_reduction(op)
+                            else f"reduction-range input span overflow for {dep.name}"
+                        ),
                     ),
                     dep_name=dep.name,
                     k_symbol=k_symbol,
                 )
             )
     return infos
+
+
+def _best_case_inner_span(
+    inner_coords: list[sympy.Expr],
+    inner_sizes: list[int],
+    dep: MemoryDep,
+    symbol_to_dim: dict[sympy.Symbol, int],
+) -> int | None:
+    """Return the best-case (smallest) inner span for one outer coordinate.
+
+    Every output symbol in an inner coordinate is modelled as tiled down to a
+    single element (the most an output-range tile could do); a reduction
+    symbol, or the stick, stays at its true extent.  A coordinate mixing both
+    -- an interleaved/collapsed stride -- is charged only its reduction part,
+    not its full extent.
+
+    Returns ``None`` -- "cannot determine, do not trust an assumed bound" --
+    if any contributing coordinate's span cannot be computed (the same
+    fail-safe ``_coordinate_span_elems`` itself documents), rather than
+    substituting a value.  A caller deciding untileability must not treat this
+    as the worst case: that would inflate the *best*-case estimate and can
+    raise on a coordinate the pass never actually proved was too large.
+    """
+    best_inner = 1
+    for idx, (inner_coord, dim_size) in enumerate(zip(inner_coords, inner_sizes)):
+        inner_syms = inner_coord.free_symbols
+        is_stick = idx == len(inner_coords) - 1
+        if not inner_syms:
+            best_inner *= dim_size
+            continue
+        split_by_symbol: dict[sympy.Symbol, int] = {}
+        for sym in inner_syms:
+            rng = _range_size_for_symbol(dep, sym)
+            if not is_stick and sym in symbol_to_dim and rng:
+                split_by_symbol[sym] = rng  # -> per-tile extent 1
+            else:
+                split_by_symbol[sym] = 1
+        inner_span = _coordinate_span_elems(inner_coord, dep, split_by_symbol)
+        if inner_span is None:
+            return None
+        best_inner *= min(inner_span, dim_size)
+    return best_inner
+
+
+def _has_untileable_reduction_span(op: ComputedBuffer, max_cores: int) -> bool:
+    """Return True when a reduction-only input span overflows unfixably.
+
+    Pre-work-division heuristic.  It fires only when no mechanism available to
+    this op could bring the span under the limit:
+
+    * reduction-range tiling for this op is disabled
+      (``config.enable_reduction_tiling``) or was never supported for its
+      ``reduction_type``/dtype/range-count in the first place -- checked by
+      ``_supports_reduction_range_tiling`` returning False for a reason other
+      than the config, below;
+    * ``reduction_type`` is in the sum/prod/max/min/mean family and the dtype is
+      floating point.  Everything else -- matmul (incl. fp8), conv, top-k,
+      welford, integer max/min -- is owned by another pass (work division
+      cross-core splits matmul/conv/pool/top-k K via ``_K_SPLIT_COMBINE_SUPPORTED``)
+      or has no combine path here at all, and must keep its historical
+      silent-skip;
+    * the overflowing coordinate itself is controlled only by reduction
+      symbols, so no output-range tile touches it;
+    * the span still exceeds the limit in the *best case* computed by
+      ``_best_case_inner_span``, which is more aggressive than any
+      output-range coarse tile or any N-way work-division core split, so if
+      even that leaves the span over the limit, no output mechanism can close
+      it -- only a reduction-range split, which this op cannot do
+      (``_K_SPLIT_COMBINE_SUPPORTED`` also excludes plain reductions).
+
+    ``max_cores`` is therefore not consulted: the best case already bounds
+    every core-split outcome.
+
+    Every op reaching the family/dtype checks below is guaranteed non-BMM:
+    ``_supports_reduction_range_tiling`` always returns True for
+    ``BATCH_MATMUL_OP`` regardless of dtype or range count, so a real BMM op
+    always returns False at the first line: BMM keeps its own, separately
+    tested kill-switch handling (the post-search retry in
+    ``plan_span_overflow_tile``), unaffected by the config check here.
+
+    Without this check (and when not disabled) the span is silently dropped,
+    ``span_reduction_pass`` cannot split the reduced axis either (plain
+    reductions are pinned to split=1), and the op reaches the backend over the
+    limit.
+    """
+    if not isinstance(op.data, Reduction) or _supports_reduction_range_tiling(op):
+        return False
+    if not config.enable_reduction_tiling:
+        # Escape hatch: with the feature disabled, do not second-guess that
+        # choice with a compile abort -- fall back to the historical
+        # silent-skip for every non-BMM reduction (see the docstring for why
+        # this is always non-BMM).
+        return False
+    if getattr(op.data, "reduction_type", None) not in _REDUCTION_RANGE_FAMILY:
+        return False
+    try:
+        if not op.get_dtype().is_floating_point:
+            return False
+    except (AttributeError, TypeError):
+        return False
+    symbol_to_dim = _output_symbol_to_dim(op)
+    if not symbol_to_dim:
+        return False
+    del max_cores  # Best case below already bounds every core-split outcome.
+    for dep, layout in _input_read_deps(op):
+        if not _layout_has_static_span_metadata(layout):
+            continue
+        try:
+            device_coords = _device_coordinates_for_span(layout, dep)
+        except (TypeError, ValueError, RuntimeError, Unsupported):
+            continue
+        device_size = [int(s) for s in layout.device_layout.device_size]
+        itemsize = layout.dtype.itemsize
+        for device_dim, coord in enumerate(device_coords[:-1]):
+            syms = coord.free_symbols
+            if not syms or any(sym in symbol_to_dim for sym in syms):
+                continue
+            span_elems = _coordinate_span_elems(coord, dep, {sym: 1 for sym in syms})
+            if span_elems is None:
+                continue
+            best_inner = _best_case_inner_span(
+                device_coords[device_dim + 1 :],
+                device_size[device_dim + 1 :],
+                dep,
+                symbol_to_dim,
+            )
+            if best_inner is None:
+                # Cannot prove this coordinate's best case either way -- do
+                # not assume untileable from it.
+                continue
+            if span_elems * best_inner * itemsize > MAX_SPAN_BYTES:
+                return True
+    return False
 
 
 def _bmm_k_alignment_error(op: ComputedBuffer, split_count: int) -> str | None:
@@ -1126,7 +1345,15 @@ def _input_span_candidates(
         candidates.append(
             SpanOverflowCandidate(info.chunking_info, source=f"input:{info.dep_name}")
         )
-    if _is_batch_matmul_reduction(op):
+    if _supports_reduction_range_tiling(op) and (
+        _is_batch_matmul_reduction(op) or config.enable_reduction_tiling
+    ):
+        # Non-BMM reduction-range candidates are gated on the config so
+        # disabling it is a real escape hatch: with no reduction candidate
+        # ever created, the search cannot emit a reduction-level plan for
+        # this op and the post-search kill-switch check below never fires.
+        # BMM is unaffected -- its kill switch is enforced after the search
+        # (plan_span_overflow_tile), as before.
         candidates.extend(
             SpanOverflowCandidate(
                 info.chunking_info,
@@ -1416,17 +1643,18 @@ def _split_candidates_for_axis(
     host_dim, is_reduction = axis
     if not is_reduction:
         return _split_candidates_for_host_dim(op, host_dim, required_count)
-    if not _is_batch_matmul_reduction(op) or host_dim != 0:
+    if not _supports_reduction_range_tiling(op) or host_dim != 0:
         raise Unsupported(
             f"Cannot auto-tile {op.get_name()}: reduction-range tiling is only "
-            "supported for BMM K (reduction dim 0)."
+            "supported for the single reduction range (dim 0) of a batch-matmul "
+            "or sum/prod/max/min reduction."
         )
     k_candidates = _bmm_k_split_candidates(op, required_count)
     if not k_candidates:
         raise Unsupported(
             f"Cannot auto-tile {op.get_name()}: a K-controlled input span "
-            "exceeds the hardware limit, but BMM K has no legal nontrivial "
-            "split."
+            "exceeds the hardware limit, but the reduction range has no legal "
+            "nontrivial split."
         )
     return [1, *k_candidates]
 
@@ -1485,8 +1713,12 @@ def _combined_tile_stick_alignment_error(
         if error is not None:
             return error
     for reduction_dim, split_count in (split_by_reduction_dim or {}).items():
-        if not _is_batch_matmul_reduction(op) or reduction_dim != 0:
-            return "reduction-range tiling is only supported for BMM K"
+        if not _supports_reduction_range_tiling(op) or reduction_dim != 0:
+            return (
+                "reduction-range tiling is only supported for the single "
+                "reduction range (dim 0) of a batch-matmul or sum/prod/max/min "
+                "reduction"
+            )
         error = _bmm_k_alignment_error(op, split_count)
         if error is not None:
             return error
@@ -1538,7 +1770,7 @@ def _remaining_span_candidates_after_tile(
                     k_split=k_split,
                 )
             ]
-        if k_split is not None and _is_batch_matmul_reduction(op):
+        if k_split is not None and _supports_reduction_range_tiling(op):
             remaining += [
                 SpanOverflowCandidate(
                     info.chunking_info,
@@ -1913,14 +2145,24 @@ def plan_span_overflow_tile(
     if isinstance(op.data, Reduction):
         # Scalar/full reductions have no output range to coarse-tile.
         # Non-scalar reductions combine output-span candidates with input spans
-        # controlled by output symbols. BMM K candidates join the same
-        # bounded search, allowing output-only, K-only, or combined plans.
+        # controlled by output symbols. Reduction-range candidates (BMM k, or a
+        # supported non-matmul reduction's axis) join the same bounded search,
+        # allowing output-only, reduction-only, or combined plans.
         if not list(op.data.ranges):
             logger.debug(
                 "[span-overflow planner] skip op=%s reason=scalar_reduction",
                 op.get_name(),
             )
             return None
+        if _has_untileable_reduction_span(op, max_cores):
+            raise Unsupported(
+                f"Cannot auto-tile {op.get_name()}: an input span controlled "
+                "only by the reduction dimension exceeds the hardware span "
+                "limit, but reduction-dimension tiling is not supported for "
+                f"this op (reduction_type={op.data.reduction_type!r}, "
+                f"{len(list(op.data.reduction_ranges))} reduction range(s); "
+                "supported: single-range sum, prod, max, min)."
+            )
         output_candidates = _output_span_candidates_from_op(op, op_name=op.get_name())
         input_candidates = _input_span_candidates(op, max_cores)
         candidates = output_candidates + input_candidates
@@ -1968,9 +2210,9 @@ def plan_span_overflow_tile(
         ):
             # The cheapest unrestricted plan may combine an output tile with a
             # reduction tile. With reduction tiling disabled, retry using only
-            # output-controlled candidates before concluding that K tiling is
-            # required. This preserves useful output tiling behind the kill
-            # switch while still rejecting a K-only overflow.
+            # output-controlled candidates before concluding that reduction-range
+            # tiling is required. This keeps useful output tiling behind the kill
+            # switch while still rejecting a reduction-only overflow.
             output_only_candidates = [
                 candidate for candidate in candidates if not candidate.is_reduction
             ]
@@ -1984,8 +2226,33 @@ def plan_span_overflow_tile(
             if output_only_plan is not None:
                 return output_only_plan
             raise Unsupported(
-                f"Cannot auto-tile {op.get_name()}: K reduction-range tiling "
+                f"Cannot auto-tile {op.get_name()}: reduction-range tiling "
                 "is required but disabled via enable_reduction_tiling"
+            )
+        if (
+            plan is None
+            and not _is_batch_matmul_reduction(op)
+            and config.enable_reduction_tiling
+            and any(candidate.is_reduction for candidate in candidates)
+        ):
+            # A non-matmul reduction produced reduction-range candidates but the
+            # search found no plan: the reduced axis overflows and no legal,
+            # stick-aligned split within _MAX_AUTO_TILE_SPLIT_COUNT clears it
+            # (the search's all-reduction branch returns None without
+            # distinguishing the two).  Fail loudly rather than silently drop
+            # it.
+            #
+            # The BMM exemption is not arbitrary: work division cross-core
+            # splits a matmul's K range (BATCH_MATMUL_OP is in
+            # work_division_constraints._K_SPLIT_COMBINE_SUPPORTED), so a
+            # BMM K-only rejection here is genuinely recoverable downstream and
+            # keeps its historical None.  Plain sum/prod/max/min are pinned to
+            # split=1 there and have no such recovery, so dropping their
+            # overflow just defers the failure to the backend.
+            raise Unsupported(
+                f"Cannot auto-tile {op.get_name()}: the reduced axis overflows "
+                "and no legal, stick-aligned reduction-range split within "
+                f"{_MAX_AUTO_TILE_SPLIT_COUNT} clears the span."
             )
         return plan
 

--- a/torch_spyre/model_utils.py
+++ b/torch_spyre/model_utils.py
@@ -292,9 +292,11 @@ def _transfer_module(
     """
     if _module_overrides_apply(module):
         module._apply(
-            lambda t: _dma_to_spyre_default(t, target_dtype=dtype)
-            if t is not None and t.device.type != DEVICE_NAME
-            else t
+            lambda t: (
+                _dma_to_spyre_default(t, target_dtype=dtype)
+                if t is not None and t.device.type != DEVICE_NAME
+                else t
+            )
         )
         return
 


### PR DESCRIPTION
Resolves #3198 (sub-issue of #206 "Working set reduction").
Resolves #4281

### What this covers

Introduces tiling on reduction dimension of generic non bmm reduction ops . Ops covered  - "sum","prod","max","min"
Before this PR the **automatic** span-overflow pass could only do this forbatch-matmul K (#3662, #4000). A plain `sum` / `prod` / `max` / `min` whose *reduced axis* drove the overflow was silently skipped — the span stayed over the limit and surfaced much later as a confusing backend failure.


This PR extends the automatic pass to those four reduction types. It is a **planner + adapter** change only — everything downstream in `coarse_tile.py`(identity-fill + per-tile combine + drain) was already generic and is
untouched.


For any other non bmm reduction op overflows apart from ops covered above, raises a clear Unsupported at compile time (new  _has_untileable_reduction_span) instead of silently dropping the overflow.

### Also in this PR: un-xfail 4 stale span-overflow tests
Investigated the 4 @unittest.expectedFailure tests in this file with latest code and changed it

test_auto_span_overflow_matches_equivalent_spyre_hint_loop_spec — asserted the planner picks a hard-coded split 5; it validly picks 4. Rewritten to read the planner's chosen split, feed it to the manual spyre_hint, and compare LoopSpec blocks.

test_reduction_input_span_codegen_contains_auto_loop_spec — asserted the tiled loop symbol is literally c0; coarse tiling renamed it _tile_adv_op<N>_lvl<L>. Rewritten to assert structure (one tiled symbol + trip count).

test_bmm_to_pointwise_join_numeric / test_bmm_to_reduction_join_numeric — asserted a fixed atol/rtol on a reordered fp16 BMM. Verified tiled and untiled runs have identical mismatch counts vs CPU (the coarse tile adds zero error). The genuine past bugs were fixed by #3612 / #3613; the comment and decorator were never removed. Rewritten to the tiled-vs-untiled comparison already used by test_lm_head_matmul_join_numeric.


test_span_overflow_hint_analysis.py: 167 passed, 0 xfailed


### Not covered yet
mean reduction-range tiling (scale-factor handling) 
More than one reduction range tiled on a single op.
can_conform_reduction_tile — a Reduction consumer adopting a producer group's split in producer/consumer fusion — separate limitation, tracked in #3625.
Output N/Vocab tiling for non-divisible / prime sizes — separate feature, tracked in #3203.


### Docs
docs/source/compiler/span_overflow_hint_analysis.md and coarse_tiling_loops.md updated: support matrix, reduction flow, failure policy, known limitations, and the producer/consumer coverage matrix (now
all-pass — the stale prose about the 4 xfails removed).


### test logs

```
(dt-inductor) hemaprasanna@hemaprasanna-torch-spyre:~/dt-inductor/torch-spyre$ python3 -m pytest -q tests/inductor/test_span_overflow_hint_analysis.py
......................................................................................................................................................... [ 90%]
................                                                                                                                                              [100%]
========================================================================= warnings summary ==========================================================================
tests/inductor/test_span_overflow_hint_analysis.py: 31 warnings
  /home/hemaprasanna/dt-inductor/.venv/lib64/python3.12/site-packages/torch/_dynamo/pgo.py:605: UserWarning: dynamo_pgo force disabled by torch.compiler.config.force_disable_caches
    warn_once(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
169 passed, 31 warnings, 4 subtests passed in 26.29s
(dt-inductor) hemaprasanna@hemaprasanna-torch-spyre:~/dt-inductor/torch-spyre$ 
```