### PR TITLE
perf(coarse_tile): memoize get_read_writes() to cut compile time

### DIFF
--- a/torch_spyre/_inductor/dedup_constants.py
+++ b/torch_spyre/_inductor/dedup_constants.py
@@ -21,7 +21,7 @@ from torch._inductor.virtualized import V
 
 from .ir import SpyreConstantFallback
 from .logging_utils import get_inductor_logger
-from .pass_utils import NameSwapHandler
+from .pass_utils import NameSwapHandler, invalidate_op_read_writes
 from .provenance import merge_provenance
 
 logger = get_inductor_logger("dedup_constants")
@@ -49,6 +49,10 @@ def _patch_inner_fn(consumer: ComputedBuffer, name_map: dict[str, str]) -> None:
 
     object.__setattr__(consumer.data, "inner_fn", _new_inner)
     ComputedBuffer.get_default_sizes_body.clear_cache(consumer)
+    # consumer's reads changed (D -> C): drop any memoized op_read_writes so
+    # later passes (e.g. work_division.span_reduction) re-trace instead of
+    # reading a stale pre-redirect dependency on the now-dropped duplicate.
+    invalidate_op_read_writes(consumer)
 
 
 def _build_reverse_consumer_index(

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -122,6 +122,7 @@ from ..pass_utils import (
     indirect_sizes_from_op,
     invalidate_op_read_writes,
     iteration_space_from_op,
+    op_read_writes,
 )
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 from .tile import compute_tile_index, compute_tile_stride, decompose_index_for_tiling
@@ -482,7 +483,7 @@ def plan_coarse_tile_groups(
                 continue
 
             op_out = op_out_coords(op)
-            rw = op.get_read_writes()
+            rw = op_read_writes(op)
             read_deps = [d for d in rw.reads if isinstance(d, MemoryDep)]
             write_deps = [d for d in rw.writes if isinstance(d, MemoryDep)]
 
@@ -596,7 +597,7 @@ def _find_outside_consumers_planned(
     for op in operations:
         if not isinstance(op, ComputedBuffer):
             continue
-        if not _reads_buffer(op, buf_name):
+        if not _reads_buffer_cached(op, buf_name):
             continue
         candidate_outer_key = name_to_group_outer_key.get(op.get_name())
         if candidate_outer_key is None or candidate_outer_key != outer_key:
@@ -848,7 +849,7 @@ def _plan_tiling_propagation(
                         if (
                             not isinstance(candidate, ComputedBuffer)
                             or candidate is op
-                            or not _reads_buffer(candidate, buf_name)
+                            or not _reads_buffer_cached(candidate, buf_name)
                         ):
                             continue
                         if name_to_group_outer_key.get(candidate.get_name()) != (
@@ -1018,7 +1019,7 @@ def _plan_tiling_propagation(
                         in_loop_carry = any(
                             isinstance(candidate, ComputedBuffer)
                             and candidate is not op
-                            and _reads_buffer(candidate, mut_target_name)
+                            and _reads_buffer_cached(candidate, mut_target_name)
                             and name_to_group_outer_key.get(candidate.get_name())
                             == info.loop_group_id[0]
                             for candidate in group_ops
@@ -1751,7 +1752,7 @@ def _consumers_reading_incomplete_reduction(
     for o in group_ops:
         if not isinstance(o, ComputedBuffer) or o.get_name() == buf_name:
             continue
-        if not _reads_buffer(o, buf_name):
+        if not _reads_buffer_cached(o, buf_name):
             continue
         if _reads_incomplete_reduction(
             o, group_ops, group_op_names, plan, group_reduction_tiled_levels
@@ -1777,8 +1778,14 @@ def _plan_is_loop_invariant_at_reduction_levels(
 
 
 def _op_reads(op: ComputedBuffer) -> set[str]:
-    """Return the set of buffer names op reads (via MemoryDep)."""
-    return {d.name for d in op.get_read_writes().reads if isinstance(d, MemoryDep)}
+    """Return the set of buffer names op reads (via MemoryDep).
+
+    Uses the memoized op_read_writes() helper: every call site of
+    _op_reads is confined to planning-time (zero-mutation) contexts, so a
+    memo scoped to the op instance cannot go stale here -- see
+    _reads_buffer_cached's docstring for the general argument.
+    """
+    return {d.name for d in op_read_writes(op).reads if isinstance(d, MemoryDep)}
 
 
 # ---------------------------------------------------------------------------
@@ -2092,13 +2099,14 @@ def _divide_ranges(
     # Invalidate ComputedBuffer-level caches derived from data.ranges.
     _clear_cache(op, _COMPUTED_BUF_SIZES_KEY)
     _clear_cache(op, _COMPUTED_BUF_FREE_SYMS_KEY)
+    # ranges just changed unconditionally above, so any memoized
+    # get_read_writes() result (pass_utils.op_read_writes) is stale
+    # regardless of which capture path (if any) runs below -- invalidate
+    # unconditionally rather than only inside the symbol-remap branch.
+    invalidate_op_read_writes(op)
 
     symbol_remap = None
     if before_symbols is not None or fused_before_symbols is not None:
-        # Both capture paths call the memoized iteration-space helper before
-        # ranges are rewritten.  Always invalidate it before observing the new
-        # iteration space, including the fused-dimension fallback.
-        invalidate_op_read_writes(op)
         if before_symbols is not None:
             symbol_remap = _order_preserving_symbol_remap(
                 op, before_symbols, _capture_logical_iteration_symbols(op)
@@ -2201,10 +2209,14 @@ def _divide_reduction_ranges(
             reduction_ranges[i] = sympy.sympify(r) / sympy.sympify(loop_count)
     # Reduction is a frozen dataclass; use object.__setattr__ to mutate it.
     object.__setattr__(data, "reduction_ranges", reduction_ranges)
+    # reduction_ranges just changed unconditionally above, so any memoized
+    # get_read_writes() result (pass_utils.op_read_writes) is stale
+    # regardless of whether a symbol-remap capture path runs below --
+    # invalidate unconditionally rather than only inside that branch.
+    invalidate_op_read_writes(op)
     if before_symbols is None and fused_before_symbols is None:
         return None
 
-    invalidate_op_read_writes(op)
     if before_symbols is not None:
         return _order_preserving_symbol_remap(
             op, before_symbols, _capture_logical_iteration_symbols(op)
@@ -3068,6 +3080,29 @@ def _reads_buffer(op: ComputedBuffer, buf_name: str) -> bool:
     except Exception as e:
         logger.debug(
             "_reads_buffer: get_read_writes() raised for %s: %s", op.get_name(), e
+        )
+        return False
+    return any(getattr(dep, "name", None) == buf_name for dep in rw.reads)
+
+
+def _reads_buffer_cached(op: ComputedBuffer, buf_name: str) -> bool:
+    """Planning-time analog of _reads_buffer that memoizes get_read_writes()
+    via pass_utils.op_read_writes().
+
+    Only safe to call from contexts that never mutate a *different* op's
+    inner_fn between calls for the same op -- see the zero-mutation
+    argument in coarse_tile_compile_time's design notes. Do NOT call this
+    from transform-time helpers (_propagate_tiled_op,
+    _propagate_tiled_reduction_op, _find_outside_consumers) where earlier
+    splices in the same pass can make another op's cached reads stale.
+    """
+    try:
+        rw = op_read_writes(op)
+    except Exception as e:
+        logger.debug(
+            "_reads_buffer_cached: get_read_writes() raised for %s: %s",
+            op.get_name(),
+            e,
         )
         return False
     return any(getattr(dep, "name", None) == buf_name for dep in rw.reads)
@@ -6406,7 +6441,11 @@ def _should_patch_retiled_load_indexes(
     loop_info = getattr(op, "loop_info", None)
     if loop_info is None or loop_info.loop_group_id != group_id:
         return False
-    return any(_reads_buffer(op, name) for name in retiled_names)
+    # Fetch op's own read names once (memoized via _op_reads -- safe here
+    # because _patch_retiled_load_indexes tests/mutates each op in
+    # group_ops at most once) instead of re-tracing inner_fn once per name
+    # in retiled_names.
+    return not retiled_names.isdisjoint(_op_reads(op))
 
 
 def _replace_group_op(
@@ -6459,6 +6498,7 @@ def _patch_retiled_load_indexes(
                 return _orig(*args)
 
         object.__setattr__(op.data, "inner_fn", new_inner_fn)
+        invalidate_op_read_writes(op)
         new_op = replace_computed_buffer_body(
             op,
             op.data,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://g
ithub.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Reduces compile time of the prestickify coarse tiling pass
(`torch_spyre/_inductor/wsr/coarse_tile.py`) for graphs with many
coarse-tiled ops, e.g. chunked flash attention.

**Root cause:** several hot loops in `coarse_tile.py` called
`op.get_read_writes()` — which is deliberately uncached upstream and
re-traces `inner_fn` from scratch every call — once per `(op,
candidate-buffer-name)` pair instead of once per op:

- `_should_patch_retiled_load_indexes` called `_reads_buffer(op, name)`
  (a full retrace of `op`) once per name in `retiled_names`, even though
  `op`'s read-set doesn't change across that inner loop.
- `_plan_tiling_propagation` (via `_find_outside_consumers_planned` /
  `_consumers_reading_incomplete_reduction`) did the same
  one-retrace-per-candidate-per-buffer-name scan over all `operations`.

Profiling `test_hint_flash_attention_kv_chunked_8_chunks` with cProfile
confirmed this: `coarse_tile_pre_stickify` accounted for 62.76s of 152.67s
total profiled wall time (41%), with `_patch_retiled_load_indexes` alone
responsible for 78% of that, and `ComputedBuffer.get_read_writes()` called
51,812 times (89.34s cumulative — over half of total profiled time). This
matches the O(n²)-ish blowup that made
`test_hint_flash_attention_kv_chunked_16_chunks`/`_32_chunks` need to be
skipped in CI (~6 min / ~40 min).

**Fix:** reuse the existing, purpose-built memoization helpers
`pass_utils.op_read_writes()` / `invalidate_op_read_writes()` (already
used by the scratchpad allocator for the identical problem) instead of
inventing new caching. Each call site was individually verified safe to
memoize by checking its mutation window:

- `_plan_tiling_propagation` is zero-mutation for its entire duration, so
  its scans (and the helpers it calls) can safely read a memoized result.
- `_patch_retiled_load_indexes`'s loop mutates only the op currently being
  tested, never a different op already scanned in the same call, so a
  per-call memo stays correct; added `invalidate_op_read_writes(op)`
  immediately after the `inner_fn` mutation, matching the existing pattern
  elsewhere in the file.
- `_divide_ranges` / `_divide_reduction_ranges`: fixed a related
  pre-existing bug where `invalidate_op_read_writes(op)` was nested inside
  a conditional branch even though the mutation it guards against is
  unconditional — moved the invalidate call to run unconditionally.

Deliberately left alone: `_propagate_tiled_op`/`_propagate_tiled_reduction_op`
(transform-time; earlier calls in the same pass can splice replacement ops
into `operations` and patch *other* consumers' `inner_fn`, so a
cross-call memo would go stale — and this bucket is only ~1% of profiled
coarse_tile time, not worth the correctness risk for negligible gain).

**Related bug found and fixed while validating (`dedup_constants.py`):**
once `coarse_tile.py` started populating `op_read_writes()`'s memo during
planning, that memo has no defined lifetime — it persists for the rest of
compilation, across every later pass in `CustomPreSchedulingPasses`.
`dedup_and_promote_constants` (which runs *after* coarse tiling)
redirects duplicate-constant consumers via `_patch_inner_fn`, which
mutates a consumer's `inner_fn` via `object.__setattr__` but never called
`invalidate_op_read_writes`. This was harmless before (nothing cached
`get_read_writes()` across that boundary), but once coarse_tile.py's
planning phase had memoized a consumer's stale pre-redirect reads, a
later pass (`work_division.py`'s `span_reduction`) read the stale memo and
crashed trying to resolve a buffer that `dedup_constants.py` had already
deleted. Fixed by adding `invalidate_op_read_writes(consumer)` in
`_patch_inner_fn`, right after the mutation — this addresses the bug at
its actual source (an unguarded mutation of a memoized op) rather than
narrowing `coarse_tile.py`'s own memoization, since it could bite any
other future caller of `op_read_writes`.

**Verified results** (repro:
`test_hint_flash_attention_kv_chunked_8_chunks` under cProfile):

- `coarse_tile_pre_stickify` / `_coarse_tile_common` cumulative time:
  62.76s → **2.32s** (~27x reduction).
- `ComputedBuffer.get_read_writes()` call count: 51,812 → **9,541**.
- Total profiled wall time: 152.67s → **92.60s**.

Local regression suites (per project convention — CI covers the full
suite):

- `tests/inductor/test_coarse_tile_e2e.py`: 230 passed, 7 skipped.
- `tests/inductor/test_building_blocks.py`: 42 passed, 2 skipped, 8
  subtests passed.
- `pre-commit run --all-files`: all hooks passed.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

- Two files touched: `torch_spyre/_inductor/wsr/coarse_tile.py` (the
  memoization fix) and `torch_spyre/_inductor/dedup_constants.py` (the
  independent staleness fix this exposed).
- `test_hint_flash_attention_kv_chunked_16_chunks`/`_32_chunks` remain
  `@pytest.mark.skip`ped in CI; this change was validated against them
  locally but the skip markers were intentionally left in place (removing
  them is out of scope for this perf change).
- No behavior change is intended — this is a compile-time-only fix.
  Correctness is covered by the unchanged e2e/building-blocks suites
  passing, plus the specific stale-memo crash this PR fixes.

#### Does this PR introduce a user-facing change?

No functional/user-facing change. Compile time improves significantly for
graphs with many coarse-tiled ops (e.g. chunked flash attention).

#### Additional note:
