### PR TITLE
Fix RAS event capture: strip ANSI before matching ERRR lines

### DIFF
--- a/.github/scripts/parse_hw_failures.py
+++ b/.github/scripts/parse_hw_failures.py
@@ -48,14 +48,18 @@ RE_ATTEMPT_PASSED = re.compile(r"=== Attempt \d+ PASSED")
 
 # -------------------- RAS errors ------------------------
 # Matches EVERY ras_base.hpp ERRR line regardless of which fields are present.
-# The JSON object starts at '{' and ends at the first '}' that closes the root
-# object.  All known RAS blobs are single-line, so we match to end-of-line.
+# The JSON object starts at '{' and, since the blob group is greedy, ends at the
+# last '}' on the line.  Applied with .search on an ANSI-stripped line (see
+# _extract_all_ras_events), so it tolerates a "[unspecified] <color> " prefix
+# before ERRR and any trailing content after the closing '}' (e.g. a color
+# reset).  It must NOT anchor the blob to end-of-line: raw GHA logs colorize the
+# whole line, so the closing '}' is not the last character.
 RE_RAS_LINE = re.compile(
     r"ERRR\s+"
     r"(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})\s+"
     r"(?P<time>\d{2}:\d{2}:\d{2}\.\d+)"
     r"\s+\[.*?ras_base\.hpp.*?\]\s+"
-    r"(?P<blob>\{.+\})\s*$"
+    r"(?P<blob>\{.+\})"
 )
 
 # Also catch RuntimeError: {...RAS...} lines (Python traceback form)
@@ -343,9 +347,15 @@ def _extract_all_ras_events(chunk_lines: list[str]) -> list[dict]:
     events: list[dict] = []
     seen_blobs: set[str] = set()
 
-    for line in chunk_lines:
-        # Primary form: ERRR ... [ras_base.hpp] { ... }
-        m = RE_RAS_LINE.match(line.strip())
+    for raw_line in chunk_lines:
+        # Raw GHA logs colorize every line; strip ANSI + control chars first so
+        # both the timestamp prefix and the JSON blob are visible to the
+        # regexes.  _clean is the same stripper used on extracted field values.
+        line = _clean(raw_line)
+        # Primary form: ERRR ... [ras_base.hpp] { ... }.  Use .search, not
+        # .match: even after stripping color codes the line begins with a
+        # "[unspecified] " source prefix before ERRR.
+        m = RE_RAS_LINE.search(line)
         blob_str = None
         ts_str = None
 


### PR DESCRIPTION
## Problem

`.github/scripts/parse_hw_failures.py` drops RAS/hardware events that appear in the job log **only** as an `ERRR ... [ras_base.hpp] {...}` line and are never re-raised as a Python `RuntimeError`. The event is real and fatal on the device side, but it never reaches the `hw_failure_diagnostics` ClickHouse table, so our RAS record is incomplete.

Raw GitHub Actions job logs wrap every line in ANSI color codes and add a source prefix, so the actual bytes look like:

```
<iso-ts> [unspecified] \x1b[31m ERRR DD.MM.YYYY HH:MM:SS [ ras_base.hpp: 74] {...}\x1b[0m
```

Two things then defeat the matcher in `_extract_all_ras_events`:

1. `RE_RAS_LINE` was applied with `.match(line.strip())`. `.match` is start-anchored, so the `[unspecified] \x1b[31m ` prefix in front of `ERRR` makes it fail.
2. The blob group ended with `\}\s*$`. The real line ends with the `\x1b[0m` color reset after the closing brace, so even `.search` would fail the end anchor.

An event that is *also* re-raised survives, because `RE_RAS_RUNTIME_ERROR.search` catches the unanchored `RuntimeError: {...}` traceback line. An event caught internally with no re-raise has no such second chance and is lost.

Concrete case from a real run: `0xf150 RAS::TSCALIBRATOR::DeviceMemAllocFailed` (ERRR line only) was dropped, while `0x7b1b RAS::RUNTIMESCHEDULER::ComputeHardwareError` from the same attempt survived only because it was re-raised.

## Fix

Parser-side only. No schema change: `hw_failure_diagnostics.ras_events_json` already carries the full per-attempt event list, so filling it correctly is all that is needed.

- Strip ANSI and control characters per line with the existing `_clean()` helper before matching.
- Match `RE_RAS_LINE` with `.search` instead of `.match`, so the source prefix no longer defeats the start anchor.
- Drop the `\s*$` anchor on the blob group, so a trailing color reset no longer defeats it. The group is greedy, so it still captures the whole single-line JSON object.

## Verification

- On the real `0xf150` line, the parser now extracts both `0xf150` and `0x7b1b`, where before only `0x7b1b` was captured.
- Clean (non-colorized) lines, deduplication by blob, and rejection of non-RAS lines are all unchanged.
- `pre-commit run --files .github/scripts/parse_hw_failures.py`: ruff, ruff-format, mypy, and the import-regex check all pass.
