### PR TITLE
fix: retry stall-retry attempt on transient VFIO DeviceOpenFail

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -265,6 +265,11 @@ runs:
 
           _STALLED=0
           [[ -f "${stall_flag}.stalled" ]] && _STALLED=1
+          # Surfaced for the stall-retry race check below: whether this
+          # attempt's own failure was RAS::VFIO::DeviceOpenFail, not just any
+          # failure exit code.
+          _DEVICE_OPEN_FAIL=0
+          grep -q 'RAS::VFIO::DeviceOpenFail' "$log_file" 2>/dev/null && _DEVICE_OPEN_FAIL=1
           rm -f "$log_file" "$stall_flag" "${stall_flag}.done" "${stall_flag}.stalled"
         }
 
@@ -306,14 +311,30 @@ runs:
           echo "AIU card released after ${_waited}s"
         fi
 
-        echo "=== Attempt 2/2 (stall retry): ${{ inputs.suite_name }} ==="
-        run_attempt "-n1"
+        # _vfio_holder_pids only sees a holder while its PID is still alive in
+        # /proc. SIGKILL reaps the killed process fast enough that /proc goes
+        # clean well before the VFIO driver actually finishes releasing the
+        # device, so the wait loop above can report "all clear" while a
+        # retry would still hit RAS::VFIO::DeviceOpenFail. Treat that one
+        # failure signature on attempt 2 as the same transient race and give
+        # it a few short-backoff device-open retries before giving up.
+        _DEVICE_OPEN_RETRY_MAX=3
+        for ((_i = 1; _i <= _DEVICE_OPEN_RETRY_MAX; _i++)); do
+          echo "=== Attempt 2/2 (stall retry, device-open try ${_i}/${_DEVICE_OPEN_RETRY_MAX}): ${{ inputs.suite_name }} ==="
+          run_attempt "-n1"
 
-        if [[ $TEST_EXIT -eq 0 ]]; then
-          echo "=== Attempt 2 PASSED ==="
-          echo "${{ inputs.suite_name }} tests done"
-          exit 0
-        fi
+          if [[ $TEST_EXIT -eq 0 ]]; then
+            echo "=== Attempt 2 PASSED ==="
+            echo "${{ inputs.suite_name }} tests done"
+            exit 0
+          fi
+
+          if [[ $_DEVICE_OPEN_FAIL -ne 1 || $_i -eq $_DEVICE_OPEN_RETRY_MAX ]]; then
+            break
+          fi
+          echo "    --> Attempt 2 hit RAS::VFIO::DeviceOpenFail — card release still racing; retrying device-open after backoff"
+          sleep 5
+        done
 
         echo "=== Attempt 2 FAILED (exit=${TEST_EXIT}) — leaving further retry to the pod-level retry"
         exit 1

--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -329,7 +329,7 @@ runs:
             exit 0
           fi
 
-          if [[ $_DEVICE_OPEN_FAIL -ne 1 || $_i -eq $_DEVICE_OPEN_RETRY_MAX ]]; then
+          if [[ $_DEVICE_OPEN_FAIL -ne 1 || $_i -ge $_DEVICE_OPEN_RETRY_MAX ]]; then
             break
           fi
           echo "    --> Attempt 2 hit RAS::VFIO::DeviceOpenFail — card release still racing; retrying device-open after backoff"


### PR DESCRIPTION
## What

The stall-triggered retry in `run-test-suite/action.yml` (attempt 2, `-n1`) now retries the
device-open itself, up to 3 times with a short backoff, when it fails specifically with
`RAS::VFIO::DeviceOpenFail` — instead of failing straight through to the pod-level retry.

## Why

`_vfio_holder_pids()` only sees a fd holder while its PID is still alive in `/proc`. A SIGKILLed
process is reaped fast enough that `/proc` goes clean well before the VFIO driver actually finishes
releasing the device at the kernel level (a process blocked in a VFIO ioctl sits in D state until
the driver returns — the existing comment in this file already anticipated this). So the
card-release wait loop can, and does, report "all clear" on its very first check, while the device
is still genuinely busy — and the stall retry then launches straight into
`RAS::VFIO::DeviceOpenFail` / `"errno":"Device or resource busy"`.

Confirmed empirically across 6 sampled real GHA job logs (`TestMemoryPressureGC`, various recent
runs against `main`): every one shows the identical sequence —

```
[stall-watcher] STALL DETECTED — killing test child processes
=== Attempt 1 FAILED ===
    --> Stall detected — retrying once with -n1 (xdist worker isolation)
=== Attempt 2/2 (stall retry) ===
... RAS::VFIO::DeviceOpenFail ("errno":"Device or resource busy") ...
=== Attempt 2 FAILED ===
```

with the card-release wait loop never printing "Waiting for AIU card release" (it broke on
iteration 1 in every sampled run) and Attempt 2 launching and failing roughly 15s after the kill.
This is a bug in the guard's detection mechanism — it is PID-liveness-based, not
driver-release-based — not environmental flakiness, which explains why `DeviceOpenFail` shows up
scattered across nearly every branch/PR rather than tracking a specific code change: it's
mechanism-specific, not commit-specific.

## Why this fix, not a driver-level reset

There is no VFIO/device reset hook reachable from a GHA workflow script — this repo has no such
mechanism anywhere, and `/dev/vfio` release timing is entirely a kernel/driver decision the
workflow can't observe or force. `tests/oot_framework/run_test.sh` already has the identical
problem at a different layer (an in-process xdist retry re-running on a possibly-wedged device)
and solves it the same way: bound the retry, don't try to force cleanup
(`OOT_FALLBACK_TIMEOUT`/`timeout --signal=KILL`). This PR applies the same pattern at the workflow
level: since the pre-check can't reliably observe true driver-release state, make the retry itself
resilient to the one specific, identified transient failure signature.

Non-device failures on attempt 2 are unaffected — they still fail through immediately to the
pod-level retry (`test_retry`/`test_multi_spyre_retry`), same as before.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/actions/run-test-suite/action.yml'))"` — OK
- Extracted the `run:` script and ran `bash -n` on it — OK
- Can't dry-run the composite action locally (needs real AIU hardware); verified against the 6
  sampled real failing runs' logs that the new `_DEVICE_OPEN_FAIL` grep pattern
  (`RAS::VFIO::DeviceOpenFail`) matches their actual log text

🤖 Generated with [Claude Code](https://claude.com/claude-code)