### PR TITLE
test(inductor): add integration coverage for core op-lowering shards

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [unit, regression, trunk]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
@@ -10,7 +10,7 @@
 # compute group, assign it to whichever shard keeps the two jobs balanced.
 
 test_suite_config:
-  labels: [unit, regression, trunk]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
@@ -8,7 +8,7 @@
 # compute group, assign it to whichever shard keeps the jobs balanced.
 
 test_suite_config:
-  labels: [unit, regression, trunk]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [unit, regression, trunk]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [unit, regression, trunk]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [unit, regression, trunk]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Adds the `integration` label to six `test_inductor_ops.py` config shards so
they run as part of the `integration` test tier:

- `test_inductor_ops_matmul_config.yaml`
- `test_inductor_ops_pointwise_config.yaml`
- `test_inductor_ops_misc_compute_b_config.yaml` (normalization, embedding,
  isin, bitwise, misc arithmetic)
- `test_inductor_ops_misc_compute_c_config.yaml` (attention, SDPA, RoPE, QKV)
- `test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml`
- `test_inductor_ops_reduction_scalar_config.yaml`

**Motivation:** the `integration` tier (triggered by `integration-tests.yaml`
when upstream `flex`/`dxp_standalone` changes land) previously covered only
device-layer plumbing -- streams, job launch plans, codegen, LX/scratchpad
planning, tensor layout, allocator/GC, D2D copies -- with zero operator-level
correctness coverage. None of the ~25 `test_inductor_ops*`/
`test_inductor_ops_lx_planning*` shards carried the `integration` label. As a
result, `dxp_standalone` backend-compiler bugs in operator lowering have been
able to slip through the integration tier undetected.

**Shard selection:** rather than adding all ~25 op shards (cost-prohibitive
for a tier that runs on every upstream `flex`/`dxp_standalone` change), the six
shards above were chosen to maximize breadth of distinct SuperDSC/backend-
compiler codegen paths per added shard, rather than picking shards that are
mostly shape/dtype sweeps of already-covered ops:

- pointwise and matmul are structurally distinct codegen families (matmul
  additionally exercises core-division/multi-core tiling)
- misc_compute_b/c add the fused-normalization (exx2/layernormscale/
  layernormnorm) and attention/SDPA codegen surfaces, neither touched by any
  other integration config
- the two reduction shards were picked as one representative each from the
  norm/index and scalar/topk/conv2d families, instead of adding all five
  `reduction_keepdim_*` shards, which are largely dim-count/keepdim
  permutations of the same handful of reduction ops

`tests/scripts/check_oot_configs.py` was run before and after the change
against `tests/configs/torch_spyre_tests/inductor`; the label edits introduce
no new duplicate/missing/unlabeled findings (pre-existing dead-pattern
warnings are unchanged).

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Motivated by recent `dxp_standalone` bugs that reached main undetected by the
`integration` tier.

#### Special notes for your reviewer:

- This only changes the `labels:` field of six existing config YAMLs -- no
  test logic, shard contents, or other tiers (`unit`/`regression`/`trunk`)
  are touched.
- Open follow-up (not addressed here): six unrelated configs
  (`test_cooptimization_types_config.yaml`, `test_fusion_config.yaml`,
  `test_inplace_op_kernels.yaml`, `test_op_features_config.yaml`,
  `test_op_spec_validation_config.yaml`, `test_sa_cooptimizer_config.yaml`)
  carry a `[core, full]`/`[core, full, device_critical]` label set that isn't
  part of the vocabulary any Makefile target or workflow actually selects on
  -- they currently run under no CI tier at all. Worth a separate PR.

#### Does this PR introduce a user-facing change?

No. Test-configuration only; no production code paths change.

#### Additional note:

This increases the per-run cost of the `integration` tier by six op-test
shards. If CI runtime for that tier becomes a concern, `misc_compute_b`
(39 test-name patterns) is the largest of the six and the first candidate to
reconsider.