### PR TITLE
removed FlexAllocator::compositeAddressToDmva use

### DIFF
--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -219,7 +219,7 @@ void SpyreAllocator::copy_data(void* dest, const void* src,
 
 uint64_t SpyreAllocator::compositeAddressToDmva(
     const flex::CompositeAddress& addr) const {
-  return getFlexAllocator()->compositeAddressToDmva(addr);
+  return flex::compositeAddressToDmva(addr);
 }
 
 void SpyreAllocator::memoryPressureCallback(


### PR DESCRIPTION
#### What type of PR is this?

feature

#### What this PR does:

This PR updates the use of FlexAllocator::compositeAddressToDmva which flex no longer suppports. Instead, a call is made to the free function flex::compositeAddressToDmva 

#### Which issue(s) this PR is related to:

#4485 

#### Does this PR introduce a user-facing change?
No