### PR TITLE
[Bug] FP32 RMSNorm layout fix

### DIFF
--- a/tests/inductor/test_sliced_staggered_convert.py
+++ b/tests/inductor/test_sliced_staggered_convert.py
@@ -1,0 +1,81 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A staggered dtype conversion whose input is a *slice* of a wider buffer.
+
+Gemma's per-head ``q_norm``/``k_norm`` apply a native FP32 RMSNorm to a slice of
+the fused QKV projection output, so the fp16->fp32 upcast at the head of the norm
+reads ``W_qkv``-wide rows and writes a narrower dense buffer.  Inheriting the
+input buffer's ``device_size``/``stride_map`` across such a conversion makes the
+token coordinate ``Mod(a*c0, b)`` with ``a/b = W_out/W_in`` in lowest terms,
+which either escapes the coordinate-normalization grammar (``a != 1``) or, worse,
+stays inside it while addressing the wrong sticks (``a == 1``).
+
+The ``k`` cases are the regression guard for the silent variant, so they must
+assert values -- a compile-only check passes even when every access is misplaced.
+"""
+
+import pytest
+import torch
+
+from torch_spyre._inductor.constants import DEVICE_NAME
+
+EPS = 1e-6
+
+# (num_q_heads, num_kv_heads, head_dim, hidden), yielding W_q/W_qkv of:
+#   gemma-3-1b     1024/1536  = 2/3   (q, hard error)  and 256/1536 = 1/6 (k, silent)
+#   gemma-4 global 16384/20480 = 4/5  (q, hard error)  and 2048/20480 = 1/10 (k, silent)
+_SHAPES = {
+    "gemma3-1b": (4, 1, 256, 1152),
+    "gemma4-global": (32, 4, 512, 5376),
+}
+
+_TOKENS = 8
+
+
+def _gemma_rms_norm(x, weight):
+    """vLLM ``GemmaRMSNorm.forward_native``: normalize and scale in fp32."""
+    x32 = x.float()
+    x32 = x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + EPS)
+    return (x32 * (1.0 + weight.float())).to(x.dtype)
+
+
+def _build(num_q_heads, num_kv_heads, head_dim, hidden, part):
+    w_q = num_q_heads * head_dim
+    w_kv = num_kv_heads * head_dim
+    heads = num_q_heads if part == "q" else num_kv_heads
+    start = 0 if part == "q" else w_q
+    width = w_q if part == "q" else w_kv
+
+    def fn(x, w_qkv, weight):
+        # One fused fp16 buffer; the norm sees only `width` of its columns.
+        qkv = x @ w_qkv
+        part_view = qkv[:, start : start + width].reshape(_TOKENS, heads, head_dim)
+        return _gemma_rms_norm(part_view, weight)
+
+    args = (
+        torch.randn(_TOKENS, hidden, dtype=torch.float16) / 8,
+        torch.randn(hidden, w_q + 2 * w_kv, dtype=torch.float16) / 8,
+        torch.randn(head_dim, dtype=torch.float16) / 8,
+    )
+    return fn, args
+
+
+@pytest.mark.parametrize("shape", list(_SHAPES), ids=list(_SHAPES))
+@pytest.mark.parametrize("part", ["q", "k"])
+def test_native_rmsnorm_on_qkv_slice(shape, part):
+    fn, args = _build(*_SHAPES[shape], part)
+    expected = fn(*args)
+    got = torch.compile(fn, dynamic=False)(*(a.to(DEVICE_NAME) for a in args))
+    torch.testing.assert_close(got.cpu(), expected, rtol=0.05, atol=0.05)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import io
+import itertools
 import math
 import warnings
 from dataclasses import dataclass
@@ -68,6 +69,7 @@ from .views import (
     build_alignment_inputs,
     compute_coordinates,
     matching_dim,
+    normalize_coordinates,
 )
 
 # PyTorch's default lower bound for size symbols (sizes 0/1 are specialised).
@@ -1301,6 +1303,39 @@ def try_device_coordinates(
         return device_coordinates(stl, dep, indirect_sizes)
     except Unsupported:
         return None
+
+
+def coordinates_normalizable(
+    stl: SpyreTensorLayout,
+    dep: MemoryDep,
+    indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+) -> bool:
+    """Whether every device coordinate of this access survives normalization.
+
+    ``try_device_coordinates`` only validates the stick expression, but codegen
+    later runs ``normalize_coordinates`` over *all* device dims, and that step
+    accepts a strictly smaller grammar (``num*(var%mod)//den + offset``).  A
+    layout whose row span is incommensurate with the access's host strides
+    yields a non-affine ``Mod(k*var, m)`` on a non-stick dim, which passes the
+    stick check and only fails at codegen.  Use this to reject such a candidate
+    while alternatives are still available.
+    """
+    try:
+        coords = alignment_coordinates(stl, dep.index, dep.ranges, indirect_sizes)
+        counter = itertools.count()
+        normalize_coordinates(
+            dict(dep.ranges),
+            stl.device_size,
+            coords,
+            lambda: Symbol(f"_probe{next(counter)}"),
+            indirect_sizes,
+        )
+    except (Unsupported, AssertionError):
+        # normalize_var_expr signals an unrepresentable term either way: the
+        # non-unit-fraction coefficient case is an assert, the modular case
+        # raises Unsupported.
+        return False
+    return True
 
 
 def _find_entry_output_dim(op) -> "tuple[int, int, int] | None":

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -80,6 +80,7 @@ from .ir import (
 from .pass_utils import (
     compute_restickify_target_layout,
     concretize_expr,
+    coordinates_normalizable,
     find_matmul_generated_var,
     find_reduction_var,
     get_matmul_m_size,
@@ -346,6 +347,36 @@ def _check_supported_input_sticks(args: list[PropArg], op_label: str) -> None:
             )
 
 
+def _convert_reads_whole_input(
+    in_layout: FixedLayout,
+    output: FixedLayout,
+    dep: MemoryDep,
+    output_dep: MemoryDep,
+) -> bool:
+    """Whether a dtype conversion traverses its input exactly as it writes its output.
+
+    Only then may the conversion inherit the input buffer's
+    ``device_size``/``stride_map`` (rescaled for the new stick depth). When the
+    read is a *slice* of a wider buffer -- Gemma's ``q_norm``/``k_norm`` upcast
+    part of the fused QKV projection into a fresh, narrower per-head buffer --
+    the inherited row span belongs to the input buffer while the elements land
+    in a buffer with a different row stride. ``compute_coordinates`` then folds
+    that mismatch into the outer coordinate as ``Mod(a*var, b)`` with
+    ``a/b = row_out/row_in`` in lowest terms, which either falls outside the
+    normalization grammar (``a != 1``, a codegen-time hard error) or, worse, is
+    representable but addresses the wrong sticks (``a == 1``, silently wrong
+    results). Mirrors the identical-access test the general convert path uses,
+    minus the element-width condition -- rescaling the stick depth is exactly
+    what this path is for.
+    """
+    return (
+        list(in_layout.size) == list(output.size)
+        and dep.index == output_dep.index
+        and host_coordinates(in_layout, dep, None)
+        == host_coordinates(output, output_dep, None)
+    )
+
+
 def _qfp8wt_stl(
     output: FixedLayout,
     in_layout: FixedLayout,
@@ -502,11 +533,15 @@ def _single_arg_op_layout(
             # Two strategies, chosen by whether a staggered EA is involved:
             #
             # 1. Staggered conversions (RMSNorm up/down-cast and their
-            #    restoration: STANDARD<->DL16_TO_FP32 / FP32_TO_DL16). The
-            #    staggered element ordering only exists on the physical device
-            #    layout, so we must propagate the input's device_size/stride_map
-            #    and rescale just the stick depth via rescale_stl_for_dtype.
-            #    Reconstructing from the logical host size would lose it.
+            #    restoration: STANDARD<->DL16_TO_FP32 / FP32_TO_DL16) that
+            #    traverse the whole input. The staggered element ordering only
+            #    exists on the physical device layout, so propagate the input's
+            #    device_size/stride_map and rescale just the stick depth via
+            #    rescale_stl_for_dtype; reconstructing from the logical host size
+            #    would lose the stick choice a downstream reduction needs.
+            #    Inheriting is only sound for an identical access -- see
+            #    _convert_reads_whole_input; a sliced read falls through to (2),
+            #    which still stamps the staggered EA.
             #
             # 2. Plain conversions (e.g. fp8->fp16 after qfp8ch). Here the input
             #    device layout can be degenerate — qfp8ch rescales a size-1
@@ -515,7 +550,10 @@ def _single_arg_op_layout(
             #    changing the layout rank and downstream graph partitioning.
             #    Rebuild a clean dense layout from the output host size instead,
             #    as the general (non-EA) convert path does.
-            if fmt in STAGGERED_EAS or input_ea in STAGGERED_EAS:
+            staggered = fmt in STAGGERED_EAS or input_ea in STAGGERED_EAS
+            if staggered and _convert_reads_whole_input(
+                in_layout, output, dep, output_dep
+            ):
                 layouts = [rescale_stl_for_dtype(stl, output.dtype, fmt)]
 
                 # A conversion that creates a staggered EA must also expose
@@ -548,7 +586,18 @@ def _single_arg_op_layout(
                 # reverse staggered-to-STANDARD restoration. It needs no
                 # expansion: preserve the stick selected before the upcast.
 
-                return layouts
+                # Last-resort guard: device_coordinates only validates the stick
+                # expression, so a candidate whose *non-stick* coordinate is
+                # outside the normalization grammar survives until codegen's
+                # normalize_coordinates rejects it. Drop those while the dense
+                # reconstruction below is still reachable.
+                layouts = [
+                    out_stl
+                    for out_stl in layouts
+                    if coordinates_normalizable(out_stl, output_dep)
+                ]
+                if layouts:
+                    return layouts
 
             # Dense reconstruction from the output host size. When the input
             # stick dim is unaligned, force a full input-stick depth so stick


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a layout-propagation bug that makes a staggered dtype conversion **silently
produce wrong results** for some shapes, and hard-fail at codegen for others.

`_single_arg_op_layout` handles a dtype conversion that creates or consumes a
staggered element arrangement (`DL16_TO_FP32` / `FP32_TO_DL16`) by inheriting the
*input buffer's* `device_size` / `stride_map` and rescaling only the stick depth
(`rescale_stl_for_dtype`). That is correct — and necessary — when the conversion
traverses its whole input: the staggered ordering is physical, existing only on
the device layout, so rebuilding from the logical host size would lose the stick
choice a downstream reduction depends on.

It is **not** correct when the conversion reads a *slice* of a wider buffer. Then
the inherited row span describes the input buffer while the elements land in an
output buffer with a different row stride. `compute_coordinates` folds that
mismatch into the outer (non-stick) coordinate as `Mod(a*var, b)`, where
`a / b = W_out / W_in` in lowest terms. Two outcomes, both bad:

| `a` | Outcome |
| --- | --- |
| `a != 1` | Outside the coordinate-normalization grammar. Hard `Unsupported` from `normalize_var_expr`, raised late, during `SpyreKernel.codegen_kernel`. |
| `a == 1` | *Representable* — so it compiles, and then addresses the wrong sticks. No diagnostic, no warning, wrong numbers. |

This is reached by vLLM's native FP32 RMSNorm on Gemma. Gemma-3/4 `q_norm` and
`k_norm` apply a per-head RMSNorm to a slice of the fused QKV projection output,
so the fp16→fp32 upcast at the head of the norm reads `W_qkv`-wide rows and
writes a narrower dense buffer:

| Case | `W_out / W_in` | Coordinate | Symptom |
| --- | --- | --- | --- |
| gemma-3-1b `q_norm` | 1024/1536 = 2/3 | `Mod(2*c0, 3)` | compile error |
| gemma-3-1b `k_norm` | 256/1536 = 1/6 | `Mod(c0, 6)` | **silent, maxabsdiff 1799** |
| gemma-4-31B `q_norm` | 16384/20480 = 4/5 | `Mod(4*c0, 5)` | compile error |
| gemma-4-31B `k_norm` | 2048/20480 = 1/10 | `Mod(c0, 10)` | **silent** |
| gemma-4-26B-A4B `q_norm` | 8192/10240 = 4/5 | `Mod(4*c0, 5)` | compile error |

Concretely for gemma-3-1b `q_norm`: input `buf10` `[8, 1536]` fp16 has
`device_size=[24, 8, 64]`, `stride_map=[64, 1536, 1]`. Output `buf13` `[8, 4, 256]`
fp32 has host row stride 1024. The inherited-and-rescaled layout is
`device_size=[48, 8, 32]`, `stride_map=[32, 1536, 1]` — claiming 1536-element rows
for a 1024-wide buffer. With `c0` step 1024, extent 8192 and `next_stride[0] = 1536`,
`compute_coordinates` emits
`[8*c1 + 16*Mod(2*c0, 3) + floor(c2/32), floor(2*c0/3), Mod(c2, 32)]`, and
`normalize_var_expr` rejects the `Mod(2*c0, 3)` term.

**The fix**, in two parts:

1. `propagate_layouts.py` — new `_convert_reads_whole_input()` gates the inherit
   path on the conversion traversing its input exactly as it writes its output
   (same host size, same `dep.index`, same `host_coordinates`). This mirrors the
   identical-access test the general non-EA convert path already applies, minus
   its element-width condition — rescaling the stick depth is precisely what this
   path exists for. A sliced read now falls through to the pre-existing dense
   reconstruction from the output host size, which still stamps the staggered EA.

2. `pass_utils.py` — new `coordinates_normalizable()` applies
   `normalize_coordinates` to a candidate layout as a predicate. `device_coordinates`
   validates **only** the stick expression (`_check_stick_expr_supported(coords[-1], …)`);
   non-stick dims are first checked much later, in codegen. This helper closes
   that gap so a doomed candidate is dropped while alternatives are still
   reachable. It is applied as a secondary, last-resort filter in the staggered
   branch — the structural guard in (1) is what actually fixes the defect, and (2)
   would not have caught the silent `a == 1` cases on its own.

Why the dense fallback is physically sound: the staggered EA records that one
fp16 stick (64 lanes) converts into two *adjacent* fp32 sticks. For gemma-3-1b
`q_norm` (`W_q = 1024 = 16 × 64`), input stick `s = 24t + j` with `j ∈ [0, 16)`
maps to output sticks `(32t + 2j, 32t + 2j + 1)` — adjacent, and on the same
device dim (`dim0`, host stride 32) that carried the pairing in the inherited
layout. So the dense reconstruction plus the staggered EA preserves everything
the inherited geometry was there to preserve, without importing the wrong row
span. Verified on paper and numerically.

#### Which issue(s) this PR is related to:

Related to <https://github.com/torch-spyre/torch-spyre/pull/4238>, which addressed
the adjacent restickify-reachability problem. That PR added `spyre::to_dtype_d2d`,
an FP16-only restickify guard, and extra restickify-reachable candidates — but
every candidate it adds is still `rescale_stl_for_dtype(target_stl, …)`, derived
from the *input buffer's* geometry. It widens the choice of **stick axis** and
never questions the **row span**, so the sliced case is untouched by it. This PR
is complementary, not a replacement.

Unblocks the Gemma entries in spyre-inference's
`tests/e2e/test_compile.py::test_basic_llm_inference` and
`tests/e2e/test_distributed_tp2.py`.

#### Special notes for your reviewer:

**Please read this as a silent-wrong-results fix, not only a compile fix.** The
`a == 1` rows in the table above compile cleanly on `main` today and return
garbage. Any Gemma accuracy number measured with vLLM's native FP32 RMSNorm
before this patch is invalid. The `k` cases in the new test are the guard for
exactly that, which is why they assert values — a compile-only check passes even
when every access is misplaced.

**Test results.**

New regression test, `tests/inductor/test_sliced_staggered_convert.py`
(gemma-3-1b and gemma-4-global geometries × `q`/`k`, values asserted against
eager):

```
$ pytest tests/inductor/test_sliced_staggered_convert.py -q
4 passed in 30.59s
```

Standalone reproducer over 8 combinations (gemma3-1b, gemma4-global × q/k/qk):

- **Before:** `gemma3-1b[q]`, `gemma3-1b[qk]` compile-fail `Mod(2*c0, 3)`;
  `gemma4-global[*]` compile-fail `Mod(4*c0, 5)`; `gemma3-1b[k]` compiles and
  returns maxabsdiff **1799** vs eager.
- **After:** all 8 compile and match eager, maxabsdiff 0.0078–0.0195 (fp16 round-trip).

Targeted suites for the code this touches:

```
$ pytest tests/inductor/test_ea_bidirectional_conversion.py tests/inductor/test_coordinates.py
97 passed, 9 subtests passed

$ pytest tests/inductor/test_restickify.py \
         tests/inductor/test_inductor_normalization_scalars.py \
         tests/inductor/test_inductor_dtype_scalars.py
2 failed, 438 passed, 30 skipped, 102 xfailed, 3 xpassed
```

Both failures — `TestNegativeScalarOperations::test_requires_grad_scalar_operation[compiled]`
and `::test_chained_scalar_multiply_twice[compiled]` — are **pre-existing**,
confirmed by stashing this patch and re-running that class on unmodified
torch-spyre: identical two failures.

End-to-end, in spyre-inference against this patched torch-spyre:

```
tests/e2e/test_compile.py::test_basic_llm_inference[model_ref_output1]   # gemma-3-1b
1 passed in 105.30s

tests/models/language/generation/test_gemma.py::test_dummy_loader[google/gemma-3-1b-it]
1 passed in 94.59s
```

**Verification gap, stated plainly.** The `4/5` geometry is validated standalone
and at unit level, but **not** end-to-end on the real `google/gemma-4-31B` and
`google/gemma-4-26B-A4B` checkpoints. `test_basic_llm_inference[model_ref_output2]`,
`[model_ref_output3]` and `test_tp2_compiled_llm_generate_matches_tp1[google/gemma-4-26B-A4B]`
still need a run on those weights to confirm nothing else is in the way. A
dummy-weight 26B build was attempted and was still in weight init after 15
minutes; it was stopped in favour of the standalone validation, which isolates
this defect precisely but says nothing about the rest of those models.

**Out of scope: the mixed-EA join.** A separate defect remains open, and this PR
does not touch it. Granite's `RMSNorm.forward_native` downcasts fp32→fp16
*before* the weight multiply, so that multiply joins a `FP32_TO_DL16` activation
with a `STANDARD` fp16 weight and neither operand broadcasts in the stick
dimension — case 3.3 of `_multi_arg_pointwise_layouts`
(`propagate_layouts.py:1457`), which raises:

```
Unsupported: Spyre backend does not support: Multi-arg pointwise with mixed EA:
STANDARD input arg1_1 must broadcast (device stick dimension size 1) to be
compatible with a staggered EA, and no staggered operand is broadcastable
either. Its stick maps to host dim 0 of size 4096
```

That needs the device-resident EA-conversion op the code comment there already
anticipates ("future: insert an explicit EA conversion at extra cost"). Gemma
never reaches it: `GemmaRMSNorm` multiplies by `1.0 + weight.float()` in fp32, so
both operands come out `DL16_TO_FP32`, which is why Gemma is fixed by this PR
while Granite's native path still needs the custom `SpyreRMSNorm` op. The
`Unsupported` above is raised during `LLM(...)` construction, so it is loud rather
than silent — no correctness risk, just an unsupported configuration.

**Style note.** `ruff` is not available in the environment this was developed in,
so the 88-character limit was checked manually; the count of over-long lines in
both touched files is unchanged (28 → 28), i.e. no new violations. Worth a
`pre-commit run` on CI.

**Follow-ups this PR deliberately leaves out** (all recorded in the plan doc):

- An optional device-free layout-level assertion that the chosen output STL's
  `stride_map` derives from the *output* buffer (1024), not the input (1536) —
  a cheap invariant that would have caught this class of bug directly.
- Assert `rescale_stl_for_dtype`'s same-shape precondition inside the helper. Its
  docstring says "same-shape … dtype conversion", but no caller enforced it, which
  is how this bug was possible.
- Use `coordinates_normalizable` at the other candidate-filtering sites, so
  non-stick coordinate validation stops being a codegen-time surprise generally.

#### Does this PR introduce a user-facing change?

Yes — a correctness fix. Models whose dtype conversion reads a slice of a wider
buffer (Gemma per-head `q_norm`/`k_norm` under vLLM's native FP32 RMSNorm) either
failed to compile or returned wrong values; they now compile and match eager. No
API change and no change to any layout decision for a conversion that reads its
whole input.

#### Additional note:

cc @moriohara 

AI assistance was used for the investigation and for preparing this change.
