### PR TITLE
fix(inductor): preserve eager layouts at graph boundaries

### DIFF
--- a/tests/inductor/test_fallback_kernel.py
+++ b/tests/inductor/test_fallback_kernel.py
@@ -47,11 +47,14 @@ the Spyre device to guard against regressions.
 """
 
 import unittest
+import warnings
 
 import torch
 import torch.nn.functional as F
 
 from torch_spyre._inductor import config
+from torch_spyre._C import SpyreTensorLayout
+from torch_spyre.ops.eager import RetileWarning
 
 
 DEVICE = "spyre"
@@ -496,6 +499,34 @@ class TestFallbackResultNonCanonicalTiling(unittest.TestCase):
     def test_multi_token_gather(self):
         """T == 8: they coincide -- guards the control arm too."""
         self._run(8)
+
+    def test_direct_eager_result_preserves_noncanonical_layout(self):
+        """A true eager boundary exposes its real layout to the next graph."""
+        num_tokens = 1
+        cache = torch.randn(self.MAXPOS, 2, 2, self.INNER, dtype=DTYPE)
+        pos = torch.arange(num_tokens, dtype=torch.int64)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            rot = torch.ops.test_fk_gather.gather(cache.to(DEVICE), pos.to(DEVICE))
+
+        canonical = SpyreTensorLayout([int(s) for s in rot.shape], rot.dtype)
+        self.assertNotEqual(rot.device_tensor_layout(), canonical)
+        self.assertFalse(any(isinstance(w.message, RetileWarning) for w in caught))
+
+        # The next compiled graph specializes on the real layout of ``rot`` at
+        # its eager input boundary and must consume it without a re-tile.
+        scale = torch.randn_like(cache[:num_tokens])
+
+        def consume(x, y):
+            return x * y
+
+        out = torch.compile(consume, fullgraph=True, dynamic=False, backend="inductor")(
+            rot, scale.to(DEVICE)
+        )
+        torch.testing.assert_close(
+            out.cpu(), cache.index_select(0, pos) * scale, atol=0.01, rtol=0.01
+        )
 
     def test_cat_disagrees_in_rank_without_size_one_dim(self):
         """`aten.cat(dim=0)` at (8, 2, 2, 64): a second, distinct instance.

--- a/torch_spyre/_inductor/wrapper.py
+++ b/torch_spyre/_inductor/wrapper.py
@@ -20,6 +20,8 @@ from torch._inductor.codegen.wrapper import (
     PythonWrapperCodegen,
     SubgraphPythonWrapperCodegen,
 )
+from torch._inductor import config, ir
+from torch._dynamo.utils import counters
 from torch._inductor.ir import GraphPartitionSignature
 from torch._inductor.virtualized import V
 from torch._inductor.sizevars import SizeVarAllocator
@@ -74,6 +76,58 @@ class _SpyreWrapperCodegenMixin(PythonWrapperCodegen):
         device = node.layout.device
         self.writeline(
             f'{node.get_name()} = spyre_constant_tensor({value}, torch.device("{device}"), {dtype})'
+        )
+
+    def _generate_extern_kernel_alloc_helper(self, extern_kernel, args):
+        """Mark calls whose eager result is consumed inside this graph.
+
+        Spyre eager kernels normally preserve their actual device layout at an
+        eager boundary.  A ``FallbackKernel`` output, however, is assigned a
+        canonical layout by Inductor before the runtime eager call occurs.  The
+        marker lets the eager dispatcher normalize only this in-graph case.
+        """
+        if not isinstance(extern_kernel, ir.FallbackKernel):
+            return super()._generate_extern_kernel_alloc_helper(extern_kernel, args)
+
+        no_return = isinstance(extern_kernel.layout, ir.NoneLayout)
+        output_name = extern_kernel.get_name()
+        origin_node = extern_kernel.get_origin_node()
+        kernel_name = extern_kernel.get_kernel_name()
+        ending = self.ending
+        if config.memory_planning and "view_as_complex" in kernel_name:
+            ending = f".clone(){ending}"
+
+        comma = ", " if args else ""
+        call = f"_run_compiled_fallback({kernel_name}{comma}{', '.join(args)}){ending}"
+        if no_return:
+            self.writeline(f"{self.declare}{call}")
+        else:
+            self.writeline(f"{self.declare}{output_name} = {call}")
+            if (
+                self.supports_intermediate_hooks
+                and config.generate_intermediate_hooks
+                and origin_node is not None
+            ):
+                counters["inductor"]["intermediate_hooks"] += 1
+                self.writeline(
+                    f"run_intermediate_hooks({origin_node.name!r}, {output_name})"
+                )
+
+    def generate_fallback_kernel_with_runtime_lookup(
+        self,
+        buf_name,
+        python_kernel_name,
+        get_args,
+        op_overload,
+        raw_args,
+        outputs,
+    ) -> None:
+        """Apply the same marker to runtime-looked-up fallback overloads."""
+        args = list(get_args())
+        comma = ", " if args else ""
+        self.writeline(
+            f"{buf_name} = _run_compiled_fallback("
+            f"{python_kernel_name}{comma}{', '.join(args)})"
         )
 
     def _is_hbm_pool_buffer(self, buffer: BufferLike) -> bool:
@@ -148,6 +202,7 @@ class SpyrePythonWrapperCodegen(_SpyreWrapperCodegenMixin, PythonWrapperCodegen)
                 from torch_spyre.execution.async_compile import SpyreAsyncCompile
                 from torch_spyre._C import DataFormats, ElementArrangement, SpyreTensorLayout, spyre_empty_with_layout, set_spyre_tensor_layout
                 import subprocess
+                from torch_spyre.ops.eager import _run_compiled_fallback
             """,
             strip=True,
         )

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -20,6 +20,7 @@ import warnings
 import functools
 import inspect
 import operator
+import threading
 
 
 aten = torch.ops.aten
@@ -97,6 +98,37 @@ class RetileWarning(UserWarning):
 warnings.simplefilter("once", RetileWarning)
 
 
+_compiled_fallback_state = threading.local()
+
+
+def _run_compiled_fallback(op, *args, **kwargs):
+    """Invoke an eager op on behalf of an Inductor ``FallbackKernel``.
+
+    Direct eager calls are device-layout boundaries: their returned tensor
+    carries its real ``SpyreTensorLayout``, and a later compiled graph reads
+    that layout from the real graph input.  A fallback *inside* a compiled
+    graph is different: layout propagation currently assigns its output the
+    canonical, size-derived layout without observing the eager result.  Mark
+    just those calls so ``_make_offset_safe_dispatch`` can make that assumed
+    layout true without canonicalizing ordinary eager-boundary results.
+
+    A depth rather than a boolean keeps nested composite fallbacks balanced.
+    The state is thread-local because generated graph wrappers can run from
+    independent application threads.
+    """
+
+    previous_depth = getattr(_compiled_fallback_state, "depth", 0)
+    _compiled_fallback_state.depth = previous_depth + 1
+    try:
+        return op(*args, **kwargs)
+    finally:
+        _compiled_fallback_state.depth = previous_depth
+
+
+def _in_compiled_fallback():
+    return bool(getattr(_compiled_fallback_state, "depth", 0))
+
+
 def _normalize_result_layout(x):
     """Return a copy of a Spyre tensor whose device layout is the *canonical* one
     for its logical shape.
@@ -106,6 +138,10 @@ def _normalize_result_layout(x):
     restickify to make that assumption true — so an eager kernel returning a
     differently-tiled buffer is read by the wrong tiling, silently. Rebuilding
     the result here makes the assumption hold.
+
+    This helper is only called while a generated compiled graph is executing a
+    fallback.  Direct eager results deliberately retain their real layout so a
+    subsequent compilation can accept it at the graph boundary.
 
     Only whole buffers are considered. ``device_tensor_layout()`` describes the
     tensor's BASE allocation, not the view, so for any view it reports a layout
@@ -315,7 +351,7 @@ def _make_offset_safe_dispatch(op):
 
         result = compiled(*args, **kwargs)
 
-        if normalize_results:
+        if normalize_results and _in_compiled_fallback():
             result = _map_result(result, _normalize_result_layout)
 
         if write_back:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Spyre eager kernels can return a valid noncanonical device layout. The eager dispatcher previously normalized every such result to the canonical size-derived layout because an in-graph Inductor fallback assumes that layout. This also normalized results at true eager boundaries, adding an unnecessary host-mediated retile and preventing the next compiled region from specializing on the real layout.

This change marks only eager calls emitted for an Inductor FallbackKernel. Results are still normalized when consumed inside the same compiled graph, while direct eager results preserve their real SpyreTensorLayout for the next graph boundary. The marker is thread-local and nesting-safe.

A regression test verifies that a noncanonical direct eager result is not retiled and is consumed correctly by a subsequent compiled graph. Existing fallback tests continue to verify canonicalization and correctness inside compiled graphs.

#### Which issue(s) this PR is related to:

Found while investigating Granite 3.3 and Gemma 4 MLP layout transitions on top of #4424 and #4391.

#### Special notes for your reviewer:

Validated with the torch-spyre development environment using PyTorch 2.13.0.

- `python -m pytest -q tests/inductor/test_fallback_kernel.py tests/inductor/test_offset_view_eager_ops.py tests/inductor/test_subgraph_wrapper.py`
  - 41 passed, 3 subtests passed
- `pre-commit run --files tests/inductor/test_fallback_kernel.py torch_spyre/_inductor/wrapper.py torch_spyre/ops/eager.py`
  - all hooks passed

#### Does this PR introduce a user-facing change?

Yes. A direct eager Spyre op may now retain its valid noncanonical device layout instead of being copied through a canonical host-mediated retile. Compiled consumers specialize on that actual boundary layout.

#### Additional note:

In-graph FallbackKernel behavior remains unchanged: noncanonical eager results are normalized to the layout already assumed by Inductor.