### PR TITLE
fix(tests): remove fixed fp16 mean xfails from #2711 (issue #2719)

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -4152,8 +4152,6 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         ("test_mean_keepdim1", "test_mean_eager"): {
             "ops_dict": {"mean": torch.mean},
             "expect_fail": [
-                "fp16_3d_dim_2",
-                "fp16_3d_dim_neg1",
                 "fp32_3d_dim_2",
                 "fp32_3d_dim_neg1",
             ],


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Re-validates the 5 tests xfailed in #2711 against main, now that PR #4400
("fix(codegen): point maskingConstId_ at samv-maskvalue, not constant 0")
has landed.

2 of the 5 are fixed by #4400 and are unskipped here:

- `test_mean_keepdim1_mean_fp16_3d_dim_2`
- `test_mean_keepdim1_mean_fp16_3d_dim_neg1`

These were the fp16 cpu/spyre-mismatch failures. `mean` inserts
`scaling_factor` into the constants dict before `samv-maskvalue`, so the
hardcoded `maskingConstId_ = 0` pointed the backend at `1/N` instead of the
mask value, splatting padding lanes with `1/N` and corrupting the reduction.
#4400 fixes exactly this; both tests now pass reliably (re-ran with a clean
fxgraph cache to rule out stale-cache false positives).

The remaining 3 are left xfailed — they fail for an unrelated reason:

- `test_mean_keepdim1_mean_fp32_3d_dim_2`
- `test_mean_keepdim1_mean_fp32_3d_dim_neg1`
- `test_sum_keepdim1_sum_fp32_3d_dim_neg1`

These crash at compile time because the DDC backend explicitly rejects
coordinate masking for element types wider than 16 bits (deeptools commit
`0b9696ef37`: "the hardware doesn't support this natively... not implemented
so best to fail explicitly early"). This is a genuine hardware/backend gap,
not something #4400 touches. Filed as #4492 with root-cause detail and
possible ways forward.

#### Which issue(s) this PR is related to:

Fixes #2719 (partially — see #4492 for the remaining fp32 gap)

#### Special notes for your reviewer:

No source changes; this PR only removes the 2 now-passing entries from the
`expect_fail` lists in `tests/inductor/test_inductor_ops.py`. The 3 fp32
entries are intentionally left in place.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:

See discussion and verification details on #2719.